### PR TITLE
Fix JettyTests etopo mtime (get from test file)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,7 @@ name: Build and test ERDDAP
 
 on:
   push:
-    branches: [ "main", "gha-test" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/src/test/java/gov/noaa/pfel/coastwatch/util/FileVisitorDNLSTests.java
+++ b/src/test/java/gov/noaa/pfel/coastwatch/util/FileVisitorDNLSTests.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import tags.TagAWS;
 import tags.TagExternalOther;
 import tags.TagLargeFiles;
+import tags.TagMissingDataset;
 import tags.TagMissingFile;
 import tags.TagSlowTests;
 import tags.TagThredds;
@@ -979,6 +980,7 @@ class FileVisitorDNLSTests {
   /** This tests GPCP. */
   @org.junit.jupiter.api.Test
   @TagSlowTests
+  @TagMissingDataset // Data temporarily unavailable at NCEI due to Hurricane Helene impacts
   void testGpcp() throws Throwable {
     String2.log("\n*** FileVisitorDNLS.testGpcp()\n");
 

--- a/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
@@ -48,6 +48,7 @@ public class TopLevelHandlerTests {
     context.setDatasetIDSet(new HashSet<>());
     context.setDuplicateDatasetIDs(new StringArray());
     context.setWarningsFromLoadDatasets(new StringBuilder());
+    context.setDatasetsThatFailedToLoadSB(new StringBuilder());
     context.settUserHashMap(new HashMap<String, Object[]>());
     context.setMajorLoad(false);
     context.setErddap(new Erddap());

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -14378,12 +14378,18 @@ class JettyTests {
     String dapQuery, tName, start, query, results, expected;
     int po;
 
+    String etopoFilePath = EDStatic.getWebInfParentDirectory() + "WEB-INF/ref/etopo1_ice_g_i2.bin";
+    long etopoLastModifiedMillis = File2.getLastModified(etopoFilePath);
+
     // get /files/datasetID/.csv
     results =
         SSR.getUrlResponseStringNewline(
             "http://localhost:" + PORT + "/erddap/files/" + tDatasetID + "/.csv");
     expected =
-        "Name,Last modified,Size,Description\n" + "etopo1_ice_g_i2.bin,1642733858000,466624802,\n";
+        "Name,Last modified,Size,Description\n"
+            + "etopo1_ice_g_i2.bin,"
+            + etopoLastModifiedMillis
+            + ",466624802,\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // get /files/datasetID/

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -17541,6 +17541,7 @@ class JettyTests {
     context.setDatasetsThatFailedToLoadSB(new StringBuilder());
     context.setFailedDatasetsWithErrorsSB(new StringBuilder());
     context.setWarningsFromLoadDatasets(new StringBuilder());
+    context.setDatasetsThatFailedToLoadSB(new StringBuilder());
     context.settUserHashMap(new HashMap<String, Object[]>());
     context.setMajorLoad(false);
     context.setErddap(new Erddap());


### PR DESCRIPTION
# Description

Fixes `JettyTests#testEtopoGridFiles` by getting `WEB-INF/ref/etopo1_ice_g_i2.bin` mtime directly from file instead of hardcoding it.

Also remove `gha-test` from GHA Maven build/target branches (no longer needed).

Note: trying a fresh PR because GHA test failed and I don't have permissions to rerun them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
