### PR TITLE
add aspect ratio as a parameter for image requests

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -7130,6 +7130,7 @@ public abstract class EDDGrid extends EDD {
       double minX = Double.NaN, maxX = Double.NaN, minY = Double.NaN, maxY = Double.NaN;
       boolean xAscending = true, yAscending = true; // this is what controls flipping of the axes
       String xScale = "", yScale = ""; // (default) or Linear or Log
+      double aspect = Double.NaN;
       int nVars = 4;
       EDV vars[] = null; // set by .vars or lower
       int axisVarI[] = null, dataVarI[] = null; // set by .vars or lower
@@ -7335,6 +7336,12 @@ public abstract class EDDGrid extends EDD {
             if (!yScale.equals("Log") && !yScale.equals("Linear"))
               yScale = ""; // "" -> (the default)
           }
+          if(pParts.length > 4){
+            aspect = String2.parseDouble(pParts[4]);
+            if(aspect < 0.01 || aspect > 100){
+              aspect = Double.NaN;
+            }
+          }
           if (reallyVerbose)
             String2.log(
                 ".yRange min="
@@ -7344,7 +7351,9 @@ public abstract class EDDGrid extends EDD {
                     + " ascending="
                     + yAscending
                     + " scale="
-                    + yScale);
+                    + yScale
+                    + " aspect="
+                    + aspect);
 
           // just to be clear: ignore any unrecognized .something
         } else if (ampPart.startsWith(".")) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
@@ -5129,6 +5129,7 @@ public abstract class EDDTable extends EDD {
       double xMin = Double.NaN, xMax = Double.NaN, yMin = Double.NaN, yMax = Double.NaN;
       boolean xAscending = true, yAscending = true; // this is what controls flipping of the axes
       String xScale = "", yScale = ""; // (default) or Linear or Log
+      double aspect = Double.NaN;
       double fontScale = 1, vectorStandard = Double.NaN;
       String currentDrawLandMask = null; // not yet set
       StringBuilder title2 = new StringBuilder();
@@ -5310,6 +5311,12 @@ public abstract class EDDTable extends EDD {
             if (!yScale.equals("Log") && !yScale.equals("Linear"))
               yScale = ""; // "" -> (the default)
           }
+          if(pParts.length > 4){
+            aspect = String2.parseDouble(pParts[4]);
+            if(aspect < 0.01 || aspect > 100){
+                aspect = Double.NaN;
+            }
+          }
           if (reallyVerbose)
             String2.log(
                 ".yRange min="
@@ -5319,7 +5326,9 @@ public abstract class EDDTable extends EDD {
                     + " ascending="
                     + yAscending
                     + " scale="
-                    + yScale);
+                    + yScale
+                    + " aspect="
+                    + aspect);
 
           // ignore any unrecognized .something
         } else if (ampPart.startsWith(".")) {


### PR DESCRIPTION
# Description

I modified EDDGrid and EDDTable saveAsImage method (in both) to parse the new value.

Fixes [#163](https://github.com/ERDDAP/erddap/issues/163)

> aspect would be a decimal between 0.01 and 100
For this, when the aspect value goes out of bounds, I set it back to Double.NaN indicating the aspect is not set. 

- [ ] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings