### PR TITLE
EDDTableAggregateRows - override actual_range with min/max calculated on all chidren

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
@@ -21,6 +21,7 @@ import gov.noaa.pfel.erddap.variable.*;
 
 import java.util.ArrayList;
 
+import com.cohort.array.PrimitiveArray;
 
 /** 
  * This class creates an EDDTable by aggregating a list of EDDTables
@@ -330,6 +331,14 @@ public class EDDTableAggregateRows extends EDDTable{
                     tMax = tMax.max(cEdv.destinationMax()); 
                 }
             }
+            
+            ///override actual_range with min/max calculated on all chidren
+            if (!tMin.isMissingValue() && !tMax.isMissingValue()) {
+                PrimitiveArray pa = PrimitiveArray.factory(childVar.destinationDataPAType(), 2, false);
+                pa.addPAOne(tMin);
+                pa.addPAOne(tMax);
+                tSourceAtts.set("actual_range", pa);
+            }
 
             //make the variable
             EDV newVar = null;
@@ -346,14 +355,10 @@ public class EDDTableAggregateRows extends EDDTable{
                 newVar = new EDVDepth(datasetID, tSourceName, tSourceAtts, tAddAtts, tDataType, tMin, tMax);
                 depthIndex = dv;
             } else if (tSourceName.equals(EDV.TIME_NAME)) { //do time before timeStamp
-                tAddAtts.add("data_min", "" + tMin); //data_min/max have priority                
-                tAddAtts.add("data_max", "" + tMax); //tMin tMax are epochSeconds    
                 newVar = new EDVTime(datasetID, tSourceName, tSourceAtts, tAddAtts, 
                     tDataType); //this constructor gets source / sets destination actual_range
                 timeIndex = dv;
             } else if (EDVTimeStamp.hasTimeUnits(tSourceAtts, tAddAtts)) {
-                tAddAtts.add("data_min", "" + tMin); //data_min/max have priority                
-                tAddAtts.add("data_max", "" + tMax); //tMin tMax are epochSeconds    
                 newVar = new EDVTimeStamp(datasetID, tSourceName, "", tSourceAtts, tAddAtts,
                     tDataType); //this constructor gets source / sets destination actual_range
             } else newVar = new EDV(datasetID, tSourceName, "", tSourceAtts, tAddAtts, tDataType, tMin, tMax);


### PR DESCRIPTION
# Description

In EDDTableAggregateRows class override actual_range in tSourceAtts Attributes with min/max values calculated on all chidren.
This is to fix the problem about range for time,latitude,longitude and depth  that is not the min/max of all the child but the range from the first child.

Fixes #145 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

