### PR TITLE
Have file updates trigger RSS changes and Subscription actions.

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -186,7 +186,8 @@ public class Erddap extends HttpServlet {
       new ConcurrentHashMap<>(16, 0.75f, 4);
 
   /** The RSS info: key=datasetId, value=utf8 byte[] of rss xml */
-  public final ConcurrentHashMap<String, byte[]> rssHashMap = new ConcurrentHashMap<>(16, 0.75f, 4);
+  public static final ConcurrentHashMap<String, byte[]> rssHashMap =
+      new ConcurrentHashMap<>(16, 0.75f, 4);
 
   public final ConcurrentHashMap<String, int[]> failedLogins =
       new ConcurrentHashMap<>(16, 0.75f, 4);
@@ -23550,7 +23551,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @param subject for email messages
    * @param change the change description must be specified or nothing is done
    */
-  protected void tryToDoActions(String tDatasetID, EDD cooDataset, String subject, String change) {
+  public static void tryToDoActions(
+      String tDatasetID, EDD cooDataset, String subject, String change) {
     if (String2.isSomething(tDatasetID) && String2.isSomething(change)) {
       if (!String2.isSomething(subject)) subject = "Change to datasetID=" + tDatasetID;
       try {
@@ -23629,7 +23631,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         // trigger RSS action
         // (after new dataset is in place and if there is either a current or older dataset)
         if (cooDataset != null) {
-          cooDataset.updateRSS(this, change);
+          cooDataset.updateRSS(change);
         }
 
       } catch (Throwable subT) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
@@ -44,6 +44,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1816,6 +1817,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
       requestReloadASAP();
       return false;
     }
+    Map<String, String> snapshot = snapshot();
 
     // get BadFile and FileTable info and make local copies
     ConcurrentHashMap badFileMap = readBadFileMap(); // already a copy of what's in file
@@ -2057,14 +2059,9 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
       }
 
       // after changes all in place
-      // Currently, update() doesn't trigger these changes.
-      // The problem is that some datasets might update every second, others every
-      // day.
-      // Even if they are done, perhaps do them in ERDDAP ((low)update return
-      // changes?)
-      // ?update rss?
-      // ?subscription and onchange actions?
-
+      if (EDStatic.updateSubsRssOnFileChanges) {
+        Erddap.tryToDoActions(datasetID(), this, "", changed(snapshot));
+      }
     }
 
     if (verbose)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
@@ -3210,6 +3210,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
       requestReloadASAP();
       return false;
     }
+    Map<String, String> snapshot = snapshot();
 
     // get BadFile and FileTable info and make local copies
     ConcurrentHashMap badFileMap = readBadFileMap(); // already a copy of what's in file
@@ -3435,14 +3436,9 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
       }
 
       // after changes all in place
-      // Currently, update() doesn't trigger these changes.
-      // The problem is that some datasets might update every second, others every
-      // day.
-      // Even if they are done, perhaps do them in ERDDAP ((low)update return
-      // changes?)
-      // ?update rss?
-      // ?subscription and onchange actions?
-
+      if (EDStatic.updateSubsRssOnFileChanges) {
+        Erddap.tryToDoActions(datasetID(), this, "", changed(snapshot));
+      }
     }
 
     if (verbose)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -809,6 +809,7 @@ public class EDStatic {
   public static final boolean variablesMustHaveIoosCategory;
   public static boolean verbose;
   public static boolean useSaxParser;
+  public static boolean updateSubsRssOnFileChanges;
   public static final boolean useEddReflection;
   public static final String[]
       categoryAttributes; // as it appears in metadata (and used for hashmap)
@@ -2294,6 +2295,7 @@ public class EDStatic {
       subscriptionSystemActive = getSetupEVBoolean(setup, ev, "subscriptionSystemActive", true);
       convertersActive = getSetupEVBoolean(setup, ev, "convertersActive", true);
       useSaxParser = getSetupEVBoolean(setup, ev, "useSaxParser", false);
+      updateSubsRssOnFileChanges = getSetupEVBoolean(setup, ev, "updateSubsRssOnFileChanges", true);
       useEddReflection = getSetupEVBoolean(setup, ev, "useEddReflection", false);
       slideSorterActive = getSetupEVBoolean(setup, ev, "slideSorterActive", true);
       variablesMustHaveIoosCategory =


### PR DESCRIPTION
# Description

Dataset updates triggered by file changes using the watch system did not trigger RSS or subscriptions. This is counter to user expectations. The stated reasoning in a code comment was to avoid spammy changes for datasets that change frequently. I also did not see an explanation for users about this behavior. So this change is bringing the RSS and subscription systems in line with both the documentation and user expectations.

I recognize that this changes behavior in a way that could cause excessive notifications and/or load. There is a new parameter "updateSubsRssOnFileChanges" that will allow admins to disable this behavior if needed.

Documentation will be added once the big documentation update is settled.

Fixes #237 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
