### PR TITLE
Maven download plugin unpackWhenChanged fixes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,4 +22,6 @@ jobs:
         mvn --batch-mode
         -Dgcf.skipInstallHooks=true
         -Dmaven.test.redirectTestOutputToFile=true
+        -Ddownload.unpack=true
+        -Ddownload.unpackWhenChanged=false
         clean verify

--- a/PROGRAMMER_GUIDE.md
+++ b/PROGRAMMER_GUIDE.md
@@ -19,7 +19,7 @@ ERDDAP™ uses Maven to load code dependencies as well as some static reference 
 
   - [erddapContent.zip](https://github.com/ERDDAP/erddapContent/releases/download/content1.0.0/erddapContent.zip) (version 1.0.0, 20333 bytes, MD5=2B8D2A5AE5ED73E3A42B529C168C60B5, dated 2024-10-14) and unzip it into _tomcat_, creating _tomcat_/content/erddap .
 
-NOTE: By default Maven will cache static reference and test data archive downloads and only extract them when a new version is downloaded. To skip downloading entirely, you may set the `skipResourceDownload` and/or `skipTestResourceDownload` properties to Maven (e.g. `mvn -DskipResourceDownload package`). To force extraction, set `-Ddownload.unpack`.
+NOTE: By default Maven will cache static reference and test data archive downloads and only extract them when a new version is downloaded. To skip downloading entirely, you may set the `skipResourceDownload` and/or `skipTestResourceDownload` properties to Maven (e.g. `mvn -DskipResourceDownload package`). To force extraction, set `-Ddownload.unpack=true` and `-Ddownload.unpackWhenChanged=false`.
 
 - ERDDAP™ and its subcomponents have very liberal, open-source [licenses](https://erddap.github.io/setup.html#license), so you can use and modify the source code for any purpose, for-profit or not-for-profit. Note that ERDDAP™ and many subcomponents have licenses that require that you acknowledge the source of the code that you are using. See [Credits](https://erddap.github.io/setup.html#credits). Whether required or not, it is just good form to acknowledge all of these contributors.
    

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <test.resources.version>test1.04</test.resources.version>
         <jettyVersion>12.0.14</jettyVersion>
         <error-prone.version>2.27.0</error-prone.version>
+        <download.unpackWhenChanged>true</download.unpackWhenChanged>
     </properties>
 
     <repositories>
@@ -269,7 +270,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapContent/releases/download/${erddapcontent.download.version}/erddapContent.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -282,7 +283,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/etopo1_ice_g_i2.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -295,7 +296,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/ERDDAPRefFiles/releases/download/${erddapreffiles.download.version}/ref_files.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/WEB-INF/ref/</outputDirectory>
                             <skip>${skipResourceDownload}</skip>
                         </configuration>
@@ -309,7 +310,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/data.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -322,7 +323,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeFiles.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -335,7 +336,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largePoints.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>
@@ -348,7 +349,7 @@
                         </goals>
                         <configuration>
                             <url>https://github.com/ERDDAP/erddapTest/releases/download/${test.resources.version}/largeSatellite.zip</url>
-                            <unpackWhenChanged>true</unpackWhenChanged>
+                            <unpackWhenChanged>${download.unpackWhenChanged}</unpackWhenChanged>
                             <outputDirectory>${project.basedir}/test-data</outputDirectory>
                             <skip>${skipTestResourceDownload}</skip>
                         </configuration>


### PR DESCRIPTION
# Description

Apparently command line options don't override plugin configuration defined in the pom, and the solution to allow such behavior is to defined a property (which _is_ overridable via command line options) and reference that in the plugin config.

https://issues.apache.org/jira/browse/MNG-4979

Also make sure ref/test data is unpacked during Github Actions maven builds.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
