### PR TITLE
Add prometheus jvm metrics. Also have erddap start on load (so datase…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Simply run `mvn test` in a terminal to run the JUnit tests.
 
 Note that by default tests that do an image comparison are enabled. To disable those tests add `ImageComparison` to the `excludedGroups` section of the surefire `configuration`. It is recommended you run the image tests before making changes to ERDDAP&trade; so you can generate a baseline set of images that will be later used for comparison.
 
+### Metrics
+
+Metrics are collected using [Prometheus](https://prometheus.github.io/client_java/). You can see the metrics on a local server at [/erddap/metrics](http://localhost:8080/erddap/metrics?debug=text).
 
 ### Building a war
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -41,6 +41,7 @@ import gov.noaa.pfel.coastwatch.util.Tally;
 import gov.noaa.pfel.erddap.*;
 import gov.noaa.pfel.erddap.dataset.*;
 import gov.noaa.pfel.erddap.variable.*;
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -1798,6 +1799,7 @@ public class EDStatic {
     String erdStartup = "EDStatic Low Level Startup";
     String errorInMethod = "";
     try {
+      JvmMetrics.builder().register(); // initialize the out-of-the-box JVM metrics
 
       skipEmailThread = Boolean.parseBoolean(System.getProperty("skipEmailThread"));
       allowDeferedLoading = Boolean.parseBoolean(System.getProperty("allowDeferedLoading"));

--- a/WEB-INF/web.xml
+++ b/WEB-INF/web.xml
@@ -65,8 +65,19 @@ Use netcat to test if this works:
 <!- - JSPC servlet mappings start -->
 
     <servlet>
+        <servlet-name>metrics</servlet-name>
+        <servlet-class>io.prometheus.metrics.exporter.servlet.jakarta.PrometheusMetricsServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>metrics</servlet-name>
+        <url-pattern>/metrics</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>ERDDAP</servlet-name>
         <servlet-class>gov.noaa.pfel.erddap.Erddap</servlet-class>
+        <load-on-startup>2</load-on-startup>
     </servlet>
     <servlet-mapping>
         <servlet-name>ERDDAP</servlet-name>

--- a/pom.xml
+++ b/pom.xml
@@ -905,6 +905,21 @@
             <version>2.50.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-core</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -104,8 +104,6 @@ class JettyTests {
     server.setHandler(context);
 
     server.start();
-    // Make a request of the server to make sure it starts loading the datasets
-    SSR.getUrlResponseStringUnchanged("http://localhost:" + PORT + "/erddap");
 
     Thread.sleep(10 * 60 * 1000);
   }
@@ -10271,7 +10269,7 @@ class JettyTests {
   @org.junit.jupiter.api.Test
   @TagJetty
   @TagFlaky // This is flaky. Specifically for the check after the files are supposed to be
-            // downloaded.
+  // downloaded.
   void testMakeCopyFileTasks() throws Exception {
 
     // String2.log("\n*** testMakeCopyFileTasks\n" +


### PR DESCRIPTION
…t loading begins immediately).

To see the metrics on a running server the path is:

http://localhost:8080/erddap/metrics?debug=text

# Description

Adds basic Prometheus jvm metrics. This can be expanded on with additional metrics to track.

This also indicates to Tomcat/Jetty/others (in the web.xml) that the ERDDAP servlet should be loaded at startup which means dataset loading should now start immediately instead of waiting until the first request is made.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X ] New feature (non-breaking change which adds functionality)
- [ X ] This change requires a documentation update

## Checklist before requesting a review
- [ X ] I have performed a self-review of my code
- [ X ] My code follows the style guidelines of this project
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
