### PR TITLE
Set a CSP in the html meta tags for search multiple erddaps

### DIFF
--- a/download/SearchMultipleERDDAPs.html
+++ b/download/SearchMultipleERDDAPs.html
@@ -6,12 +6,62 @@
 <link rel="shortcut icon" href="https://coastwatch.pfeg.noaa.gov/erddap/images/favicon.ico">
 <link href="https://coastwatch.pfeg.noaa.gov/erddap/images/erddap2.css" rel="stylesheet" type="text/css">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- This isn't ideal, CSP should be managed by the server, not hardcoded here, but since this page makes calls to many servers that are likely 
+ not needed elsewhere, include the list of servers here. -->
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://coastwatch.pfeg.noaa.gov/erddap/
+    https://apdrc.soest.hawaii.edu/erddap/
+    https://www.ncei.noaa.gov/erddap/
+    https://erddap.bco-dmo.org/erddap/
+    https://erddap.emodnet-physics.eu/erddap/
+    https://erddap.marine.ie/erddap/
+    https://cwcgom.aoml.noaa.gov/erddap/
+    https://erddap.sensors.ioos.us/erddap/
+    https://erddap.axiomdatascience.com/erddap/
+    https://oceanview.pfeg.noaa.gov/erddap/
+    http://www.neracoos.org/erddap/
+    https://data.ioos.us/gliders/erddap/
+    https://pae-paha.pacioos.hawaii.edu/erddap/
+    https://catalogue.hakai.org/erddap/
+    https://sccoos.org/erddap/  
+    https://erddap.secoora.org/erddap/
+    https://ecowatch.ncddc.noaa.gov/erddap/
+    http://osmc.noaa.gov/erddap/
+    https://coastwatch.noaa.gov//erddap/
+    http://dap.onc.uvic.ca/erddap/
+    https://oceanwatch.pifsc.noaa.gov/erddap/
+    https://erddap-goldcopy.dataexplorer.oceanobservatories.org/erddap/
+    https://members.oceantrack.org/erddap/
+    https://erddap.oa.iode.org/erddap/
+    http://www.myroms.org:8080/erddap/
+    http://tds.marine.rutgers.edu/erddap/
+    https://comet.nefsc.noaa.gov/erddap/
+    https://opendap.co-ops.nos.noaa.gov/erddap/
+    https://gcoos5.geos.tamu.edu/erddap/
+    https://gcoos4.tamu.edu/erddap/
+    https://erddap.gcoos.org/erddap/
+    https://coastwatch.glerl.noaa.gov/erddap/
+    https://spraydata.ucsd.edu/erddap/
+    https://salishsea.eos.ubc.ca/erddap/
+    https://erddap.ichec.ie/erddap/
+    https://canwinerddap.ad.umanitoba.ca/erddap/
+    https://erddap.incois.gov.in/erddap/
+    https://www.smartatlantic.ca/erddap/
+    https://erddap.griidc.org/erddap/
+    https://geoport.usgs.esipfed.org/erddap/
+    https://upwell.pfeg.noaa.gov/erddap/ 
+    https://erddap-uncabled.oceanobservatories.org/uncabled/erddap/
+    https://gliders.ioos.us/erddap/
+    https://erddap.sccoos.org/erddap/
+    https://apps.glerl.noaa.gov/erddap/;
+font-src 'self' https://fonts.googleapis.com https://stackpath.bootstrapcdn.com;" />
 </head>
 
 <body>
 
 <script>
   //you can add, comment out, or remove ERDDAP™ URLs from this list
+  // Any changes to this list should be reflected in the above CSP list.
   var urls = [
     "https://coastwatch.pfeg.noaa.gov/erddap/",
     "https://apdrc.soest.hawaii.edu/erddap/",


### PR DESCRIPTION
# Description

Adds a hardcoded CSP to the search multiple erddaps page. This should allow the page to fully function without needing to adjust the CSP for the entire server.

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [ X ] I have performed a self-review of my code
- [ X ] My code follows the style guidelines of this project
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
