### PR TITLE
Add GitHub Actions maven build and test for main branch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target
+test-data

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,12 +17,12 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
+    - name: Build and test with Maven
       run: >
         mvn --batch-mode
         -Dgcf.skipInstallHooks=true
         -Dmaven.test.redirectTestOutputToFile=true
-        clean test
+        clean verify
 
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,28 @@
+name: Build and test ERDDAP
+
+on:
+  push:
+    branches: [ "main", "gha-test" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: >
+        mvn --batch-mode
+        -Dgcf.skipInstallHooks=true
+        -Dmaven.test.redirectTestOutputToFile=true
+        clean test
+
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ images/post
 /content/
 /data/
 /target/
-download_cache/
 *.class
 Thumbs.db
 .vscode
@@ -19,8 +18,7 @@ Thumbs.db
 /build/
 /out/
 /.gradle/
-src/test/resources/*
-!src/test/resources/datasets/
+/test-data/
 .idea
 development/test/datasets.xml
 development/test/datasets.xml*

--- a/development/docker/Dockerfile
+++ b/development/docker/Dockerfile
@@ -7,7 +7,7 @@
 # ERDDAP should then be available at http://localhost:8080/erddap
 
 # Set up build env.
-FROM maven:3.9.6-eclipse-temurin-17 AS build
+FROM maven:3.9.6-eclipse-temurin-21 AS build
 
 RUN mkdir /app/
 WORKDIR /app/
@@ -21,11 +21,12 @@ ADD download ./download
 ADD images ./images
 ADD src ./src
 ADD WEB-INF ./WEB-INF
+ADD .mvn ./.mvn
 COPY pom.xml .
-RUN --mount=type=cache,id=m2_repo,target=/root/.m2/repository --mount=type=cache,id=download_cache,target=download_cache mvn -f pom.xml package
+RUN --mount=type=cache,id=m2_repo,target=/root/.m2/repository mvn package -Dgcf.skipInstallHooks
 
 # Run the built erddap war via a tomcat instance.
-FROM tomcat:10.1.19-jdk17-temurin-jammy
+FROM tomcat:10.1.19-jdk21-temurin-jammy
 RUN mkdir /usr/local/tomcat/content/erddap/ -p
 RUN mkdir /usr/local/erddap_data/
 COPY --from=build /app/target/*.war /usr/local/tomcat/webapps/erddap.war

--- a/development/test/setup.xml
+++ b/development/test/setup.xml
@@ -19,7 +19,7 @@ Subdirectories that will be created by ERDDAP are:
 The ERDDAP log file (log.txt) will be put in this directory.
 At ERD, we use '/u00/cwatch/erddap/' for releases.
 -->
-<bigParentDirectory>data</bigParentDirectory>
+<bigParentDirectory>target/data</bigParentDirectory>
 
 <!-- baseUrl is the start of the public url, to which "/erddap" 
 is appended. For example:

--- a/pom.xml
+++ b/pom.xml
@@ -158,19 +158,38 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
                 <executions>
-                <execution>
-                    <id>enforce-maven</id>
-                    <goals>
-                    <goal>enforce</goal>
-                    </goals>
-                    <configuration>
-                    <rules>
-                        <requireMavenVersion>
-                            <version>3.6.3</version>
-                        </requireMavenVersion>
-                    </rules>    
-                    </configuration>
-                </execution>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.6.3</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>no-test-data-in-src-test-resources</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesDontExist>
+                                    <message>Test data directories should be removed from src/test/resources</message>
+                                    <files>
+                                        <file>${project.basedir}/src/test/resources/data</file>
+                                        <file>${project.basedir}/src/test/resources/largeFiles</file>
+                                        <file>${project.basedir}/src/test/resources/largePoints</file>
+                                        <file>${project.basedir}/src/test/resources/largeSatellite</file>
+                                    </files>
+                                </requireFilesDontExist>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
                 <configuration>
                     <attachClasses>true</attachClasses>
                     <warSourceDirectory>${project.basedir}</warSourceDirectory>
-                    <warSourceExcludes>**/*.java, **/*.javaINACTIVE, **/*.javaInactive, **/*.java_NOT_YET, **/*.javaNOT_FINISHED, **/*.javaOLD, content/**, data/**, development/**, download_cache/**, /src/test/**, target/**, src/**, WEB-INF/classes/gov/noaa/pfel/coastwatch/log.*, WEB-INF/lib/**, WEB-INF/NetCheck.*, WEB-INF/*.web.xml, WEB-INF/DoubleCenterGrids.sh, WEB-INF/FileVisitorDNLS.sh, WEB-INF/FindDuplicateTime.*, WEB-INF/GenerateO*, WEB-INF/GenerateT*, WEB-INF/GridSaveAs*, WEB-INF/incompleteMainCatalog.xml, WEB-INF/iobis.m, WEB-INF/obis.m, WEB-INF/MapViewer.*, WEB-INF/QN2005193*, WEB-INF/ValidateDataSetProperties*, WEB-INF/fonts/**, WEB-INF/temp/**, *.*, .settings/**, .github/**, .vscode/**</warSourceExcludes>
+                    <warSourceExcludes>**/*.java, **/*.javaINACTIVE, **/*.javaInactive, **/*.java_NOT_YET, **/*.javaNOT_FINISHED, **/*.javaOLD, content/**, data/**, development/**, test-data/**, /src/test/**, target/**, src/**, WEB-INF/classes/gov/noaa/pfel/coastwatch/log.*, WEB-INF/lib/**, WEB-INF/NetCheck.*, WEB-INF/*.web.xml, WEB-INF/DoubleCenterGrids.sh, WEB-INF/FileVisitorDNLS.sh, WEB-INF/FindDuplicateTime.*, WEB-INF/GenerateO*, WEB-INF/GenerateT*, WEB-INF/GridSaveAs*, WEB-INF/incompleteMainCatalog.xml, WEB-INF/iobis.m, WEB-INF/obis.m, WEB-INF/MapViewer.*, WEB-INF/QN2005193*, WEB-INF/ValidateDataSetProperties*, WEB-INF/fonts/**, WEB-INF/temp/**, *.*, .settings/**, .github/**, .vscode/**</warSourceExcludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -252,7 +252,6 @@
                             <url>https://github.com/ERDDAP/erddapContent/releases/download/${erddapcontent.download.version}/erddapContent.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -266,7 +265,6 @@
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/etopo1_ice_g_i2.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -280,7 +278,6 @@
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/ref_files.zip</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -294,8 +291,7 @@
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/data.zip</url>
                             <unpack>true</unpack>
-                            <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -308,8 +304,7 @@
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeFiles.zip</url>
                             <unpack>true</unpack>
-                            <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -322,8 +317,7 @@
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largePoints.zip</url>
                             <unpack>true</unpack>
-                            <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -336,8 +330,7 @@
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeSatellite.zip</url>
                             <unpack>true</unpack>
-                            <outputDirectory>${project.basedir}/src/test/resources/</outputDirectory>
-                            <cacheDirectory>${project.basedir}/download_cache</cacheDirectory>
+                            <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
                     </execution>
@@ -347,6 +340,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
                 <configuration>
+                    <additionalClasspathElements>
+                        <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
+                    </additionalClasspathElements>
                     <excludedGroups>Jetty, Slow, LargeFiles, Flaky, AWS, LocalERDDAP, Password, Thredds, ExternalERDDAP, MissingFile, ExternalOther, IncompleteTest, RequiresContent, MissingDataset</excludedGroups>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
                         </goals>
                         <configuration>
                             <target>
-                                <mkdir dir="${project.basedir}/data"/>
+                                <mkdir dir="${project.basedir}/target/data"/>
                             </target>
                         </configuration>
                     </execution>
@@ -376,6 +376,9 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
+                            </additionalClasspathElements>
                             <groups>Jetty, Slow</groups>
                             <excludedGroups>LargeFiles, Flaky, AWS, LocalERDDAP, Password, Thredds, ExternalERDDAP, MissingFile, ExternalOther, IncompleteTest, RequiresContent, MissingDataset</excludedGroups>
                             <includes>

--- a/src/test/java/com/cohort/util/TestUtil.java
+++ b/src/test/java/com/cohort/util/TestUtil.java
@@ -8283,7 +8283,7 @@ class TestUtil {
     Test.ensureEqual(File2.getProtocolDomain("/"), "", "");
 
     // test File2.getFileInputStream(
-    String path = "src/test/resources/data";
+    String path = "test-data/data";
     File file = new File(path);
     String absolutePath = file.getAbsolutePath();
     String utff = absolutePath + "/compressed/AUTF8File";

--- a/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,10 +29,17 @@ public class TopLevelHandlerTests {
   private static InputStream inputStream;
   private static SaxHandler saxHandler;
   private static SaxParsingContext context;
+  private static HashSet<String> preservedAngularDegreeUnitsSet;
 
   @BeforeAll
   static void initAll() throws Throwable {
     Initialization.edStatic();
+
+    // FIXME: Tests should not alter EDStatic state which other tests depend on
+    //        because test execution order is not guaranteed. As a temporary fix,
+    //        preserve the original angularDegreeUnitsSet and restore it after the tests.
+    preservedAngularDegreeUnitsSet = new HashSet<>(EDStatic.angularDegreeUnitsSet);
+
     context = new SaxParsingContext();
 
     context.setNTryAndDatasets(new int[2]);
@@ -54,6 +62,13 @@ public class TopLevelHandlerTests {
     saxHandler = new SaxHandler(context);
     topLevelHandler = new TopLevelHandler(saxHandler, context);
     saxHandler.setState(topLevelHandler);
+  }
+
+  @AfterAll
+  static void tearDownAll() throws IOException {
+    // restore altered angularDegreeUnitsSet because other tests depend on it
+    // (e.g. EDDTableFromNcFilesTests#testOrderByMean2)
+    EDStatic.angularDegreeUnitsSet = preservedAngularDegreeUnitsSet;
   }
 
   @BeforeEach


### PR DESCRIPTION
# Description

* Adds GitHub Action in `.github/workflows/maven.yml` to build and test on pushes or pull_requests to `main`
* Moves test data from `src/test/resources` to `test-data` and adds `test-data` as a `maven-surefire-plugin` `additionalClasspathElement`
* Removes `download-maven-plugin` cacheDirectory overrides, moving cache directory to default `.m2/respository/.cache/maven-download-plugin`
* Fixes `TopLevelHandlerTests` which alters the value of `EDStatic.angularDegreeUnitsSet`, affecting subsequent tests (test order is indeterminate)
* Updates `development/docker/Dockerfile` (adds missing .mvn dir needed for `errorprone`, skips git-code-format hook installtion, and updates Java version to 21)

The test data move from `src/test/resources` to `test-data` was needed because many of the test cases require a specific data file to be the last file (latest mtime) in the matching set. `maven-resources-plugin` does not preserve mtime when copying test resources into `target/test-classes`, which was leading to files in test datasets having exactly the same mtime (the time at which `maven-resources-plugin` copied the files), and an indeterminate file was being selected as "latest". By using the test data in place via `additionalClasspathElement`, we preserve the mtimes and also avoid copying huge amounts of data into `target/test-classes` (win win).

Note: `gha-test` branch reference in `.github/workflows/maven.yml` can be deleted just before or after merge. It's just there to demonstrate working build/test.


Adds a simple GitHub Actions maven build and test for the main branch and pull requests against the main branch.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project