### PR TITLE
displayInfo and displayAttribute tags for datasets.xml

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -229,12 +229,7 @@ public class LoadDatasets extends Thread {
       int nTry = nTryAndDatasets[0];
       int nDatasets = nTryAndDatasets[1];
 
-      // validation for displayInfo and displayAttribute Tags
-      if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
-        String2.log("Incorrect input to the displayAttribute and displayInfo tags");
-        EDStatic.displayAttributeAr = EDStatic.DEFAULT_displayAttributeAr;
-        EDStatic.displayInfoAr = EDStatic.DEFAULT_displayInfoAr;
-      }
+      validateDatasetsXmlResults();
 
       erddap.updateLucene(changedDatasetIDs);
       lastLuceneUpdate = System.currentTimeMillis();
@@ -453,6 +448,15 @@ public class LoadDatasets extends Thread {
       synchronized (EDStatic.suggestAddFillValueCSV) {
         EDStatic.suggestAddFillValueCSV.setLength(0);
       }
+    }
+  }
+
+  /** Validation checks post the parsing of the datasets.xml file */
+  private void validateDatasetsXmlResults() {
+    if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
+      String2.log("Incorrect input to the displayAttribute and displayInfo tags");
+      EDStatic.displayAttributeAr = EDStatic.DEFAULT_displayAttributeAr;
+      EDStatic.displayInfoAr = EDStatic.DEFAULT_displayInfoAr;
     }
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -229,6 +229,13 @@ public class LoadDatasets extends Thread {
       int nTry = nTryAndDatasets[0];
       int nDatasets = nTryAndDatasets[1];
 
+      // validation for displayInfo and displayAttribute Tags
+      if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
+        String2.log("Incorrect input to the displayAttribute and displayInfo tags");
+        EDStatic.displayAttributeAr = EDStatic.DEFAULT_displayAttributeAr;
+        EDStatic.displayInfoAr = EDStatic.DEFAULT_displayInfoAr;
+      }
+
       erddap.updateLucene(changedDatasetIDs);
       lastLuceneUpdate = System.currentTimeMillis();
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -3795,63 +3795,73 @@ public abstract class EDD {
             + "</table>\n");
   }
 
+  /**
+   * This renders the string for the Information section of the dataset page
+   *
+   * @return the String to append to Information row
+   */
   private String getDisplayInfo(int language, String loggedInAs) {
     if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
+      String2.log("Incorrect input to the displayAttribute and displayInfo tags");
       return "";
     }
 
     StringBuilder displayInfoStr = new StringBuilder();
