### PR TITLE
Upgrade to maven-download-plugin 1.11.1, use unpackWhenChanged

### DIFF
--- a/PROGRAMMER_GUIDE.md
+++ b/PROGRAMMER_GUIDE.md
@@ -19,8 +19,7 @@ ERDDAP™ uses Maven to load code dependencies as well as some static reference 
 
   - [erddapContent.zip](https://github.com/ERDDAP/erddapContent/releases/download/content1.0.0/erddapContent.zip) (version 1.0.0, 20333 bytes, MD5=2B8D2A5AE5ED73E3A42B529C168C60B5, dated 2024-10-14) and unzip it into _tomcat_, creating _tomcat_/content/erddap .
 
-NOTE: Maven caches downloads but will unzip the downloaded archives on each execution, which takes time. To skip downloading
-and unzipping archives, you may specify the `skipResourceDownload` property to Maven (e.g. `mvn -DskipResourceDownload package`).
+NOTE: By default Maven will cache static reference and test data archive downloads and only extract them when a new version is downloaded. To skip downloading entirely, you may set the `skipResourceDownload` and/or `skipTestResourceDownload` properties to Maven (e.g. `mvn -DskipResourceDownload package`). To force extraction, set `-Ddownload.unpack`.
 
 - ERDDAP™ and its subcomponents have very liberal, open-source [licenses](https://erddap.github.io/setup.html#license), so you can use and modify the source code for any purpose, for-profit or not-for-profit. Note that ERDDAP™ and many subcomponents have licenses that require that you acknowledge the source of the code that you are using. See [Credits](https://erddap.github.io/setup.html#credits). Whether required or not, it is just good form to acknowledge all of these contributors.
    

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.11.0</version>
+                <version>1.11.1</version>
                 <executions>
                     <execution>
                         <id>download-content</id>
@@ -269,7 +269,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapContent/releases/download/${erddapcontent.download.version}/erddapContent.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -282,7 +282,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/etopo1_ice_g_i2.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -295,7 +295,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/ref_files.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -309,7 +309,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/data.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -322,7 +322,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeFiles.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -335,7 +335,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largePoints.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -348,7 +348,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeSatellite.zip</url>
-                            <unpack>true</unpack>
+                            <unpackWhenChanged>true</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>


### PR DESCRIPTION
Update `maven-download-plugin` to `1.11.1` and use the new `unpackWhenChanged` option to only extract downloaded reference/test data archives when a new or updated archive is downloaded by default.