### PR TITLE
Allow skipping resource download/unzip

### DIFF
--- a/PROGRAMMER_GUIDE.md
+++ b/PROGRAMMER_GUIDE.md
@@ -17,7 +17,10 @@ ERDDAP™ uses Maven to load code dependencies as well as some static reference 
 
   - [ref\_files.zip](https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/1.0.0/ref_files.zip) and unzip it into /WEB-INF/ref/ .
 
-  - [erddapContent.zip](https://github.com/ERDDAP/erddap/releases/download/v2.23/erddapContent.zip) (version 2.23, 19810 bytes, MD5=1E26F62E7A06191EE6868C40B9A29362, dated 2023-02-27) and unzip it into _tomcat_, creating _tomcat_/content/erddap .
+  - [erddapContent.zip](https://github.com/ERDDAP/erddap/releases/download/v2.24/erddapContent.zip) (version 2.24, 19810 bytes, MD5=1E26F62E7A06191EE6868C40B9A29362, dated 2024-06-07) and unzip it into _tomcat_, creating _tomcat_/content/erddap .
+
+NOTE: Maven caches downloads but will unzip the downloaded archives on each execution, which takes time. To skip downloading
+and unzipping archives, you may specify the `skipResourceDownload` property to Maven (e.g. `mvn -DskipResourceDownload package`).
 
 - ERDDAP™ and its subcomponents have very liberal, open-source [licenses](https://erddap.github.io/setup.html#license), so you can use and modify the source code for any purpose, for-profit or not-for-profit. Note that ERDDAP™ and many subcomponents have licenses that require that you acknowledge the source of the code that you are using. See [Credits](https://erddap.github.io/setup.html#credits). Whether required or not, it is just good form to acknowledge all of these contributors.
    
@@ -66,6 +69,8 @@ ERDDAP™ uses Maven to load code dependencies as well as some static reference 
 
   - Most classes have test methods in their associated src/test file. You can run the JUnit tests with the `mvn test` command. This will download several zip files of data that the tests rely on from the latest release of [ERDDAP/erddapTest](https://github.com/ERDDAP/erddapTest/releases/).\
      
+NOTE: Maven caches downloads but will unzip the downloaded archives on each execution, which takes time. To skip downloading
+and unzipping test data archives, you may specify the `skipTestResourceDownload` property to Maven (e.g. `mvn -DskipTestResourceDownload package`).
 
 ###  **Important Classes**
 

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -251,6 +252,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -264,6 +266,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
 
@@ -278,6 +281,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -291,6 +295,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -304,6 +309,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -317,6 +323,7 @@
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
                             <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Allow skipping external resource download/unzip
using Maven properties.

`skipResourceDownload` skips downloading/unzipping erddapContent, ref, and etopo.

`skipTestResourceDownload` skips downloading/unzipping test data downloads data, largeFiles, largePoints, and largeSatellite.

Example invocation:

`mvn -DskipResourceDownload -DskipTestResourceDownload package`

These options can be also be set in the `MAVEN_ARGS` environment variable or in `.mvn/maven.config` (see https://maven.apache.org/configure.html).

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
