### PR TITLE
Scan classpath for EDD subclasses/dataset types

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDFromXmlMethod.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDFromXmlMethod.java
@@ -1,0 +1,14 @@
+package gov.noaa.pfel.erddap.dataset;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated method should be used to create an EDD object from an XML string
+ * (non-Sax parser approach)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface EDDFromXmlMethod {}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
@@ -20,6 +20,8 @@ import gov.noaa.pfel.coastwatch.util.FileVisitorDNLS;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridAggregateExistingDimensionHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.text.MessageFormat;
@@ -31,6 +33,7 @@ import java.util.ArrayList;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2008-02-04
  */
+@SaxHandlerClass(EDDGridAggregateExistingDimensionHandler.class)
 public class EDDGridAggregateExistingDimension extends EDDGrid {
 
   protected EDDGrid childDatasets[];
@@ -53,6 +56,7 @@ public class EDDGridAggregateExistingDimension extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridAggregateExistingDimension fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
@@ -20,6 +20,8 @@ import gov.noaa.pfel.coastwatch.util.RegexFilenameFilter;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridCopyHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.util.TaskThread;
 import gov.noaa.pfel.erddap.variable.*;
@@ -33,6 +35,7 @@ import ucar.nc2.*;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2009-05-25
  */
+@SaxHandlerClass(EDDGridCopyHandler.class)
 public class EDDGridCopy extends EDDGrid {
 
   protected EDDGrid sourceEdd;
@@ -61,6 +64,7 @@ public class EDDGridCopy extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridCopy fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     // data to be obtained (or not)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
@@ -29,6 +29,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridFromDapHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.ByteArrayInputStream;
@@ -56,6 +58,7 @@ import thredds.client.catalog.builder.CatalogBuilder;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-06-04
  */
+@SaxHandlerClass(EDDGridFromDapHandler.class)
 public class EDDGridFromDap extends EDDGrid {
 
   /**
@@ -74,6 +77,7 @@ public class EDDGridFromDap extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridFromDap fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     // data to be obtained (or not)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
@@ -21,6 +21,8 @@ import com.cohort.util.String2;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridFromEDDTableHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.DataInputStream;
@@ -33,6 +35,7 @@ import java.util.Arrays;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2015-01-27
  */
+@SaxHandlerClass(EDDGridFromEDDTableHandler.class)
 public class EDDGridFromEDDTable extends EDDGrid {
 
   protected EDDTable eddTable;
@@ -55,6 +58,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridFromEDDTable fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
@@ -26,6 +26,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridFromErddapHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -42,6 +44,7 @@ import java.util.BitSet;
  *
  * @author Bob Simons (bob.simons@noaa.gov) 2007-06-04
  */
+@SaxHandlerClass(EDDGridFromErddapHandler.class)
 public class EDDGridFromErddap extends EDDGrid implements FromErddap {
 
   protected double sourceErddapVersion =
@@ -67,6 +70,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridFromErddap fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
@@ -23,6 +23,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.sgt.SgtMap;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridFromEtopoHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedOutputStream;
@@ -41,6 +43,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2008-02-20
  */
+@SaxHandlerClass(EDDGridFromEtopoHandler.class)
 public class EDDGridFromEtopo extends EDDGrid {
 
   /** Properties of the datafile */
@@ -73,6 +76,7 @@ public class EDDGridFromEtopo extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridFromEtopo fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
     // data to be obtained (or not)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
@@ -31,6 +31,8 @@ import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.coastwatch.util.WatchDirectory;
 import gov.noaa.pfel.coastwatch.util.WatchUpdateHandler;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridFromFilesHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.util.ThreadedWorkManager;
 import gov.noaa.pfel.erddap.variable.*;
@@ -64,6 +66,7 @@ import java.util.regex.Pattern;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2008-11-26
  */
+@SaxHandlerClass(EDDGridFromFilesHandler.class)
 public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHandler {
 
   public static final String MF_FIRST = "first", MF_LAST = "last";
@@ -164,6 +167,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridFromFiles fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
@@ -21,6 +21,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridLon0360Handler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -32,6 +34,7 @@ import java.text.MessageFormat;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2021-05-28
  */
+@SaxHandlerClass(EDDGridLon0360Handler.class)
 public class EDDGridLon0360 extends EDDGrid {
 
   private EDDGrid childDataset;
@@ -65,6 +68,7 @@ public class EDDGridLon0360 extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridLon0360 fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     if (verbose) String2.log("\n*** constructing EDDGridLon0360(xmlReader)...");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
@@ -21,6 +21,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridLonPM180Handler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -32,6 +34,7 @@ import java.text.MessageFormat;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2015-08-05
  */
+@SaxHandlerClass(EDDGridLonPM180Handler.class)
 public class EDDGridLonPM180 extends EDDGrid {
 
   private EDDGrid childDataset;
@@ -64,6 +67,7 @@ public class EDDGridLonPM180 extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridLonPM180 fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     if (verbose) String2.log("\n*** constructing EDDGridLonPM180(xmlReader)...");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
@@ -15,6 +15,8 @@ import com.cohort.util.Test;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDGridSideBySideHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.text.MessageFormat;
@@ -36,6 +38,7 @@ import java.util.Arrays;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2008-02-04
  */
+@SaxHandlerClass(EDDGridSideBySideHandler.class)
 public class EDDGridSideBySide extends EDDGrid {
 
   protected EDDGrid childDatasets[];
@@ -59,6 +62,7 @@ public class EDDGridSideBySide extends EDDGrid {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDGridSideBySide fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
@@ -15,6 +15,8 @@ import com.cohort.util.String2;
 import com.cohort.util.Test;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableAggregateRowsHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import java.util.ArrayList;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2016-02-19
  */
+@SaxHandlerClass(EDDTableAggregateRowsHandler.class)
 public class EDDTableAggregateRows extends EDDTable {
 
   protected int nChildren;
@@ -48,6 +51,7 @@ public class EDDTableAggregateRows extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableAggregateRows fromXml(Erddap tErddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopy.java
@@ -15,6 +15,8 @@ import gov.noaa.pfel.coastwatch.util.RegexFilenameFilter;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableCopyHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.util.TaskThread;
 import gov.noaa.pfel.erddap.variable.*;
@@ -25,6 +27,7 @@ import gov.noaa.pfel.erddap.variable.*;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2009-05-19
  */
+@SaxHandlerClass(EDDTableCopyHandler.class)
 public class EDDTableCopy extends EDDTable {
 
   protected EDDTable sourceEdd;
@@ -58,6 +61,7 @@ public class EDDTableCopy extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableCopy fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     // data to be obtained (or not)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
@@ -15,6 +15,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromAsciiServiceHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2010-11-12
  */
+@SaxHandlerClass(EDDTableFromAsciiServiceHandler.class)
 public abstract class EDDTableFromAsciiService extends EDDTable {
 
   protected String beforeData[];
@@ -48,6 +51,7 @@ public abstract class EDDTableFromAsciiService extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromAsciiService fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
@@ -228,6 +228,8 @@ import com.datastax.driver.core.*;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromCassandraHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -260,6 +262,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2014-11-03
  */
+@SaxHandlerClass(EDDTableFromCassandraHandler.class)
 public class EDDTableFromCassandra extends EDDTable {
 
   // see getSession
@@ -317,6 +320,7 @@ public class EDDTableFromCassandra extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromCassandra fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
@@ -23,6 +23,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromDapSequenceHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.ByteArrayInputStream;
@@ -34,6 +36,7 @@ import java.util.Enumeration;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-06-08
  */
+@SaxHandlerClass(EDDTableFromDapSequenceHandler.class)
 public class EDDTableFromDapSequence extends EDDTable {
 
   protected String outerSequenceName, innerSequenceName;
@@ -58,6 +61,7 @@ public class EDDTableFromDapSequence extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromDapSequence fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
@@ -21,6 +21,8 @@ import com.cohort.util.XML;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromDatabaseHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.math.BigDecimal;
@@ -47,6 +49,7 @@ import javax.sql.DataSource;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-06-08
  */
+@SaxHandlerClass(EDDTableFromDatabaseHandler.class)
 public class EDDTableFromDatabase extends EDDTable {
 
   /** set by the constructor */
@@ -79,6 +82,7 @@ public class EDDTableFromDatabase extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromDatabase fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
     return lowFromXml(erddap, xmlReader, "");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
@@ -21,6 +21,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromEDDGridHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -31,6 +33,7 @@ import java.text.MessageFormat;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2013-03-08
  */
+@SaxHandlerClass(EDDTableFromEDDGridHandler.class)
 public class EDDTableFromEDDGrid extends EDDTable {
 
   public static final int DEFAULT_MAX_AXIS0 = 10;
@@ -53,6 +56,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromEDDGrid fromXml(Erddap tErddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromErddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromErddap.java
@@ -22,6 +22,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromErddapHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -29,16 +31,13 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
-import ucar.ma2.*;
-import ucar.nc2.*;
-// import ucar.nc2.dods.*;
-import ucar.nc2.util.*;
 
 /**
  * This class represents a table of data from an opendap sequence source.
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-06-08
  */
+@SaxHandlerClass(EDDTableFromErddapHandler.class)
 public class EDDTableFromErddap extends EDDTable implements FromErddap {
 
   protected double sourceErddapVersion =
@@ -66,6 +65,7 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromErddap fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
@@ -25,6 +25,8 @@ import gov.noaa.pfel.coastwatch.util.FileVisitorDNLS;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromFileNamesHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.regex.Pattern;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2015-01-06
  */
+@SaxHandlerClass(EDDTableFromFileNamesHandler.class)
 public class EDDTableFromFileNames extends EDDTable {
 
   protected String fileDir; // has forward slashes and trailing slash
@@ -99,6 +102,7 @@ public class EDDTableFromFileNames extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromFileNames fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
@@ -33,6 +33,8 @@ import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.coastwatch.util.WatchDirectory;
 import gov.noaa.pfel.coastwatch.util.WatchUpdateHandler;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromFilesHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.util.ThreadedWorkManager;
 import gov.noaa.pfel.erddap.variable.*;
@@ -60,6 +62,7 @@ import java.util.regex.*;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2008-04-12
  */
+@SaxHandlerClass(EDDTableFromFilesHandler.class)
 public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateHandler {
 
   public static final String MF_FIRST = "first", MF_LAST = "last";
@@ -198,6 +201,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromFiles fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
@@ -17,6 +17,8 @@ import gov.noaa.pfel.coastwatch.pointdata.DigirHelper;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromOBISHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.util.Arrays;
@@ -28,6 +30,7 @@ import java.util.HashSet;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-10-22
  */
+@SaxHandlerClass(EDDTableFromOBISHandler.class)
 public class EDDTableFromOBIS extends EDDTable {
 
   protected String sourceCode;
@@ -196,6 +199,7 @@ public class EDDTableFromOBIS extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromOBIS fromXml(Erddap erddap, SimpleXMLReader xmlReader)
       throws Throwable {
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
@@ -24,6 +24,8 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.SimpleXMLReader;
 import gov.noaa.pfel.erddap.Erddap;
+import gov.noaa.pfel.erddap.handlers.EDDTableFromSOSHandler;
+import gov.noaa.pfel.erddap.handlers.SaxHandlerClass;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.*;
 import java.io.BufferedReader;
@@ -103,6 +105,7 @@ import java.util.HashSet;
  *
  * @author Bob Simons (was bob.simons@noaa.gov, now BobSimons2.00@gmail.com) 2007-09-21
  */
+@SaxHandlerClass(EDDTableFromSOSHandler.class)
 public class EDDTableFromSOS extends EDDTable {
 
   /** stationTable */
@@ -179,6 +182,7 @@ public class EDDTableFromSOS extends EDDTable {
    *     &lt;erddapDatasets&gt;&lt;/dataset&gt; .
    * @throws Throwable if trouble
    */
+  @EDDFromXmlMethod
   public static EDDTableFromSOS fromXml(Erddap erddap, SimpleXMLReader xmlReader) throws Throwable {
 
     // data to be obtained (or not)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromFilesHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromFilesHandler.java
@@ -735,7 +735,7 @@ public class EDDTableFromFilesHandler extends BaseTableHandler {
           throw new Exception(
               "type=\""
                   + datasetType
-                  + "\" needs to be added to EDDTableFromFiles.fromXml at end.");
+                  + "\" needs to be added to EDDTableFromFilesHandler.getDataset at end.");
     }
     return dataset;
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
@@ -10,6 +10,9 @@ import gov.noaa.pfel.coastwatch.util.FileVisitorDNLS;
 import gov.noaa.pfel.erddap.Erddap;
 import gov.noaa.pfel.erddap.dataset.EDD;
 import gov.noaa.pfel.erddap.util.EDStatic;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
 import java.util.HashSet;
 
 public class HandlerFactory {
@@ -32,97 +35,147 @@ public class HandlerFactory {
     EDStatic.cldStartMillis = timeToLoadThisDataset;
     EDStatic.cldDatasetID = datasetID;
 
-    nTry++;
-    context.getNTryAndDatasets()[0] = nTry;
-    switch (datasetType) {
-      case "EDDTableFromErddap" -> {
-        return new EDDTableFromErddapHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromEDDGrid" -> {
-        return new EDDTableFromEDDGridHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridFromDap" -> {
-        return new EDDGridFromDapHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDGridLonPM180" -> {
-        return new EDDGridLonPM180Handler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridFromErddap" -> {
-        return new EDDGridFromErddapHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromAsciiFiles",
-          "EDDTableFromNcFiles",
-          "EDDTableFromAudioFiles",
-          "EDDTableFromAwsXmlFiles",
-          "EDDTableFromColumnarAsciiFiles",
-          "EDDTableFromHttpGet",
-          "EDDTableFromInvalidCRAFiles",
-          "EDDTableFromJsonlCSVFiles",
-          "EDDTableFromMultidimNcFiles",
-          "EDDTableFromNcCFFiles",
-          "EDDTableFromNccsvFiles",
-          "EDDTableFromHyraxFiles",
-          "EDDTableFromThreddsFiles",
-          "EDDTableFromWFSFiles" -> {
-        return new EDDTableFromFilesHandler(saxHandler, datasetID, completeState, datasetType);
-      }
-      case "EDDGridAggregateExistingDimension" -> {
-        return new EDDGridAggregateExistingDimensionHandler(
-            saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridCopy" -> {
-        return new EDDGridCopyHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridFromEDDTable" -> {
-        return new EDDGridFromEDDTableHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridLon0360" -> {
-        return new EDDGridLon0360Handler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDGridSideBySide" -> {
-        return new EDDGridSideBySideHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDTableAggregateRows" -> {
-        return new EDDTableAggregateRowsHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDTableCopy" -> {
-        return new EDDTableCopyHandler(saxHandler, datasetID, completeState, context);
-      }
-      case "EDDTableFromCassandra" -> {
-        return new EDDTableFromCassandraHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromDapSequence" -> {
-        return new EDDTableFromDapSequenceHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromDatabase" -> {
-        return new EDDTableFromDatabaseHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromAsciiService" -> {
-        return new EDDTableFromAsciiServiceHandler(
-            saxHandler, datasetID, completeState, datasetType);
-      }
-      case "EDDTableFromOBIS" -> {
-        return new EDDTableFromOBISHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromSOS" -> {
-        return new EDDTableFromSOSHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDTableFromFileNames" -> {
-        return new EDDTableFromFileNamesHandler(saxHandler, datasetID, completeState);
-      }
-      case "EDDGridFromAudioFiles",
-          "EDDGridFromNcFiles",
-          "EDDGridFromNcFilesUnpacked",
-          "EDDGridFromMergeIRFiles" -> {
-        return new EDDGridFromFilesHandler(saxHandler, datasetID, completeState, datasetType);
-      }
-      case "EDDGridFromEtopo" -> {
-        return new EDDGridFromEtopoHandler(saxHandler, datasetID, completeState);
-      }
-      default -> {
-        nTry--;
-        context.getNTryAndDatasets()[0] = nTry;
+    if (EDStatic.useEddReflection) {
+      // use reflection to discover handlers
+      EDD.EDDClassInfo eddClassInfo = EDD.EDD_CLASS_INFO_MAP.get(datasetType);
+      if (eddClassInfo == null || !eddClassInfo.hasSaxHandlerClass()) {
         throw new IllegalArgumentException("Unknown dataset type: " + datasetType);
+      }
+
+      nTry++;
+      context.getNTryAndDatasets()[0] = nTry;
+
+      // TODO using the first constructor here, should we scan through all to find the most
+      // appropriate one?
+      Constructor<?> constructor = eddClassInfo.getSaxHandlerClass().get().getConstructors()[0];
+
+      // Constructors for handlers don't have uniform signatures so we have to do some investigation
+      // TODO: standardize the constructor signatures or change to accept a config object?
+      Parameter[] parameters = constructor.getParameters();
+      if (parameters.length < 3
+          || !parameters[0].getType().equals(SaxHandler.class)
+          || !parameters[1].getType().equals(String.class)
+          || !parameters[2].getType().equals(State.class)) {
+        throw new IllegalArgumentException(
+            "First constructor for " + datasetType + " did not have a valid signature");
+      }
+
+      // build array of constructor arguments based on the constructor signature
+      Object[] constructorArgs = new Object[parameters.length];
+      constructorArgs[0] = saxHandler;
+      constructorArgs[1] = datasetID;
+      constructorArgs[2] = completeState;
+      for (int i = 3; i < parameters.length; i++) {
+        Class<?> parameterClass = parameters[i].getType();
+        if (parameterClass.equals(SaxParsingContext.class)) {
+          constructorArgs[i] = context;
+        } else if (parameterClass.equals(String.class)) {
+          constructorArgs[i] = datasetType;
+        } else {
+          throw new IllegalArgumentException(
+              "Unknown parameter type for " + datasetType + ": " + parameterClass);
+        }
+      }
+
+      try {
+        return (State) constructor.newInstance(constructorArgs);
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+        throw new RuntimeException("Error creating handler for " + datasetType, e);
+      }
+    } else {
+      // legacy hardcoded approach
+      nTry++;
+      context.getNTryAndDatasets()[0] = nTry;
+      switch (datasetType) {
+        case "EDDTableFromErddap" -> {
+          return new EDDTableFromErddapHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromEDDGrid" -> {
+          return new EDDTableFromEDDGridHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridFromDap" -> {
+          return new EDDGridFromDapHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDGridLonPM180" -> {
+          return new EDDGridLonPM180Handler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridFromErddap" -> {
+          return new EDDGridFromErddapHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromAsciiFiles",
+            "EDDTableFromNcFiles",
+            "EDDTableFromAudioFiles",
+            "EDDTableFromAwsXmlFiles",
+            "EDDTableFromColumnarAsciiFiles",
+            "EDDTableFromHttpGet",
+            "EDDTableFromInvalidCRAFiles",
+            "EDDTableFromJsonlCSVFiles",
+            "EDDTableFromMultidimNcFiles",
+            "EDDTableFromNcCFFiles",
+            "EDDTableFromNccsvFiles",
+            "EDDTableFromHyraxFiles",
+            "EDDTableFromThreddsFiles",
+            "EDDTableFromWFSFiles" -> {
+          return new EDDTableFromFilesHandler(saxHandler, datasetID, completeState, datasetType);
+        }
+        case "EDDGridAggregateExistingDimension" -> {
+          return new EDDGridAggregateExistingDimensionHandler(
+              saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridCopy" -> {
+          return new EDDGridCopyHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridFromEDDTable" -> {
+          return new EDDGridFromEDDTableHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridLon0360" -> {
+          return new EDDGridLon0360Handler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDGridSideBySide" -> {
+          return new EDDGridSideBySideHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDTableAggregateRows" -> {
+          return new EDDTableAggregateRowsHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDTableCopy" -> {
+          return new EDDTableCopyHandler(saxHandler, datasetID, completeState, context);
+        }
+        case "EDDTableFromCassandra" -> {
+          return new EDDTableFromCassandraHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromDapSequence" -> {
+          return new EDDTableFromDapSequenceHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromDatabase" -> {
+          return new EDDTableFromDatabaseHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromAsciiService" -> {
+          return new EDDTableFromAsciiServiceHandler(
+              saxHandler, datasetID, completeState, datasetType);
+        }
+        case "EDDTableFromOBIS" -> {
+          return new EDDTableFromOBISHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromSOS" -> {
+          return new EDDTableFromSOSHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDTableFromFileNames" -> {
+          return new EDDTableFromFileNamesHandler(saxHandler, datasetID, completeState);
+        }
+        case "EDDGridFromAudioFiles",
+            "EDDGridFromNcFiles",
+            "EDDGridFromNcFilesUnpacked",
+            "EDDGridFromMergeIRFiles" -> {
+          return new EDDGridFromFilesHandler(saxHandler, datasetID, completeState, datasetType);
+        }
+        case "EDDGridFromEtopo" -> {
+          return new EDDGridFromEtopoHandler(saxHandler, datasetID, completeState);
+        }
+        default -> {
+          nTry--;
+          context.getNTryAndDatasets()[0] = nTry;
+          throw new IllegalArgumentException("Unknown dataset type: " + datasetType);
+        }
       }
     }
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/SaxHandlerClass.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/SaxHandlerClass.java
@@ -1,0 +1,15 @@
+package gov.noaa.pfel.erddap.handlers;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Specifies which State subclass should be used to parse an XML string. */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SaxHandlerClass {
+  Class<? extends State> value();
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -791,7 +791,8 @@ public class EDStatic {
       useLuceneSearchEngine,
       variablesMustHaveIoosCategory,
       verbose,
-      useSaxParser;
+      useSaxParser,
+      useEddReflection;
   public static String categoryAttributes[]; // as it appears in metadata (and used for hashmap)
   public static String categoryAttributesInURLs[]; // fileNameSafe (as used in URLs)
   public static boolean categoryIsGlobal[];
@@ -2269,6 +2270,7 @@ public class EDStatic {
       subscriptionSystemActive = getSetupEVBoolean(setup, ev, "subscriptionSystemActive", true);
       convertersActive = getSetupEVBoolean(setup, ev, "convertersActive", true);
       useSaxParser = getSetupEVBoolean(setup, ev, "useSaxParser", false);
+      useEddReflection = getSetupEVBoolean(setup, ev, "useEddReflection", false);
       slideSorterActive = getSetupEVBoolean(setup, ev, "slideSorterActive", true);
       variablesMustHaveIoosCategory =
           getSetupEVBoolean(setup, ev, "variablesMustHaveIoosCategory", true);

--- a/pom.xml
+++ b/pom.xml
@@ -180,9 +180,24 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.4.0</version>
                 <configuration>
+                    <attachClasses>true</attachClasses>
                     <warSourceDirectory>${project.basedir}</warSourceDirectory>
                     <warSourceExcludes>**/*.java, **/*.javaINACTIVE, **/*.javaInactive, **/*.java_NOT_YET, **/*.javaNOT_FINISHED, **/*.javaOLD, content/**, data/**, development/**, download_cache/**, /src/test/**, target/**, src/**, WEB-INF/classes/gov/noaa/pfel/coastwatch/log.*, WEB-INF/lib/**, WEB-INF/NetCheck.*, WEB-INF/*.web.xml, WEB-INF/DoubleCenterGrids.sh, WEB-INF/FileVisitorDNLS.sh, WEB-INF/FindDuplicateTime.*, WEB-INF/GenerateO*, WEB-INF/GenerateT*, WEB-INF/GridSaveAs*, WEB-INF/incompleteMainCatalog.xml, WEB-INF/iobis.m, WEB-INF/obis.m, WEB-INF/MapViewer.*, WEB-INF/QN2005193*, WEB-INF/ValidateDataSetProperties*, WEB-INF/fonts/**, WEB-INF/temp/**, *.*, .settings/**, .github/**, .vscode/**</warSourceExcludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-maven-plugin -->
@@ -923,6 +938,11 @@
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
             <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.176</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Description

This change uses reflection, specifically the [ClassGraph](https://github.com/classgraph/classgraph) classpath scanner, to discover concrete EDD subclasses and associated class metadata (`fromXml` methods and Sax handlers for XML deseralization) at runtime. The scan is performed once and stored in a static map for use in XML deserialization methods.

In addition to eliminating the need to register various EDD implementations in the ERDDAP codebase in `EDD.fromXml` and `HandlerFactory.getHandlerFor`, this change also allows loading of third party EDD implementations at runtime.

The reflection based EDD class discovery is enabled by the ERDDAP setting `useEddReflection`. If true, the class map built using reflection is used to discover classes/methods for XML deserialization. If false, legacy hardcoded approaches are used.

In local testing classpath scanning took about 1 second. This scan occurs only once at startup. Scanning is confined to EDD's package (`gov.noaa.pfel.erddap.dataset`) for performance reasons; scanning all packages took around 12 seconds. For this reason, all EDD implementations need to belong to the `gov.noaa.pfel.erddap.dataset` package to be detected.
    
This adds a dependency on classgraph, which is very small (~560k).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
