### PR TITLE
Feature: unusualActivityFailPercent

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -416,7 +416,9 @@ public class LoadDatasets extends Thread {
           emailDailyReport(threadSummary, threadList, reportDate);
         } else {
           // major load, but not daily report
-          emailUnusualActivity(threadSummary, threadList);
+          if (EDStatic.unusualActivityFailPercent != -1) {
+            emailUnusualActivity(threadSummary, threadList);
+          }
         }
 
         // after every major loadDatasets
@@ -1069,6 +1071,15 @@ public class LoadDatasets extends Thread {
               tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_unusualActivity : tnt;
           String2.log("unusualActivity=" + EDStatic.unusualActivity);
 
+        } else if (tags.equals("<erddapDatasets><unusualActivityFailPercent>")) {
+        } else if (tags.equals("<erddapDatasets></unusualActivityFailPercent>")) {
+          int tnt = String2.parseInt(xmlReader.content());
+          EDStatic.unusualActivityFailPercent =
+              tnt < 0 || tnt == Integer.MAX_VALUE
+                  ? EDStatic.DEFAULT_unusualActivityFailPercent
+                  : tnt;
+          String2.log("unusualActivityFailPercent=" + EDStatic.unusualActivityFailPercent);
+
         } else if (tags.equals("<erddapDatasets><updateMaxEvents>")) {
         } else if (tags.equals("<erddapDatasets></updateMaxEvents>")) {
           int tnt = String2.parseInt(xmlReader.content());
@@ -1249,14 +1260,17 @@ public class LoadDatasets extends Thread {
     // email if some threshold is surpassed???
     int nFailed = String2.getTimeDistributionN(EDStatic.failureTimesDistributionLoadDatasets);
     int nSucceeded = String2.getTimeDistributionN(EDStatic.responseTimesDistributionLoadDatasets);
-    if (nFailed + nSucceeded > EDStatic.unusualActivity) // high activity level
-    EDStatic.email(
+    if (nFailed + nSucceeded > EDStatic.unusualActivity) { // high activity level
+      EDStatic.email(
           EDStatic.emailEverythingToCsv, "Unusual Activity: lots of requests", sb.toString());
-    else if (nFailed > 10 && nFailed > nSucceeded / 4) // >25% of requests fail
-    EDStatic.email(
+    } else if (nFailed > 10
+        && nFailed
+            > nSucceeded * (EDStatic.unusualActivityFailPercent) / 100) { // >25% of requests fail
+      EDStatic.email(
           EDStatic.emailEverythingToCsv,
-          "Unusual Activity: >25% of requests failed",
+          "Unusual Activity: >" + EDStatic.unusualActivityFailPercent + "% of requests failed",
           sb.toString());
+    }
   }
 
   private void emailDailyReport(String threadSummary, String threadList, String reportDate) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -1075,7 +1075,7 @@ public class LoadDatasets extends Thread {
         } else if (tags.equals("<erddapDatasets></unusualActivityFailPercent>")) {
           int tnt = String2.parseInt(xmlReader.content());
           EDStatic.unusualActivityFailPercent =
-              tnt < 0 || tnt == Integer.MAX_VALUE
+              tnt < 0 || tnt > 100 || tnt == Integer.MAX_VALUE
                   ? EDStatic.DEFAULT_unusualActivityFailPercent
                   : tnt;
           String2.log("unusualActivityFailPercent=" + EDStatic.unusualActivityFailPercent);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
@@ -507,6 +507,15 @@ public class TopLevelHandler extends State {
           String2.log("updateMaxEvents=" + EDStatic.updateMaxEvents);
         }
       }
+      case "unusualActivityFailPercent" -> {
+        int tnt = String2.parseInt(data.toString());
+        EDStatic.unusualActivityFailPercent =
+            tnt < 0 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_unusualActivityFailPercent : tnt;
+
+        if (reallyVerbose) {
+          String2.log("unusualActivityFailPercent" + EDStatic.unusualActivityFailPercent);
+        }
+      }
     }
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
@@ -510,7 +510,9 @@ public class TopLevelHandler extends State {
       case "unusualActivityFailPercent" -> {
         int tnt = String2.parseInt(data.toString());
         EDStatic.unusualActivityFailPercent =
-            tnt < 0 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_unusualActivityFailPercent : tnt;
+            tnt < 0 || tnt > 100 || tnt == Integer.MAX_VALUE
+                ? EDStatic.DEFAULT_unusualActivityFailPercent
+                : tnt;
 
         if (reallyVerbose) {
           String2.log("unusualActivityFailPercent" + EDStatic.unusualActivityFailPercent);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -384,7 +384,7 @@ public class EDStatic {
   public static final int DEFAULT_slowDownTroubleMillis = 1000;
   public static final int DEFAULT_unusualActivity = 10000;
   public static final int DEFAULT_updateMaxEvents = 10;
-  public static final int DEFAULT_unusualActivityFailPercent = -1;
+  public static final int DEFAULT_unusualActivityFailPercent = 25;
   public static long cacheMillis = DEFAULT_cacheMinutes * Calendar2.MILLIS_PER_MINUTE;
   public static String drawLandMask = DEFAULT_drawLandMask;
   public static boolean emailDiagnosticsToErdData = true;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -384,6 +384,7 @@ public class EDStatic {
   public static final int DEFAULT_slowDownTroubleMillis = 1000;
   public static final int DEFAULT_unusualActivity = 10000;
   public static final int DEFAULT_updateMaxEvents = 10;
+  public static final int DEFAULT_unusualActivityFailPercent = -1;
   public static long cacheMillis = DEFAULT_cacheMinutes * Calendar2.MILLIS_PER_MINUTE;
   public static String drawLandMask = DEFAULT_drawLandMask;
   public static boolean emailDiagnosticsToErdData = true;
@@ -399,6 +400,7 @@ public class EDStatic {
   public static int slowDownTroubleMillis = DEFAULT_slowDownTroubleMillis;
   public static int unusualActivity = DEFAULT_unusualActivity;
   public static int updateMaxEvents = DEFAULT_updateMaxEvents;
+  public static int unusualActivityFailPercent = DEFAULT_unusualActivityFailPercent;
 
   // not translated
   public static


### PR DESCRIPTION
## Description
- < unusualActivityFailPercent ></ unusualActivityFailPercent > tag for both SAX and simpleXml parsers in `datasets.xml`
- Any integer value from 0 to 100 to tweak the threshold percentage, Default = -1 for sending no mails 
- Fixes https://github.com/ERDDAP/erddap/issues/139