### PR TITLE
Fix issue #119: Incorrect varName in logs

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
@@ -1343,11 +1343,12 @@ public class NcHelper  {
         //read the sourcglobalAttributes
         if (ncAtts == null)
             return;
+        String ncAttsName = ncAtts.getName();
         Iterator it = ncAtts.iterator();
         while (it.hasNext()) { //there is also a dods.dap.Attribute                        
             Attribute att = (Attribute)it.next();            
-            String name = ncAtts.getName();
-            attributes.add(name, getAttributePA(name, att));
+            String name = att.getName();
+            attributes.add(name, getAttributePA(ncAttsName, att));
         }
     }
 

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
@@ -1346,7 +1346,7 @@ public class NcHelper  {
         Iterator it = ncAtts.iterator();
         while (it.hasNext()) { //there is also a dods.dap.Attribute                        
             Attribute att = (Attribute)it.next();            
-            String name = att.getName();
+            String name = ncAtts.getName();
             attributes.add(name, getAttributePA(name, att));
         }
     }


### PR DESCRIPTION
# Description

`varName` was being incorrectly logged by being copied from the `attribute`

Fixes #119 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)