### PR TITLE
Fix JettyTests etopo mtime (get from test file)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,7 @@ name: Build and test ERDDAP
 
 on:
   push:
-    branches: [ "main", "gha-test" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -14378,12 +14378,18 @@ class JettyTests {
     String dapQuery, tName, start, query, results, expected;
     int po;
 
+    String etopoFilePath = EDStatic.getWebInfParentDirectory() + "WEB-INF/ref/etopo1_ice_g_i2.bin";
+    long etopoLastModifiedMillis = File2.getLastModified(etopoFilePath);
+
     // get /files/datasetID/.csv
     results =
         SSR.getUrlResponseStringNewline(
             "http://localhost:" + PORT + "/erddap/files/" + tDatasetID + "/.csv");
     expected =
-        "Name,Last modified,Size,Description\n" + "etopo1_ice_g_i2.bin,1642733858000,466624802,\n";
+        "Name,Last modified,Size,Description\n"
+            + "etopo1_ice_g_i2.bin,"
+            + etopoLastModifiedMillis
+            + ",466624802,\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // get /files/datasetID/


### PR DESCRIPTION

# Description

Fixes `JettyTests#testEtopoGridFiles` by getting `WEB-INF/ref/etopo1_ice_g_i2.bin` mtime directly from file instead of hardcoding it.

Also remove `gha-test` from GHA Maven build/target branches (no longer needed).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
