### PR TITLE
Control versions of indirect dependencies from hadoop (which is neede…

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/pointdata/Table.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/pointdata/Table.java
@@ -66,16 +66,15 @@ import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
 import javax.sound.sampled.AudioSystem;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.example.data.simple.convert.GroupRecordConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.ColumnIOFactory;
 import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.io.LocalOutputFile;
 import org.apache.parquet.io.MessageColumnIO;
 import org.apache.parquet.io.RecordReader;
@@ -15956,10 +15955,7 @@ public class Table {
       String fullFileName, StringArray colNames, String[] colTypes, boolean simplify)
       throws Exception {
     clear();
-    Path filePath = new Path(fullFileName);
-    Configuration conf = new Configuration();
-
-    InputFile parquetFile = HadoopInputFile.fromPath(filePath, conf);
+    InputFile parquetFile = new LocalInputFile(java.nio.file.Path.of(fullFileName));
     ParquetFileReader fileReader =
         new ParquetFileReader(parquetFile, ParquetReadOptions.builder().build());
     try {

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,42 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!--
+            The below are here to force updated dependencies of the hadoop libraries.
+            The default selections have security vulnerabilities. Ideally we wouldn't be including
+            hadoop at all, but parquet currently has dependencies on hadoop to read and write files.
+            -->
+            <!-- https://mvnrepository.com/artifact/org.apache.avro/avro -->
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>1.12.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/dnsjava/dnsjava -->
+            <dependency>
+                <groupId>dnsjava</groupId>
+                <artifactId>dnsjava</artifactId>
+                <version>3.6.2</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.78.1</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2 -->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.11.0</version>
+            </dependency>
+            <!-- https://mvnrepository.com/artifact/com.nimbusds/nimbus-jose-jwt -->
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>9.41.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -966,6 +1002,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>3.4.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,14 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- This is needed due to indirect dependency in cdm-core -->
+            <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.25.5</version>
+            </dependency>
+
             <!--
             The below are here to force updated dependencies of the hadoop libraries.
             The default selections have security vulnerabilities. Ideally we wouldn't be including

--- a/src/test/java/gov/noaa/pfel/coastwatch/pointdata/TableTests.java
+++ b/src/test/java/gov/noaa/pfel/coastwatch/pointdata/TableTests.java
@@ -18897,8 +18897,10 @@ public class TableTests {
   void testReadParquet() throws Exception {
 
     String fileName =
-        TableTests.class
-            .getResource("/data/parquet/GHG_national_2012_m1_v2.0.0_a8c5929.parquet")
+        new java.io.File(
+                TableTests.class
+                    .getResource("/data/parquet/GHG_national_2012_m1_v2.0.0_a8c5929.parquet")
+                    .getFile())
             .getPath();
     // don't simplify
     Table table = new Table();


### PR DESCRIPTION
…d for parquet at least for now).

The parquet org is working on separating the read/write logic from hadoop, but that has been an ongoing project for years, and is still not completed. Eventually we should be able to remove the hadoop dependency.

Fixes: Security vulnerabilities due to indirect hadoop dependencies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