-    String tSummary = extendedSummary();
-    displayInfoStr
-        .append(EDStatic.EDDSummaryAr[language])
-        .append(" ")
-        .append(
+
+    for (int i = 0; i < EDStatic.displayAttributeAr.length; i++) {
+      String attribute = EDStatic.displayAttributeAr[i];
+      String displayInfo = EDStatic.displayInfoAr[i];
+      String value;
+
+      // Handle "summary"
+      if ("summary".equals(attribute)) {
+        String tSummary = extendedSummary();
+        value =
             EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
-                "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tSummary) + "</div>"))
-        .append("\n");
-
-    String tLicense = combinedGlobalAttributes().getString("license");
-    boolean nonStandardLicense = tLicense != null && !tLicense.equals(EDStatic.standardLicense);
-    tLicense =
-        tLicense == null
-            ? ""
-            : "    | "
-                + (nonStandardLicense ? "<span class=\"warningColor\">" : "")
-                + EDStatic.licenseAr[language]
-                + " "
-                + (nonStandardLicense ? "</span>" : "")
-                +
-                // link below should have rel=\"license\"
-                EDStatic.htmlTooltipImage(
-                    language,
-                    loggedInAs,
-                    "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tLicense) + "</div>")
-                + "\n";
-    displayInfoStr.append(tLicense);
-    for (int i = 0; i < EDStatic.displayAttributeAr.length; i++) {
-      String attribute = EDStatic.displayAttributeAr[i];
-
-      // Skip "summary" and "license" as they are already handled
-      if ("summary".equals(attribute) || "license".equals(attribute)) {
+                "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tSummary) + "</div>");
+        displayInfoStr
+            .append(EDStatic.EDDSummaryAr[language])
+            .append(" ")
+            .append(value)
+            .append("\n");
         continue;
       }
 
+      // Handle "license"
+      if ("license".equals(attribute)) {
+        String tLicense = combinedGlobalAttributes().getString("license");
+        boolean nonStandardLicense = tLicense != null && !tLicense.equals(EDStatic.standardLicense);
+        value =
+            tLicense == null
+                ? attribute + " is undefined"
+                : (nonStandardLicense ? "<span class=\"warningColor\">" : "")
+                    + EDStatic.licenseAr[language]
+                    + " "
+                    + (nonStandardLicense ? "</span>" : "")
+                    + EDStatic.htmlTooltipImage(
+                        language,
+                        loggedInAs,
+                        "<div class=\"standard_max_width\">"
+                            + XML.encodeAsPreHTML(tLicense)
+                            + "</div>");
+        displayInfoStr.append("    | ").append(value).append("\n");
+        continue;
+      }
+
+      // Handle other attributes
       String attVal = combinedGlobalAttributes().getString(attribute);
-      displayInfoStr
-          .append("    | ")
-          .append(EDStatic.displayInfoAr[i])
-          .append(" ")
-          .append(
-              EDStatic.htmlTooltipImage(
-                  language,
-                  loggedInAs,
-                  "<div class=\"standard_max_width\">"
-                      + XML.encodeAsPreHTML(attVal != null ? attVal : attribute + " is undefined")
-                      + "</div>"))
-          .append("\n");
+      value =
+          EDStatic.htmlTooltipImage(
+              language,
+              loggedInAs,
+              "<div class=\"standard_max_width\">"
+                  + XML.encodeAsPreHTML(attVal != null ? attVal : attribute + " is undefined")
+                  + "</div>");
+      displayInfoStr.append("    | ").append(displayInfo).append(" ").append(value).append("\n");
     }
+
     return displayInfoStr.toString();
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -3694,24 +3694,6 @@ public abstract class EDD {
               + "\">"
               + EDStatic.EDDMakeAGraphAr[language]
               + "</a>\n";
-    String tSummary = extendedSummary();
-    String tLicense = combinedGlobalAttributes().getString("license");
-    boolean nonStandardLicense = tLicense != null && !tLicense.equals(EDStatic.standardLicense);
-    tLicense =
-        tLicense == null
-            ? ""
-            : "    | "
-                + (nonStandardLicense ? "<span class=\"warningColor\">" : "")
-                + EDStatic.licenseAr[language]
-                + " "
-                + (nonStandardLicense ? "</span>" : "")
-                +
-                // link below should have rel=\"license\"
-                EDStatic.htmlTooltipImage(
-                    language,
-                    loggedInAs,
-                    "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tLicense) + "</div>")
-                + "\n";
     String encTitle = XML.encodeAsHTML(String2.noLongLines(title(), 80, ""));
     encTitle = String2.replaceAll(encTitle, "\n", "<br>");
     writer.write(
@@ -3755,14 +3737,6 @@ public abstract class EDD {
             + EDStatic.EDDInformationAr[language]
             + ":&nbsp;</td>\n"
             + "    <td>"
-            + EDStatic.EDDSummaryAr[language]
-            + " "
-            + EDStatic.htmlTooltipImage(
-                language,
-                loggedInAs,
-                "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tSummary) + "</div>")
-            + "\n"
-            + tLicense
             + getDisplayInfo(language, loggedInAs)
             + (accessibleViaFGDC.length() > 0
                 ? ""
@@ -3827,6 +3801,35 @@ public abstract class EDD {
     }
 
     StringBuilder displayInfoStr = new StringBuilder();
+    String tSummary = extendedSummary();
+    displayInfoStr
+        .append(EDStatic.EDDSummaryAr[language])
+        .append(" ")
+        .append(
+            EDStatic.htmlTooltipImage(
+                language,
+                loggedInAs,
+                "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tSummary) + "</div>"))
+        .append("\n");
+
+    String tLicense = combinedGlobalAttributes().getString("license");
+    boolean nonStandardLicense = tLicense != null && !tLicense.equals(EDStatic.standardLicense);
+    tLicense =
+        tLicense == null
+            ? ""
+            : "    | "
+                + (nonStandardLicense ? "<span class=\"warningColor\">" : "")
+                + EDStatic.licenseAr[language]
+                + " "
+                + (nonStandardLicense ? "</span>" : "")
+                +
+                // link below should have rel=\"license\"
+                EDStatic.htmlTooltipImage(
+                    language,
+                    loggedInAs,
+                    "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tLicense) + "</div>")
+                + "\n";
+    displayInfoStr.append(tLicense);
     for (int i = 0; i < EDStatic.displayAttributeAr.length; i++) {
       String attribute = EDStatic.displayAttributeAr[i];
 
@@ -3836,7 +3839,6 @@ public abstract class EDD {
       }
 
       String attVal = combinedGlobalAttributes().getString(attribute);
-
       displayInfoStr
           .append("    | ")
           .append(EDStatic.displayInfoAr[i])
@@ -3850,7 +3852,6 @@ public abstract class EDD {
                       + "</div>"))
           .append("\n");
     }
-
     return displayInfoStr.toString();
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -3763,6 +3763,7 @@ public abstract class EDD {
                 "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(tSummary) + "</div>")
             + "\n"
             + tLicense
+            + getDisplayInfo(language, loggedInAs)
             + (accessibleViaFGDC.length() > 0
                 ? ""
                 : "     | <a rel=\"alternate\" \n"
@@ -3818,6 +3819,39 @@ public abstract class EDD {
             + "</td>\n"
             + "  </tr>\n"
             + "</table>\n");
+  }
+
+  private String getDisplayInfo(int language, String loggedInAs) {
+    if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
+      return "";
+    }
+
+    StringBuilder displayInfoStr = new StringBuilder();
+    for (int i = 0; i < EDStatic.displayAttributeAr.length; i++) {
+      String attribute = EDStatic.displayAttributeAr[i];
+
+      // Skip "summary" and "license" as they are already handled
+      if ("summary".equals(attribute) || "license".equals(attribute)) {
+        continue;
+      }
+
+      String attVal = combinedGlobalAttributes().getString(attribute);
+
+      displayInfoStr
+          .append("    | ")
+          .append(EDStatic.displayInfoAr[i])
+          .append(" ")
+          .append(
+              EDStatic.htmlTooltipImage(
+                  language,
+                  loggedInAs,
+                  "<div class=\"standard_max_width\">"
+                      + XML.encodeAsPreHTML(attVal != null ? attVal : attribute + " is undefined")
+                      + "</div>"))
+          .append("\n");
+    }
+
+    return displayInfoStr.toString();
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
@@ -206,6 +206,22 @@ public class TopLevelHandler extends State {
           String2.log("decompressedCacheMaxMinutesOld=" + EDStatic.decompressedCacheMaxMinutesOld);
         }
       }
+      case "displayAttribute" -> {
+        String tContent = data.toString();
+        String[] displayAttributeAr =
+            String2.isSomething(tContent)
+                ? String2.split(tContent, ',')
+                : EDStatic.DEFAULT_displayAttributeAr;
+        EDStatic.displayAttributeAr = displayAttributeAr;
+      }
+      case "displayInfo" -> {
+        String tContent = data.toString();
+        String[] displayInfoAr =
+            String2.isSomething(tContent)
+                ? String2.split(tContent, ',')
+                : EDStatic.DEFAULT_displayInfoAr;
+        EDStatic.displayInfoAr = displayInfoAr;
+      }
       case "drawLandMask" -> {
         String ts = data.toString();
         int tnt = SgtMap.drawLandMask_OPTIONS.indexOf(ts);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -817,6 +817,11 @@ public class EDStatic {
   public static int variableNameCategoryAttributeIndex = -1;
   public static final int logMaxSizeMB;
 
+  public static String[] DEFAULT_displayAttributeAr = {"summary", "license"};
+  public static String[] DEFAULT_displayInfoAr = {"Summary", "License"};
+  public static String[] displayAttributeAr = DEFAULT_displayAttributeAr;
+  public static String[] displayInfoAr = DEFAULT_displayInfoAr;
+
   public static final String emailSmtpHost;
   public static final String emailUserName;
   public static final String emailFromAddress;

--- a/development/jetty/config/datasets.xml
+++ b/development/jetty/config/datasets.xml
@@ -59,6 +59,8 @@ https://coastwatch.pfel.noaa.gov/erddap/download/setupDatasetsXml.html
 <standardDisclaimerOfEndorsement></standardDisclaimerOfEndorsement>
 <standardDisclaimerOfExternalLinks></standardDisclaimerOfExternalLinks>
 <standardGeneralDisclaimer></standardGeneralDisclaimer>
+<displayInfo></displayInfo>
+<displayAttribute></displayAttribute>
 
 <standardPrivacyPolicy><![CDATA[
 <br>&nbsp;

--- a/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
@@ -10,6 +10,7 @@ import gov.noaa.pfel.erddap.handlers.TopLevelHandler;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import javax.xml.parsers.SAXParser;
@@ -30,6 +31,7 @@ public class TopLevelHandlerTests {
   private static SaxHandler saxHandler;
   private static SaxParsingContext context;
   private static HashSet<String> preservedAngularDegreeUnitsSet;
+  private static String[] preserverDisplayAttributeAr;
 
   @BeforeAll
   static void initAll() throws Throwable {
@@ -39,6 +41,8 @@ public class TopLevelHandlerTests {
     //        because test execution order is not guaranteed. As a temporary fix,
     //        preserve the original angularDegreeUnitsSet and restore it after the tests.
     preservedAngularDegreeUnitsSet = new HashSet<>(EDStatic.angularDegreeUnitsSet);
+    preserverDisplayAttributeAr =
+        Arrays.copyOf(EDStatic.displayAttributeAr, EDStatic.displayAttributeAr.length);
 
     context = new SaxParsingContext();
 
@@ -71,6 +75,7 @@ public class TopLevelHandlerTests {
     // restore altered angularDegreeUnitsSet because other tests depend on it
     // (e.g. EDDTableFromNcFilesTests#testOrderByMean2)
     EDStatic.angularDegreeUnitsSet = preservedAngularDegreeUnitsSet;
+    EDStatic.displayAttributeAr = preserverDisplayAttributeAr;
   }
 
   @BeforeEach
@@ -109,5 +114,17 @@ public class TopLevelHandlerTests {
   @Test
   void datasetTest() {
     assertEquals(2, context.getNTryAndDatasets()[1]);
+  }
+
+  @Test
+  void displayAttributeTest() {
+    assertEquals(EDStatic.displayAttributeAr[0], "attribute1");
+    assertEquals(EDStatic.displayAttributeAr[1], "attribute2");
+  }
+
+  @Test
+  void displayInfoTest() {
+    assertEquals(EDStatic.displayInfoAr[0], "info1");
+    assertEquals(EDStatic.displayInfoAr[1], "info2");
   }
 }

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -120,6 +120,18 @@ class JettyTests {
     server.stop();
   }
 
+  /** Check if the Institution row attributes are being displayed correctly */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void displayInformation() throws Exception {
+    String results =
+        SSR.getUrlResponseStringUnchanged(
+            "http://localhost:" + PORT + "/erddap/griddap/erdMH1chla1day.html");
+
+    Test.ensureTrue(results.indexOf("value for att1") > 0, "");
+    Test.ensureTrue(results.indexOf("value for att2") > 0, "");
+  }
+
   /** Test the metadata */
   @org.junit.jupiter.api.Test
   @TagJetty

--- a/src/test/java/testDataset/EDDTestDataset.java
+++ b/src/test/java/testDataset/EDDTestDataset.java
@@ -60,7 +60,9 @@ public class EDDTestDataset {
               // Try to set this so the datasets that need to load in the background have a chance
               // and this runs again before the jetty tests to ensure all the datasets are loaded.
               + "<loadDatasetsMinMinutes>4</loadDatasetsMinMinutes>\n"
-              + "<loadDatasetsMaxMinutes>8</loadDatasetsMaxMinutes>\n");
+              + "<loadDatasetsMaxMinutes>8</loadDatasetsMaxMinutes>\n"
+              + "<displayInfo>display1,display2</displayInfo>\n"
+              + "<displayAttribute>att1,att2</displayAttribute>\n");
 
       datasetsXml.append(xmlFragment_test_chars());
       datasetsXml.append(xmlFragment_testZarr_compressedData());
@@ -45504,6 +45506,10 @@ public class EDDTestDataset {
         "    <addAttributes>\n"
         + //
         "        <att name=\"Conventions\">CF-1.6, COARDS, ACDD-1.3</att>\n"
+        + //
+        "        <att name=\"att1\">value for att1</att>\n"
+        + //
+        "        <att name=\"att2\">value for att2</att>\n"
         + //
         "        <att name=\"creator_type\">group</att>\n"
         + //

--- a/src/test/resources/datasets/topLevelHandlerTest.xml
+++ b/src/test/resources/datasets/topLevelHandlerTest.xml
@@ -18,4 +18,6 @@
     <dataset type="EDDTableFromErddap" datasetID="CW_erdGtsppBest" active="false">
         <sourceUrl>https://coastwatch.pfeg.noaa.gov/erddap/tabledap/erdGtsppBest</sourceUrl>
     </dataset>
+    <displayAttribute>attribute1,attribute2</displayAttribute>
+    <displayInfo>info1,info2</displayInfo>
 </erddapDatasets>


### PR DESCRIPTION
Issue https://github.com/ERDDAP/erddap/issues/134

- Tags `<displayInfo>` and `<displayAttribute>` are now available as global level tags in `datasets.xml`
- They should contain the same number of elements seperated by a `,`
- `displayAttribute` is the attribute name from the top level `addAttributes` tag of a dataset whose value is displayed in the tooltip
- `displayInfo` should contain what the word should be beside the tooltip
- If tags are not added in `datasets.xml` the default values are "summary" and "license" which work the same