### PR TITLE
EDStatic refactor and Prometheus FeatureFlag metrics

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/TestAll.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/TestAll.java
@@ -49,11 +49,12 @@ public class TestAll {
     String2.setupCommonsLogging(-1);
 
     // set log file to <bigParentDir>/logs/TestAll.out
-    EDStatic.quickRestart = false; // also, this forces EDStatic instantiation when running TestAll
+    EDStatic.config.quickRestart =
+        false; // also, this forces EDStatic instantiation when running TestAll
     String2.setupLog(
         true,
         false, // output to system.out and a file:
-        EDStatic.fullLogsDirectory + "TestAll.log",
+        EDStatic.config.fullLogsDirectory + "TestAll.log",
         false,
         1000000000); // append?
     EDD.testVerboseOn();
@@ -71,8 +72,8 @@ public class TestAll {
     // this might cause small problems for a public running erddap
     // but Bob only uses this on laptop, with private erddap.
     File2.deleteAllFiles(
-        EDStatic.fullPublicDirectory, true, false); // recursive, deleteEmptySubdirectories
-    File2.deleteAllFiles(EDStatic.fullCacheDirectory, true, false);
+        EDStatic.config.fullPublicDirectory, true, false); // recursive, deleteEmptySubdirectories
+    File2.deleteAllFiles(EDStatic.config.fullCacheDirectory, true, false);
 
     // make it appear that initialLoadDatasets() is not true
     EDStatic.majorLoadDatasetsTimeSeriesSB.append("\n");
@@ -328,7 +329,7 @@ public class TestAll {
 
     //    s = Projects.makeAwsS3FilesDatasets(".*"); //all: .*   tests: nrel-pds-wtk\\.yaml,
     // silo\\.yaml (has ?Name: but ? doesn't show in EditPlus)
-    //    File2.writeToFileUtf8(EDStatic.bigParentDirectory + "logs/awsS3Files.txt", s);
+    //    File2.writeToFileUtf8(EDStatic.config.bigParentDirectory + "logs/awsS3Files.txt", s);
     //    String2.log(EDD.testDasDds("radar_vola"));
 
     /*
@@ -453,7 +454,7 @@ public class TestAll {
     //        String2.setClipboardString(s); String2.log(s);
 
     /*   //tallyXml
-       String tfn = EDStatic.fullLogsDirectory + "tallyLterSbsStorageUnitsMV.log";
+       String tfn = EDStatic.config.fullLogsDirectory + "tallyLterSbsStorageUnitsMV.log";
        File2.writeToFileUtf8(tfn,
            FileVisitorDNLS.tallyXml(
            "/u00/data/points/lterSbc/", "knb-lter-sbc\\.\\d+", false,
@@ -1215,7 +1216,7 @@ public class TestAll {
     // of testAll
 
     if (errorSB != null && errorSB.length() > 0) {
-      String fileName = EDStatic.fullLogsDirectory + "/TestAllErrorSB.txt";
+      String fileName = EDStatic.config.fullLogsDirectory + "/TestAllErrorSB.txt";
       String2.log(
           File2.writeToFileUtf8(
               fileName,

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/GSHHS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/GSHHS.java
@@ -8,6 +8,8 @@ import com.cohort.array.IntArray;
 import com.cohort.util.File2;
 import com.cohort.util.LRUCache;
 import com.cohort.util.String2;
+import gov.noaa.pfel.erddap.util.BoundaryCounter;
+import gov.noaa.pfel.erddap.util.Metrics;
 import java.awt.geom.GeneralPath;
 import java.io.*;
 import java.util.Collections;
@@ -70,9 +72,8 @@ public class GSHHS {
 
   private static final Map<String, GeneralPath> cache =
       Collections.synchronizedMap(new LRUCache<>(CACHE_SIZE));
-  private static int nCoarse = 0;
-  private static int nSuccesses = 0;
-  private static int nTossed = 0;
+  public static final BoundaryCounter requestStatus =
+      new BoundaryCounter("gshhs_request_total", "Requests to the GSHHS");
 
   /**
    * This limits the number of lakes that appear at lower resolutions. Smaller numbers lead to more
@@ -136,7 +137,7 @@ public class GSHHS {
       // Don't cache it. Coarse resolutions are always fast because source file is small.
       // And the request is usually a large part of whole world. Most paths will be used.
       tCoarse = "*";
-      nCoarse++;
+      requestStatus.increment(Metrics.BoundaryRequest.coarse);
 
       // make GeneralPath
       path =
@@ -174,10 +175,10 @@ public class GSHHS {
           // cache full?
           if (cache.size() == CACHE_SIZE) {
             tTossed = "*";
-            nTossed++;
+            requestStatus.increment(Metrics.BoundaryRequest.tossed);
           } else {
             tSuccess = "*"; // if cache wasn't full, treat as success
-            nSuccesses++;
+            requestStatus.increment(Metrics.BoundaryRequest.success);
           }
 
           // put new path in the cache
@@ -186,7 +187,7 @@ public class GSHHS {
         } else {
           // yes, it is in cache.
           tSuccess = "*(already in cache)";
-          nSuccesses++;
+          requestStatus.increment(Metrics.BoundaryRequest.success);
         }
       } finally {
         lock.unlock();
@@ -202,13 +203,13 @@ public class GSHHS {
               + (desiredLevel == 1 ? "land" : desiredLevel == 2 ? "lake" : "" + desiredLevel)
               + " done,"
               + " nCoarse="
-              + nCoarse
+              + requestStatus.get(Metrics.BoundaryRequest.coarse)
               + tCoarse
               + " nSuccesses="
-              + nSuccesses
+              + requestStatus.get(Metrics.BoundaryRequest.success)
               + tSuccess
               + " nTossed="
-              + nTossed
+              + requestStatus.get(Metrics.BoundaryRequest.tossed)
               + tTossed
               + " totalTime="
               + (System.currentTimeMillis() - time));
@@ -222,11 +223,11 @@ public class GSHHS {
         + " of "
         + CACHE_SIZE
         + ", nCoarse="
-        + nCoarse
+        + requestStatus.get(Metrics.BoundaryRequest.coarse)
         + ", nSuccesses="
-        + nSuccesses
+        + requestStatus.get(Metrics.BoundaryRequest.success)
         + ", nTossed="
-        + nTossed;
+        + requestStatus.get(Metrics.BoundaryRequest.tossed);
   }
 
   /** This is like getGeneralPath, but with no caching. */

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/SgtGraph.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/SgtGraph.java
@@ -59,8 +59,6 @@ public class SgtGraph {
 
   public static Color DefaultBackgroundColor = new Color(0xCCCCFF); // just the RGB part (no A)
   public final int widenOnePoint = 1; // pixels
-  public static String fullTestCacheDir =
-      "/erddapBPD/cache/_test/"; // EDStatic resets this if needed
 
   /**
    * Constructor. This throws exception if trouble

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
@@ -561,17 +561,17 @@ public class HtmlWidgets {
         // "copy text/image to clipboard" buttons
         "\ndata:image/png;base64\n"
         + "<button type=\"button\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('"
-        + EDStatic.copyToClipboardNotAvailableAr[language]
+        + EDStatic.messages.copyToClipboardNotAvailableAr[language]
         + "');return false};navigator.clipboard.writeText("
         + "document.getElementById('"
         + img2ID
         + "').getAttribute('data-src')"
         + // reuse img2Url data from img2ID.data-src
         ");\" style=\"cursor: pointer; cursor: hand;\" >"
-        + EDStatic.copyTextToClipboardAr[language]
+        + EDStatic.messages.copyTextToClipboardAr[language]
         + "</button>\n"
         + "<button type=\"button\" onclick=\"javascript:if(navigator.clipboard==undefined){alert('"
-        + EDStatic.copyToClipboardNotAvailableAr[language]
+        + EDStatic.messages.copyToClipboardNotAvailableAr[language]
         + "');return false};"
         + " var img = new Image();"
         + " img.onload = () => {"
@@ -587,7 +587,7 @@ public class HtmlWidgets {
         + // reuse img2Url data from img2ID.data-src
         " return false;\""
         + " style=\"cursor: pointer; cursor: hand;\" >"
-        + EDStatic.copyImageToClipboardAr[language]
+        + EDStatic.messages.copyImageToClipboardAr[language]
         + "</button>";
   }
 
@@ -1593,7 +1593,7 @@ public class HtmlWidgets {
    * htmlTooltipScript (see above) must be already in the document. See tip().
    *
    * @param imageRef the reference for the question mark image (e.g.,
-   *     EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile)
+   *     EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile)
    * @param alt the alt text to be displayed, e.g., "?" (not yet encoded)
    * @param html the html tooltip text, e.g., "Hi,<br>
    *     there!". It needs explicit br tags to set window width correctly. For plain text, use

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/ArchiveADataset.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/ArchiveADataset.java
@@ -79,7 +79,7 @@ public class ArchiveADataset {
     GregorianCalendar gcZ = Calendar2.newGCalendarZulu();
     String isoTime = Calendar2.formatAsISODateTimeTZ(gcZ);
     String compactTime = Calendar2.formatAsCompactDateTime(gcZ) + "Z";
-    String aadDir = EDStatic.bigParentDirectory + "ArchiveADataset/";
+    String aadDir = EDStatic.config.bigParentDirectory + "ArchiveADataset/";
     File2.makeDirectory(aadDir);
     String logFileName = aadDir + "log_" + compactTime + ".txt";
     String2.setupLog(
@@ -212,7 +212,7 @@ public class ArchiveADataset {
           get(
               args,
               whichArg++,
-              EDStatic.adminEmail, // default
+              EDStatic.config.adminEmail, // default
               "What is a contact email address for this archive\n"
                   + "(it will be written in the READ_ME.txt file in the archive)");
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/DasDds.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/DasDds.java
@@ -27,8 +27,8 @@ public class DasDds {
   Writer outFile = null;
 
   public DasDds() {
-    logFileName = EDStatic.fullLogsDirectory + "DasDds.log";
-    outFileName = EDStatic.fullLogsDirectory + "DasDds.out";
+    logFileName = EDStatic.config.fullLogsDirectory + "DasDds.log";
+    outFileName = EDStatic.config.fullLogsDirectory + "DasDds.out";
   }
 
   private void printToBoth(String s) throws IOException {
@@ -100,8 +100,8 @@ public class DasDds {
     try {
 
       // delete the old log files (pre 1.48 names)
-      File2.delete(EDStatic.fullLogsDirectory + "DasDdsLog.txt");
-      File2.delete(EDStatic.fullLogsDirectory + "DasDdsLog.txt.previous");
+      File2.delete(EDStatic.config.fullLogsDirectory + "DasDdsLog.txt");
+      File2.delete(EDStatic.config.fullLogsDirectory + "DasDdsLog.txt.previous");
 
       String datasetID = "";
       if (args == null) args = new String[0];

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -566,7 +566,7 @@ public class Erddap extends HttpServlet {
                 requestNumber,
                 response,
                 429, // 429=Too Many Requests
-                EDStatic.oneRequestAtATimeAr[language]);
+                EDStatic.messages.oneRequestAtATimeAr[language]);
             // FUTURE? email yesterday's list to erddap admin when generating daily report
             // so they can consider blacklisting them?
             return;
@@ -615,9 +615,9 @@ public class Erddap extends HttpServlet {
                 200); // millis. Not Math2.sleep() because we want to allow InterruptedException
             if (System.currentTimeMillis() - start > 120000) // 120s * 1000 millis/s
             throw new TimeoutException(
-                  EDStatic.timeoutOtherRequestsAr[language]
+                  EDStatic.messages.timeoutOtherRequestsAr[language]
                       + " "
-                      + EDStatic.oneRequestAtATimeAr[language]);
+                      + EDStatic.messages.oneRequestAtATimeAr[language]);
           }
         }
       }
@@ -837,9 +837,11 @@ public class Erddap extends HttpServlet {
               response,
               EDStatic.bilingual(
                   language,
-                  MessageFormat.format(EDStatic.disabledAr[0], EDStatic.dataProviderFormAr[0]),
                   MessageFormat.format(
-                      EDStatic.disabledAr[language], EDStatic.dataProviderFormAr[language])));
+                      EDStatic.messages.disabledAr[0], EDStatic.messages.dataProviderFormAr[0]),
+                  MessageFormat.format(
+                      EDStatic.messages.disabledAr[language],
+                      EDStatic.messages.dataProviderFormAr[language])));
         else if (endOfRequest.equals("dataProviderForm.html"))
           doDataProviderForm(language, request, response, loggedInAs, endOfRequest, queryString);
         else if (endOfRequest.equals("dataProviderForm1.html"))
@@ -1147,7 +1149,7 @@ public class Erddap extends HttpServlet {
               + "<td style=\"width:60%;\" class=\"T\">\n");
 
       // *** left column: theShortDescription
-      writer.write(EDStatic.theShortDescriptionHtml(language, tErddapUrl));
+      writer.write(EDStatic.messages.theShortDescriptionHtml(language, tErddapUrl));
 
       // thin vertical line between text columns
       writer.write(
@@ -1159,7 +1161,7 @@ public class Erddap extends HttpServlet {
               "<td style=\"width:38%;\" class=\"T\">\n");
 
       // *** the right column: Get Started with ERDDAP
-      writer.write("<h2>" + EDStatic.getStartedHtmlAr[language] + "</h2>\n" + "<ul>");
+      writer.write("<h2>" + EDStatic.messages.getStartedHtmlAr[language] + "</h2>\n" + "<ul>");
 
       // display a search form
       writer.write("\n<li>");
@@ -1174,7 +1176,7 @@ public class Erddap extends HttpServlet {
               + EDStatic.encodedDefaultPIppQuery
               + "\">"
               + MessageFormat.format(
-                  EDStatic.indexViewAllAr[language],
+                  EDStatic.messages.indexViewAllAr[language],
                   // below is one of few places where number isn't converted to string
                   // (so 1000's separator is used to format the number):
                   gridDatasetHashMap.size() + tableDatasetHashMap.size())
@@ -1189,7 +1191,7 @@ public class Erddap extends HttpServlet {
       writer.write(
           "\n<li><h3>"
               + MessageFormat.format(
-                  EDStatic.indexSearchWithAr[language],
+                  EDStatic.messages.indexSearchWithAr[language],
                   getAdvancedSearchLink(language, loggedInAs, EDStatic.defaultPIppQuery))
               + "</h3>\n");
 
@@ -1197,19 +1199,19 @@ public class Erddap extends HttpServlet {
       writer.write(
           "\n<li>"
               + "<h3>"
-              + EDStatic.protocolSearchHtmlAr[language]
+              + EDStatic.messages.protocolSearchHtmlAr[language]
               + "</h3>\n"
-              + EDStatic.protocolSearch2HtmlAr[language]
+              + EDStatic.messages.protocolSearch2HtmlAr[language]
               +
               // "<br>Click on a protocol to see a list of datasets which are available via that
               // protocol in ERDDAP." +
               "<br>&nbsp;\n"
               + "<table class=\"erd commonBGColor\">\n"
               + "  <tr><th>"
-              + EDStatic.indexProtocolAr[language]
+              + EDStatic.messages.indexProtocolAr[language]
               + "</th>"
               + "<th>"
-              + EDStatic.indexDescriptionAr[language]
+              + EDStatic.messages.indexDescriptionAr[language]
               + "</th></tr>\n"
               + "  <tr>\n"
               + "    <td><a rel=\"bookmark\" "
@@ -1219,20 +1221,20 @@ public class Erddap extends HttpServlet {
               + EDStatic.encodedDefaultPIppQuery
               + "\""
               + " title=\""
-              + MessageFormat.format(EDStatic.protocolClickAr[language], "griddap")
+              + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "griddap")
               + "\">"
-              + MessageFormat.format(EDStatic.indexDatasetsAr[language], "griddap")
+              + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "griddap")
               + "</a> </td>\n"
               + "    <td>"
-              + EDStatic.EDDGridDapDescriptionAr[language]
+              + EDStatic.messages.EDDGridDapDescriptionAr[language]
               + "\n"
               + "      <a rel=\"help\" href=\""
               +
-              // EDStatic.EDDGridErddapUrlExample + //2021-09-22 no, always go local
+              // EDStatic.messages.EDDGridErddapUrlExample + //2021-09-22 no, always go local
               tErddapUrl
               + "/"
               + "griddap/documentation.html\">"
-              + MessageFormat.format(EDStatic.indexDocumentationAr[language], "griddap")
+              + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "griddap")
               + "</a>\n"
               + "    </td>\n"
               + "  </tr>\n"
@@ -1244,20 +1246,20 @@ public class Erddap extends HttpServlet {
               + EDStatic.encodedDefaultPIppQuery
               + "\""
               + " title=\""
-              + MessageFormat.format(EDStatic.protocolClickAr[language], "tabledap")
+              + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "tabledap")
               + "\">"
-              + MessageFormat.format(EDStatic.indexDatasetsAr[language], "tabledap")
+              + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "tabledap")
               + "</a></td>\n"
               + "    <td>"
-              + EDStatic.EDDTableDapDescriptionAr[language]
+              + EDStatic.messages.EDDTableDapDescriptionAr[language]
               + "\n"
               + "      <a rel=\"help\" href=\""
               +
-              // EDStatic.EDDTableErddapUrlExample + //2021-09-22 no, always go local
+              // EDStatic.messages.EDDTableErddapUrlExample + //2021-09-22 no, always go local
               tErddapUrl
               + "/"
               + "tabledap/documentation.html\">"
-              + MessageFormat.format(EDStatic.indexDocumentationAr[language], "tabledap")
+              + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "tabledap")
               + "</a>\n"
               + "    </td>\n"
               + "  </tr>\n"
@@ -1267,21 +1269,21 @@ public class Erddap extends HttpServlet {
               + tErddapUrl
               + "/files/\""
               + " title=\""
-              + MessageFormat.format(EDStatic.protocolClickAr[language], "files")
+              + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "files")
               + "\">"
-              + MessageFormat.format(EDStatic.indexDatasetsAr[language], "\"files\"")
+              + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "\"files\"")
               + "</a></td>\n"
               + "    <td>"
-              + EDStatic.filesDescriptionAr[language]
+              + EDStatic.messages.filesDescriptionAr[language]
               + " "
-              + EDStatic.warningAr[language]
+              + EDStatic.messages.warningAr[language]
               + " "
-              + EDStatic.filesWarningAr[language]
+              + EDStatic.messages.filesWarningAr[language]
               + "\n"
               + "      <a rel=\"help\" href=\""
               + tErddapUrl
               + "/files/documentation.html\">"
-              + MessageFormat.format(EDStatic.indexDocumentationAr[language], "\"files\"")
+              + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "\"files\"")
               + "</a>\n"
               + "    </td>\n"
               + "  </tr>\n");
@@ -1295,17 +1297,17 @@ public class Erddap extends HttpServlet {
                 + EDStatic.encodedDefaultPIppQuery
                 + "\""
                 + " title=\""
-                + MessageFormat.format(EDStatic.protocolClickAr[language], "SOS")
+                + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "SOS")
                 + "\">"
-                + MessageFormat.format(EDStatic.indexDatasetsAr[language], "SOS")
+                + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "SOS")
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.sosDescriptionHtmlAr[language]
+                + EDStatic.messages.sosDescriptionHtmlAr[language]
                 + "\n"
                 + "      <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/sos/documentation.html\">"
-                + MessageFormat.format(EDStatic.indexDocumentationAr[language], "SOS")
+                + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "SOS")
                 + "</a>\n"
                 + "    </td>\n"
                 + "  </tr>\n");
@@ -1319,17 +1321,17 @@ public class Erddap extends HttpServlet {
                 + EDStatic.encodedDefaultPIppQuery
                 + "\""
                 + " title=\""
-                + MessageFormat.format(EDStatic.protocolClickAr[language], "WCS")
+                + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "WCS")
                 + "\">"
-                + MessageFormat.format(EDStatic.indexDatasetsAr[language], "WCS")
+                + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "WCS")
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.wcsDescriptionHtmlAr[language]
+                + EDStatic.messages.wcsDescriptionHtmlAr[language]
                 + "\n"
                 + "      <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/wcs/documentation.html\">"
-                + MessageFormat.format(EDStatic.indexDocumentationAr[language], "WCS")
+                + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "WCS")
                 + "</a>\n"
                 + "    </td>\n"
                 + "  </tr>\n");
@@ -1343,17 +1345,17 @@ public class Erddap extends HttpServlet {
                 + EDStatic.encodedDefaultPIppQuery
                 + "\""
                 + " title=\""
-                + MessageFormat.format(EDStatic.protocolClickAr[language], "WMS")
+                + MessageFormat.format(EDStatic.messages.protocolClickAr[language], "WMS")
                 + "\">"
-                + MessageFormat.format(EDStatic.indexDatasetsAr[language], "WMS")
+                + MessageFormat.format(EDStatic.messages.indexDatasetsAr[language], "WMS")
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.wmsDescriptionHtmlAr[language]
+                + EDStatic.messages.wmsDescriptionHtmlAr[language]
                 + "\n"
                 + "      <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/wms/documentation.html\">"
-                + MessageFormat.format(EDStatic.indexDocumentationAr[language], "WMS")
+                + MessageFormat.format(EDStatic.messages.indexDocumentationAr[language], "WMS")
                 + "</a>\n"
                 + "    </td>\n"
                 + "  </tr>\n");
@@ -1366,23 +1368,23 @@ public class Erddap extends HttpServlet {
       // connections to OpenSearch and SRU
       writer.write(
           "<li><h3>"
-              + EDStatic.indexDevelopersSearchAr[language]
+              + EDStatic.messages.indexDevelopersSearchAr[language]
               + "</h3>\n"
               + "  <ul>\n"
               + "  <li><a rel=\"help\" href=\""
               + tErddapUrl
               + "/rest.html\">"
-              + EDStatic.indexRESTfulSearchAr[language]
+              + EDStatic.messages.indexRESTfulSearchAr[language]
               + "</a>\n"
               + "  <li><a rel=\"help\" href=\""
               + tErddapUrl
               + "/tabledap/allDatasets.html\">"
-              + EDStatic.indexAllDatasetsSearchAr[language]
+              + EDStatic.messages.indexAllDatasetsSearchAr[language]
               + "</a>\n"
               + "  <li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/opensearch1.1/index.html\">"
-              + EDStatic.indexOpenSearchAr[language]
+              + EDStatic.messages.indexOpenSearchAr[language]
               + "</a>\n"
               + "  </ul>\n"
               + "\n");
@@ -1390,10 +1392,12 @@ public class Erddap extends HttpServlet {
       // Search Multiple ERDDAPs
       writer.write(
           "<li><h3>"
-              + EDStatic.searchMultipleERDDAPsAr[language]
+              + EDStatic.messages.searchMultipleERDDAPsAr[language]
               + "</h3>\n"
               + String2.replaceAll(
-                  EDStatic.searchMultipleERDDAPsDescriptionAr[language], "&erddapUrl;", tErddapUrl)
+                  EDStatic.messages.searchMultipleERDDAPsDescriptionAr[language],
+                  "&erddapUrl;",
+                  tErddapUrl)
               + "\n");
 
       // end of search/protocol options list
@@ -1407,73 +1411,73 @@ public class Erddap extends HttpServlet {
       if (EDStatic.convertersActive)
         writer.write(
             "<p><strong><a class=\"selfLink\" id=\"converters\" href=\"#converters\" rel=\"bookmark\">"
-                + EDStatic.indexConvertersAr[language]
+                + EDStatic.messages.indexConvertersAr[language]
                 + "</a></strong>\n"
                 + "<br>"
-                + EDStatic.indexDescribeConvertersAr[language]
+                + EDStatic.messages.indexDescribeConvertersAr[language]
                 + "\n"
                 + "<table class=\"erd commonBGColor\">\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/oceanicAtmosphericAcronyms.html\">"
-                + EDStatic.acronymsAr[language]
+                + EDStatic.messages.acronymsAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertOAAcronymsToFromAr[language]
+                + EDStatic.messages.convertOAAcronymsToFromAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/fipscounty.html\">"
-                + EDStatic.FIPSCountyCodesAr[language]
+                + EDStatic.messages.FIPSCountyCodesAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertFipsCountyAr[language]
+                + EDStatic.messages.convertFipsCountyAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/interpolate.html\">"
-                + EDStatic.interpolateAr[language]
+                + EDStatic.messages.interpolateAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertInterpolateAr[language]
+                + EDStatic.messages.convertInterpolateAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/keywords.html\">"
-                + EDStatic.keywordsAr[language]
+                + EDStatic.messages.keywordsAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertKeywordsAr[language]
+                + EDStatic.messages.convertKeywordsAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/time.html\">"
-                + EDStatic.timeAr[language]
+                + EDStatic.messages.timeAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertTimeAr[language]
+                + EDStatic.messages.convertTimeAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/units.html\">"
-                + EDStatic.unitsAr[language]
+                + EDStatic.messages.unitsAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertUnitsAr[language]
+                + EDStatic.messages.convertUnitsAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/urls.html\">URLs</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertURLsAr[language]
+                + EDStatic.messages.convertURLsAr[language]
                 + "</td></tr>\n"
                 + "<tr><td><a rel=\"bookmark\" href=\""
                 + tErddapUrl
                 + "/convert/oceanicAtmosphericVariableNames.html\">"
-                + EDStatic.variableNamesAr[language]
+                + EDStatic.messages.variableNamesAr[language]
                 + "</a></td>\n"
                 + "    <td>"
-                + EDStatic.convertOAVariableNamesToFromAr[language]
+                + EDStatic.messages.convertOAVariableNamesToFromAr[language]
                 + "</td></tr>\n"
                 + "</table>\n"
                 + "\n");
@@ -1482,7 +1486,7 @@ public class Erddap extends HttpServlet {
       if (EDStatic.fgdcActive || EDStatic.iso19115Active) {
         writer.write(
             "<p><strong><a class=\"selfLink\" id=\"metadata\" href=\"#metadata\" rel=\"bookmark\">"
-                + EDStatic.indexMetadataAr[language]
+                + EDStatic.messages.indexMetadataAr[language]
                 + "</a></strong>\n"
                 + "<br>");
         String fgdcLink1 =
@@ -1495,7 +1499,7 @@ public class Erddap extends HttpServlet {
         String fgdcLink2 = // &#8209; is a non-breaking hyphen
             "<a rel=\"help\" href=\"https://www.fgdc.gov/standards/projects/FGDC-standards-projects/metadata/base-metadata/index_html\"\n"
                 + ">FGDC&#8209;STD&#8209;001&#8209;1998"
-                + EDStatic.externalLinkHtml(language, tErddapUrl)
+                + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                 + "</a>";
         String isoLink1 =
             "<br><a rel=\"bookmark\" "
@@ -1507,79 +1511,88 @@ public class Erddap extends HttpServlet {
         String isoLink2 = // &#8209; is a non-breaking hyphen
             "<a rel=\"help\" href=\"https://en.wikipedia.org/wiki/Geospatial_metadata\"\n"
                 + ">ISO&nbsp;19115&#8209;2/19139"
-                + EDStatic.externalLinkHtml(language, tErddapUrl)
+                + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                 + "</a>";
         if (EDStatic.fgdcActive && EDStatic.iso19115Active)
           writer.write(
               MessageFormat.format(
-                  EDStatic.indexWAF2Ar[language], fgdcLink1, fgdcLink2, isoLink1, isoLink2));
+                  EDStatic.messages.indexWAF2Ar[language],
+                  fgdcLink1,
+                  fgdcLink2,
+                  isoLink1,
+                  isoLink2));
         else if (EDStatic.fgdcActive)
-          writer.write(MessageFormat.format(EDStatic.indexWAF1Ar[language], fgdcLink1, fgdcLink2));
-        else writer.write(MessageFormat.format(EDStatic.indexWAF1Ar[language], isoLink1, isoLink2));
+          writer.write(
+              MessageFormat.format(EDStatic.messages.indexWAF1Ar[language], fgdcLink1, fgdcLink2));
+        else
+          writer.write(
+              MessageFormat.format(EDStatic.messages.indexWAF1Ar[language], isoLink1, isoLink2));
         writer.write("\n\n");
       }
 
       // REST services
       writer.write(
           "<p><strong><a class=\"selfLink\" id=\"services\" href=\"#services\" rel=\"bookmark\">"
-              + EDStatic.indexServicesAr[language]
+              + EDStatic.messages.indexServicesAr[language]
               + "</a></strong>\n"
               + "<br>"
-              + MessageFormat.format(EDStatic.indexDescribeServicesAr[language], tErddapUrl)
+              + MessageFormat.format(
+                  EDStatic.messages.indexDescribeServicesAr[language], tErddapUrl)
               + "\n\n");
 
       // And
       writer.write(
           "<p><strong><a class=\"selfLink\" id=\"otherFeatures\" href=\"#otherFeatures\" rel=\"bookmark\">"
-              + EDStatic.otherFeaturesAr[language]
+              + EDStatic.messages.otherFeaturesAr[language]
               + "</a></strong>\n"
               + "<table class=\"erd commonBGColor\">\n"
               + "<tr><td><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/status.html\">"
-              + EDStatic.statusAr[language]
+              + EDStatic.messages.statusAr[language]
               + "</a></td>\n"
               + "    <td>"
-              + EDStatic.statusHtmlAr[language]
+              + EDStatic.messages.statusHtmlAr[language]
               + "</td></tr>\n"
               + (EDStatic.outOfDateDatasetsActive
                   ? "<tr><td><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/outOfDateDatasets.html\">"
-                      + EDStatic.outOfDateDatasetsAr[language]
+                      + EDStatic.messages.outOfDateDatasetsAr[language]
                       + "</a></td>\n"
                       + "    <td>"
-                      + EDStatic.outOfDateHtmlAr[language]
+                      + EDStatic.messages.outOfDateHtmlAr[language]
                       + "</td></tr>\n"
                   : "")
               + (EDStatic.subscriptionSystemActive
                   ? "<tr><td><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/subscriptions/index.html\">"
-                      + EDStatic.subscriptionsTitleAr[language]
+                      + EDStatic.messages.subscriptionsTitleAr[language]
                       + "</a></td>\n"
                       + "    <td>"
-                      + String2.replaceAll(EDStatic.subscription0HtmlAr[language], "<br>", " ")
+                      + String2.replaceAll(
+                          EDStatic.messages.subscription0HtmlAr[language], "<br>", " ")
                       + "</td></tr>\n"
                   : "")
               + (EDStatic.slideSorterActive
                   ? "<tr><td><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/slidesorter.html\">"
-                      + EDStatic.slideSorterAr[language]
+                      + EDStatic.messages.slideSorterAr[language]
                       + "</a></td>\n"
                       + "    <td>"
-                      + EDStatic.ssUsePlainAr[language]
+                      + EDStatic.messages.ssUsePlainAr[language]
                       + "</td></tr>\n"
                   : "")
               + (EDStatic.dataProviderFormActive
                   ? "<tr><td><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/dataProviderForm.html\">"
-                      + EDStatic.dataProviderFormAr[language]
+                      + EDStatic.messages.dataProviderFormAr[language]
                       + "</a></td>\n"
                       + "    <td>"
-                      + EDStatic.dataProviderFormShortDescriptionAr[language]
+                      + EDStatic.messages.dataProviderFormShortDescriptionAr[language]
                       + "</td></tr>\n"
                   : "")
               + "</table>\n\n");
@@ -1628,7 +1641,7 @@ public class Erddap extends HttpServlet {
             "Embed Images",
             out);
     try {
-      writer.write(EDStatic.imagesEmbedAr[language]);
+      writer.write(EDStatic.messages.imagesEmbedAr[language]);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
@@ -1640,7 +1653,7 @@ public class Erddap extends HttpServlet {
 
   /**
    * This responds by sending out the "Information" Html page (information.html,
-   * EDStatic.theLongDescriptionHtml).
+   * EDStatic.messages.theLongDescriptionHtml).
    *
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in)
@@ -1666,9 +1679,10 @@ public class Erddap extends HttpServlet {
             out);
     try {
       writer.write("<div class=\"standard_width\">\n");
-      writer.write(EDStatic.youAreHere(language, loggedInAs, EDStatic.informationAr[language]));
+      writer.write(
+          EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.informationAr[language]));
       // writer.write(EDStatic.youAreHere(language, loggedInAs, "Information"));
-      writer.write(EDStatic.theLongDescriptionHtml(language, tErddapUrl));
+      writer.write(EDStatic.messages.theLongDescriptionHtml(language, tErddapUrl));
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
@@ -1707,10 +1721,11 @@ public class Erddap extends HttpServlet {
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.legalNoticesTitleAr[language])
-              + EDStatic.legalNoticesAr[language]
+              + EDStatic.youAreHere(
+                  language, loggedInAs, EDStatic.messages.legalNoticesTitleAr[language])
+              + EDStatic.messages.legalNoticesAr[language]
               + "\n"
-              + EDStatic.standardGeneralDisclaimerAr[language]
+              + EDStatic.messages.standardGeneralDisclaimerAr[language]
               + "\n\n"
               + EDStatic.legal(language, tErddapUrl));
       writer.write("</div>\n");
@@ -1869,7 +1884,7 @@ public class Erddap extends HttpServlet {
       Math2.sleep(500); // give session changes time to take effect
       loginSucceeded(email);
       // sendRedirect(response, loginUrl + "?message=" +
-      //    SSR.minimalPercentEncode(EDStatic.loginSucceededAr[language]));
+      //    SSR.minimalPercentEncode(EDStatic.messages.loginSucceededAr[language]));
       return;
 
     } catch (Throwable t) {
@@ -1877,7 +1892,7 @@ public class Erddap extends HttpServlet {
       String2.log("Caught: " + MustBe.throwableToString(t));
       loginFailed(email == null ? "(unknown)" : email);
       // sendRedirect(response, loginUrl + "?message=" +
-      //    SSR.minimalPercentEncode(EDStatic.loginFailedAr[language] + ": " +
+      //    SSR.minimalPercentEncode(EDStatic.messages.loginFailedAr[language] + ": " +
       //        MustBe.getShortErrorMessage(t)));
       return;
     }
@@ -1986,7 +2001,9 @@ public class Erddap extends HttpServlet {
       loginSucceeded(orcid);
       sendRedirect(
           response,
-          loginUrl + "?message=" + SSR.minimalPercentEncode(EDStatic.loginSucceededAr[language]));
+          loginUrl
+              + "?message="
+              + SSR.minimalPercentEncode(EDStatic.messages.loginSucceededAr[language]));
       return;
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
@@ -2001,7 +2018,9 @@ public class Erddap extends HttpServlet {
           loginUrl
               + "?message="
               + SSR.minimalPercentEncode(
-                  EDStatic.loginFailedAr[language] + ": " + MustBe.getShortErrorMessage(t)));
+                  EDStatic.messages.loginFailedAr[language]
+                      + ": "
+                      + MustBe.getShortErrorMessage(t)));
       return;
     }
   }
@@ -2066,7 +2085,7 @@ public class Erddap extends HttpServlet {
                   + "?message="
                   + SSR.minimalPercentEncode(
                       MessageFormat.format(
-                          EDStatic.loginAttemptBlockedAr[language],
+                          EDStatic.messages.loginAttemptBlockedAr[language],
                           user,
                           "" + minutesUntilLoginAttempt)));
           return;
@@ -2084,7 +2103,7 @@ public class Erddap extends HttpServlet {
                 response,
                 loginUrl
                     + "?message="
-                    + SSR.minimalPercentEncode(EDStatic.loginSucceededAr[language]));
+                    + SSR.minimalPercentEncode(EDStatic.messages.loginSucceededAr[language]));
             return;
           } else {
             // invalid login;  if currently logged in, logout
@@ -2100,9 +2119,9 @@ public class Erddap extends HttpServlet {
                 loginUrl
                     + "?message="
                     + SSR.minimalPercentEncode(
-                        EDStatic.loginFailedAr[language]
+                        EDStatic.messages.loginFailedAr[language]
                             + ": "
-                            + EDStatic.loginInvalidAr[language]));
+                            + EDStatic.messages.loginInvalidAr[language]));
             return;
           }
         } catch (Throwable t) {
@@ -2112,7 +2131,9 @@ public class Erddap extends HttpServlet {
               loginUrl
                   + "?message="
                   + SSR.minimalPercentEncode(
-                      EDStatic.loginFailedAr[language] + ": " + MustBe.getShortErrorMessage(t)));
+                      EDStatic.messages.loginFailedAr[language]
+                          + ": "
+                          + MustBe.getShortErrorMessage(t)));
           return;
         }
       }
@@ -2125,58 +2146,61 @@ public class Erddap extends HttpServlet {
               loggedInAs,
               "login.html", // was endOfRequest,
               queryString,
-              EDStatic.LogInAr[language],
+              EDStatic.messages.loginAr[language],
               out);
       try {
         writer.write("<div class=\"standard_width\">\n");
-        writer.write(EDStatic.youAreHere(language, loggedInAs, EDStatic.LogInAr[language]));
+        writer.write(
+            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
 
-        writer.write(EDStatic.loginDescribeCustomAr[language]);
+        writer.write(EDStatic.messages.loginDescribeCustomAr[language]);
 
         if (loggedInAs.equals(EDStatic.loggedInAsHttps)) {
 
           String tProblems =
               String2.replaceAll(
-                  EDStatic.loginProblemsAr[language],
+                  EDStatic.messages.loginProblemsAr[language],
                   "&initialHelp;",
-                  EDStatic.loginProblemExactAr[language] + EDStatic.loginProblem3TimesAr[language]);
+                  EDStatic.messages.loginProblemExactAr[language]
+                      + EDStatic.messages.loginProblem3TimesAr[language]);
           tProblems =
               String2.replaceAll(
                   tProblems,
                   "&info;",
-                  EDStatic.loginUserNameAndPasswordAr[language]); // it's in loginProblemExact
+                  EDStatic.messages
+                      .loginUserNameAndPasswordAr[language]); // it's in loginProblemExact
           tProblems = String2.replaceAll(tProblems, "&erddapUrl;", tErddapUrl); // it's in cookies
 
           // show the login form
           writer.write(
               "<p><strong>"
-                  + EDStatic.loginNotAr[language]
+                  + EDStatic.messages.loginNotAr[language]
                   + "</strong>\n"
-                  + EDStatic.loginPublicAccessAr[language]
+                  + EDStatic.messages.loginPublicAccessAr[language]
                   +
                   // use POST, not GET, so that form params (password!) aren't in url (and so
                   // browser history, etc.)
                   "<form action=\"login.html\" method=\"post\" id=\"login_form\">\n"
                   + "<p><strong>"
-                  + EDStatic.loginToLogInAr[language]
+                  + EDStatic.messages.loginToLogInAr[language]
                   + ":</strong>\n"
                   + "<table class=\"compact\">\n"
                   + "  <tr>\n"
                   + "    <td>"
-                  + EDStatic.loginUserNameAr[language]
+                  + EDStatic.messages.loginUserNameAr[language]
                   + ":&nbsp;</td>\n"
                   + "    <td><input type=\"text\" size=\"30\" value=\"\" name=\"user\" id=\"user\"/></td>\n"
                   + "  </tr>\n"
                   + "  <tr>\n"
                   + "    <td>"
-                  + EDStatic.loginPasswordAr[language]
+                  + EDStatic.messages.loginPasswordAr[language]
                   + ":&nbsp;</td>\n"
                   + "    <td><input type=\"password\" size=\"20\" value=\"\" name=\"password\" id=\"password\" autocomplete=\"off\"/>\n"
                   + "      <input type=\"submit\" value=\""
-                  + EDStatic.LogInAr[language]
+                  + EDStatic.messages.loginAr[language]
                   + "\"/></td>\n"
                   + "  </tr>\n"
                   + "</table>\n"
@@ -2189,18 +2213,18 @@ public class Erddap extends HttpServlet {
           writer.write(
               "<p><span class=\"successColor\">"
                   + MessageFormat.format(
-                      EDStatic.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
+                      EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
                   + EDStatic.erddapUrl(loggedInAs, language)
                   + "/logout.html\">"
-                  + EDStatic.logoutAr[language]
+                  + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
                   + "<p>"
-                  + EDStatic.loginBackAr[language]
+                  + EDStatic.messages.loginBackAr[language]
                   + "\n"
                   + String2.replaceAll(
-                      EDStatic.loginProblemsAfterAr[language], "&secondPart;", ""));
+                      EDStatic.messages.loginProblemsAfterAr[language], "&secondPart;", ""));
         }
         writer.write("</div>\n");
         endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -2274,7 +2298,7 @@ public class Erddap extends HttpServlet {
                   + "?message="
                   + SSR.minimalPercentEncode(
                       MessageFormat.format(
-                          EDStatic.loginAttemptBlockedAr[language],
+                          EDStatic.messages.loginAttemptBlockedAr[language],
                           email,
                           "" + minutesUntilLoginAttempt)));
           return;
@@ -2364,7 +2388,9 @@ public class Erddap extends HttpServlet {
           loginFailed(email);
           sendRedirect(
               response,
-              loginUrl + "?message=" + SSR.minimalPercentEncode(EDStatic.loginFailedAr[language]));
+              loginUrl
+                  + "?message="
+                  + SSR.minimalPercentEncode(EDStatic.messages.loginFailedAr[language]));
           return;
 
         } else {
@@ -2377,7 +2403,7 @@ public class Erddap extends HttpServlet {
               response,
               loginUrl
                   + "?message="
-                  + SSR.minimalPercentEncode(EDStatic.loginSucceededAr[language]));
+                  + SSR.minimalPercentEncode(EDStatic.messages.loginSucceededAr[language]));
           return;
         }
       }
@@ -2390,27 +2416,28 @@ public class Erddap extends HttpServlet {
               loggedInAs,
               "login.html", // was endOfRequest,
               queryString,
-              EDStatic.LogInAr[language],
+              EDStatic.messages.loginAr[language],
               out);
       try {
         writer.write("<div class=\"standard_width\">\n");
-        writer.write(EDStatic.youAreHere(language, loggedInAs, EDStatic.LogInAr[language]));
+        writer.write(
+            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
 
-        writer.write(EDStatic.loginDescribeEmailAr[language]);
+        writer.write(EDStatic.messages.loginDescribeEmailAr[language]);
 
         if (loggedInAs.equals(EDStatic.loggedInAsHttps)) {
 
           // show the login form
           String tProblems =
               String2.replaceAll(
-                  EDStatic.loginProblemsAr[language],
+                  EDStatic.messages.loginProblemsAr[language],
                   "&initialHelp;",
-                  EDStatic.loginProblemSameBrowserAr[language]
-                      + EDStatic.loginProblemExpireAr[language]
-                      + EDStatic.loginProblem3TimesAr[language]);
+                  EDStatic.messages.loginProblemSameBrowserAr[language]
+                      + EDStatic.messages.loginProblemExpireAr[language]
+                      + EDStatic.messages.loginProblem3TimesAr[language]);
           tProblems =
               String2.replaceAll(
                   tProblems, "&offerValidMinutes;", "" + offerValidMinutes); // it's in expire
@@ -2418,25 +2445,25 @@ public class Erddap extends HttpServlet {
 
           writer.write(
               "<p><strong>"
-                  + EDStatic.loginNotAr[language]
+                  + EDStatic.messages.loginNotAr[language]
                   + "</strong>\n"
-                  + EDStatic.loginPublicAccessAr[language]
+                  + EDStatic.messages.loginPublicAccessAr[language]
                   +
                   // use POST, not GET, so that form params (password!) aren't in url (and so
                   // browser history, etc.)
                   "\n"
                   + "<p><strong>"
-                  + EDStatic.loginToLogInAr[language]
+                  + EDStatic.messages.loginToLogInAr[language]
                   + ":</strong>\n"
                   + "<form action=\"login.html\" method=\"post\" id=\"login_form\">"
                   + "<table class=\"compact\">\n"
                   + "  <tr>\n"
                   + "    <td>"
-                  + EDStatic.loginYourEmailAddressAr[language]
+                  + EDStatic.messages.loginYourEmailAddressAr[language]
                   + ":&nbsp;</td>\n"
                   + "    <td><input type=\"text\" size=\"60\" value=\"\" name=\"email\" id=\"email\"/>\n"
                   + "      <input type=\"submit\" value=\""
-                  + EDStatic.LogInAr[language]
+                  + EDStatic.messages.loginAr[language]
                   + "\"/></td>\n"
                   + "  </tr>\n"
                   + "</table></form>\n"
@@ -2448,18 +2475,18 @@ public class Erddap extends HttpServlet {
           writer.write(
               "<p><span class=\"successColor\">"
                   + MessageFormat.format(
-                      EDStatic.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
+                      EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
                   + EDStatic.erddapUrl(loggedInAs, language)
                   + "/logout.html\">"
-                  + EDStatic.logoutAr[language]
+                  + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
                   + "<p>"
-                  + EDStatic.loginBackAr[language]
+                  + EDStatic.messages.loginBackAr[language]
                   + "\n"
                   + String2.replaceAll(
-                      EDStatic.loginProblemsAfterAr[language], "&secondPart;", ""));
+                      EDStatic.messages.loginProblemsAfterAr[language], "&secondPart;", ""));
         }
         writer.write("</div>\n");
         endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -2492,7 +2519,7 @@ public class Erddap extends HttpServlet {
               loggedInAs,
               "login.html", // was endOfRequest,
               queryString,
-              EDStatic.LogInAr[language],
+              EDStatic.messages.loginAr[language],
               (isGoogle || isOauth2
                   ? "<script src=\"https://accounts.google.com/gsi/client\" async defer></script>\n"
                   : ""),
@@ -2500,30 +2527,31 @@ public class Erddap extends HttpServlet {
 
       try {
         writer.write("<div class=\"standard_width\">\n");
-        writer.write(EDStatic.youAreHere(language, loggedInAs, EDStatic.LogInAr[language]));
+        writer.write(
+            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
 
         writer.write(
             isGoogle
-                ? EDStatic.loginDescribeGoogleAr[language]
+                ? EDStatic.messages.loginDescribeGoogleAr[language]
                 : isOrcid
-                    ? EDStatic.loginDescribeOrcidAr[language]
-                    : EDStatic.loginDescribeOauth2Ar[language]);
+                    ? EDStatic.messages.loginDescribeOrcidAr[language]
+                    : EDStatic.messages.loginDescribeOauth2Ar[language]);
 
         if (loggedInAs.equals(EDStatic.loggedInAsHttps)) {
 
           // login page for google/orcid/oauth2
           String tProblems =
               String2.replaceAll(
-                  EDStatic.loginProblemsAr[language],
+                  EDStatic.messages.loginProblemsAr[language],
                   "&initialHelp;",
                   isGoogle
-                      ? EDStatic.loginProblemGoogleAgainAr[language]
+                      ? EDStatic.messages.loginProblemGoogleAgainAr[language]
                       : isOrcid
-                          ? EDStatic.loginProblemOrcidAgainAr[language]
-                          : EDStatic.loginProblemOauth2AgainAr[language]);
+                          ? EDStatic.messages.loginProblemOrcidAgainAr[language]
+                          : EDStatic.messages.loginProblemOauth2AgainAr[language]);
           tProblems = String2.replaceAll(tProblems, "&erddapUrl;", tErddapUrl); // it's in cookies
 
           // show the login button
@@ -2551,16 +2579,16 @@ public class Erddap extends HttpServlet {
                       : "")
                   + "\n"
                   + "<p><strong>"
-                  + EDStatic.loginNotAr[language]
+                  + EDStatic.messages.loginNotAr[language]
                   + "</strong>\n"
-                  + EDStatic.loginPublicAccessAr[language]
+                  + EDStatic.messages.loginPublicAccessAr[language]
                   + "<p>"
-                  + EDStatic.loginToLogInAr[language]
+                  + EDStatic.messages.loginToLogInAr[language]
                   + ":\n"
                   + "<ul>\n"
                   + (isGoogle || isOauth2
                       ? "<li>"
-                          + EDStatic.loginGoogleSignInAr[language]
+                          + EDStatic.messages.loginGoogleSignInAr[language]
                           + "\n"
                           + "  <div id=\"g_id_onload\" data-client_id=\""
                           + EDStatic.googleClientID
@@ -2576,7 +2604,7 @@ public class Erddap extends HttpServlet {
                       // Orcid web page then redirects user to redirect_uri (loginOrcid.html) with
                       // one-time-use 6-digit code
                       "<li>"
-                          + (isOauth2 ? EDStatic.orCommaAr[language] + " " : "")
+                          + (isOauth2 ? EDStatic.messages.orCommaAr[language] + " " : "")
                           + "<a rel=\"help\" href=\"https://orcid.org/oauth/authorize?"
                           + "client_id="
                           + EDStatic.orcidClientID
@@ -2588,7 +2616,7 @@ public class Erddap extends HttpServlet {
                               EDStatic.erddapHttpsUrl(language) + "/loginOrcid.html")
                           + "\" \n"
                           + "  ><img style=\"vertical-align:middle;\" src=\"images/orcid_24x24.png\" alt=\"ORCID iD icon\"/>&nbsp;"
-                          + EDStatic.loginOrcidSignInAr[language]
+                          + EDStatic.messages.loginOrcidSignInAr[language]
                           + "</a>\n"
                           + "  <br>&nbsp;\n"
                       : "")
@@ -2605,20 +2633,22 @@ public class Erddap extends HttpServlet {
           writer.write(
               "<p><span class=\"successColor\">"
                   + MessageFormat.format(
-                      EDStatic.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
+                      EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
                   + EDStatic.erddapUrl(loggedInAs, language)
                   + "/logout.html\">"
-                  + EDStatic.logoutAr[language]
+                  + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
                   + "<p>"
-                  + EDStatic.loginBackAr[language]
+                  + EDStatic.messages.loginBackAr[language]
                   + "\n"
                   + String2.replaceAll(
-                      EDStatic.loginProblemsAfterAr[language],
+                      EDStatic.messages.loginProblemsAfterAr[language],
                       "&secondPart;",
-                      isOrcid || isOauth2 ? EDStatic.loginProblemOrcidAgainAr[language] : ""));
+                      isOrcid || isOauth2
+                          ? EDStatic.messages.loginProblemOrcidAgainAr[language]
+                          : ""));
         }
         writer.write("</div>\n");
         endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -2634,7 +2664,7 @@ public class Erddap extends HttpServlet {
 
     // *** Other
     // alternative: lowSendError(requestNumber, response, HttpServletResponse.SC_UNAUTHORIZED,
-    //    EDStatic.loginCanNotAr[language]);
+    //    EDStatic.messages.loginCanNotAr[language]);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
@@ -2642,15 +2672,15 @@ public class Erddap extends HttpServlet {
             loggedInAs,
             "login.html", // was endOfRequest,
             queryString,
-            EDStatic.LogInAr[language],
+            EDStatic.messages.loginAr[language],
             out);
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.LogInAr[language])
+              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language])
               + standoutMessage
               + "<p><span class=\"highlightColor\">"
-              + EDStatic.loginCanNotAr[language]
+              + EDStatic.messages.loginCanNotAr[language]
               + "</span>\n");
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -2691,7 +2721,7 @@ public class Erddap extends HttpServlet {
 
     // user wasn't logged in?
     String encodedYouWerentLoggedIn =
-        "?message=" + SSR.minimalPercentEncode(EDStatic.loginAreNotAr[language]);
+        "?message=" + SSR.minimalPercentEncode(EDStatic.messages.loginAreNotAr[language]);
     if (loggedInAs == null || loggedInAs.equals(EDStatic.loggedInAsHttps)) {
       // user wasn't logged in
       sendRedirect(response, loginUrl + encodedYouWerentLoggedIn);
@@ -2711,7 +2741,7 @@ public class Erddap extends HttpServlet {
         EDStatic.tally.add("Log out (since last daily report)", "success");
       }
       String encodedSuccessMessage =
-          "?message=" + SSR.minimalPercentEncode(EDStatic.logoutSuccessAr[language]);
+          "?message=" + SSR.minimalPercentEncode(EDStatic.messages.logoutSuccessAr[language]);
 
       // *** CUSTOM, EMAIL, ORCID logout
       if (EDStatic.authentication.equals("custom")
@@ -2733,7 +2763,7 @@ public class Erddap extends HttpServlet {
                 loggedInAs,
                 "logout.html", // was endOfRequest,
                 queryString,
-                EDStatic.LogOutAr[language],
+                EDStatic.messages.LogOutAr[language],
                 "<meta name=\"google-signin-client_id\" content=\""
                     + EDStatic.googleClientID
                     + "\">\n",
@@ -2746,7 +2776,7 @@ public class Erddap extends HttpServlet {
                   EDStatic.imageDir);
           writer.write(
               "<div class=\"standard_width\">\n"
-                  + EDStatic.youAreHere(language, loggedInAs, EDStatic.LogOutAr[language])
+                  + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.LogOutAr[language])
                   +
                   // "Logging out and redirecting back to login.html.\n" +
                   // Sequence of events here was very difficult to set up.
@@ -2769,14 +2799,15 @@ public class Erddap extends HttpServlet {
                   // "  onload = mySignOff;\n" +
                   "</script>\n"
                   + MessageFormat.format(
-                      EDStatic.loginPartwayAsAr[language], "<strong>" + loggedInAs + "</strong>")
+                      EDStatic.messages.loginPartwayAsAr[language],
+                      "<strong>" + loggedInAs + "</strong>")
                   + "\n"
                   + widgets.htmlButton(
                       "button",
                       "logout",
                       "",
-                      EDStatic.LogOutAr[language],
-                      EDStatic.LogOutAr[language],
+                      EDStatic.messages.LogOutAr[language],
+                      EDStatic.messages.LogOutAr[language],
                       "onclick=\"signOut();\""));
           writer.write("</div>\n");
           endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -2827,21 +2858,23 @@ public class Erddap extends HttpServlet {
             tLoggedInAs,
             "dataProviderForm.html", // was endOfRequest,
             queryString,
-            EDStatic.dataProviderFormAr[language],
+            EDStatic.messages.dataProviderFormAr[language],
             out);
     String dataProviderFormLongDescriptionHTML =
-        EDStatic.dataProviderFormLongDescriptionHTMLAr[language]
+        EDStatic.messages
+            .dataProviderFormLongDescriptionHTMLAr[language]
             .replaceAll(
                 "&safeEmail;", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)))
             .replaceAll(
                 "&htmlTooltipImage;",
                 EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dataProviderFormSuccessAr[language]))
+                    language, tLoggedInAs, EDStatic.messages.dataProviderFormSuccessAr[language]))
             .replaceAll("&tErddapUrl;", tErddapUrl);
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, tLoggedInAs, EDStatic.dataProviderFormAr[language]));
+              + EDStatic.youAreHere(
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormAr[language]));
 
       // begin text
       writer.write(dataProviderFormLongDescriptionHTML /*
@@ -3012,7 +3045,7 @@ public class Erddap extends HttpServlet {
               language, "Frequency", 0, frequencyOption, frequencyOptions.length - 1, errorMsgSB);
       if (errorMsgSB.length() > 0)
         errorMsgSB.insert(
-            0, EDStatic.dpf_fixProblemAr[language]
+            0, EDStatic.messages.dpf_fixProblemAr[language]
             // "<br>Please fix these problems, then 'Submit' this part of the form again.\n"
             );
 
@@ -3020,7 +3053,7 @@ public class Erddap extends HttpServlet {
 
       // if this is a submission,
       boolean isSubmission =
-          EDStatic.submitAr[0].equals(request.getParameter(EDStatic.submitAr[0]));
+          EDStatic.messages.submitAr[0].equals(request.getParameter(EDStatic.messages.submitAr[0]));
       if (isSubmission && errorMsgSB.length() == 0) {
         // convert the info into pseudo datasets.xml
         String content =
@@ -3077,12 +3110,12 @@ public class Erddap extends HttpServlet {
               tLoggedInAs,
               "dataProviderForm1.html", // was endOfRequest,
               queryString,
-              EDStatic.dataProviderFormP1Ar[language],
+              EDStatic.messages.dataProviderFormP1Ar[language],
               out);
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.dataProviderFormP1Ar[language]));
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP1Ar[language]));
 
       // begin form
       String formName = "f1";
@@ -3106,7 +3139,7 @@ public class Erddap extends HttpServlet {
 
       // begin text
       String dataProviderFormPart1 =
-          EDStatic.dataProviderFormPart1Ar[language].replaceAll(
+          EDStatic.messages.dataProviderFormPart1Ar[language].replaceAll(
               "&safeEmail;", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)));
       writer.write(dataProviderFormPart1 /*
 "This is part 1 (of 4) of the Data Provider Form.\n" +
@@ -3122,7 +3155,8 @@ public class Erddap extends HttpServlet {
 
       // Contact Info
       String dataProviderContactInfo =
-          EDStatic.dataProviderContactInfoAr[language]
+          EDStatic.messages
+              .dataProviderContactInfoAr[language]
               .replace(
                   "&widgetYourName;",
                   widgets.textField(
@@ -3156,7 +3190,8 @@ widgets.textField("emailAddress", "", //tooltip
 "\n"
 */);
       String dataProviderData =
-          EDStatic.dataProviderDataAr[language]
+          EDStatic.messages
+              .dataProviderDataAr[language]
               .replaceAll(
                   "&safeEmail;", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)))
               .replace(
@@ -3236,10 +3271,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // Submit
       writer.write(
-          EDStatic.dpf_submitAr[language]
+          EDStatic.messages
+              .dpf_submitAr[language]
               .replace(
                   "&widgetSubmitButton;",
-                  widgets.button("submit", EDStatic.submitAr[0], "", EDStatic.submitAr[0], ""))
+                  widgets.button(
+                      "submit",
+                      EDStatic.messages.submitAr[0],
+                      "",
+                      EDStatic.messages.submitAr[0],
+                      ""))
               .replace("&partNumberA;", "1")
               .replace("&partNumberB;", "2")
           /*
@@ -3301,7 +3342,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       };
       int defaultCdmDataType = String2.indexOf(cdmDataTypes, "Other");
       int tCdmDataType = String2.indexOf(cdmDataTypes, request.getParameter("cdm_data_type"));
-      String cdmDataTypeHelp = EDStatic.cdmDataTypeHelpAr[language];
+      String cdmDataTypeHelp = EDStatic.messages.cdmDataTypeHelpAr[language];
       /*
       "CDM is Unidata's Common Data Model, a way of categorizing datasets" +
       "<br>based on the geometry of the dataset. Pick the cdm_data_type which" +
@@ -3418,13 +3459,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         errorMsgSB.insert(
             0,
             // "<br>Please fix these problems, then 'Submit' this part of the form again.\n");
-            EDStatic.dpf_fixProblemAr[language]);
+            EDStatic.messages.dpf_fixProblemAr[language]);
 
       String fromInfo = tYourName + " <" + tEmailAddress + "> at " + tTimestamp;
 
       // if this is a submission,
       boolean isSubmission =
-          EDStatic.submitAr[0].equals(request.getParameter(EDStatic.submitAr[0]));
+          EDStatic.messages.submitAr[0].equals(request.getParameter(EDStatic.messages.submitAr[0]));
       if (isSubmission && errorMsgSB.length() == 0) {
         // convert the info into pseudo datasets.xml
         String tcdmType =
@@ -3551,12 +3592,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               tLoggedInAs,
               "dataProviderForm2.html", // was endOfRequest,
               queryString,
-              EDStatic.dataProviderFormP2Ar[language],
+              EDStatic.messages.dataProviderFormP2Ar[language],
               out);
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.dataProviderFormP2Ar[language]));
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP2Ar[language]));
 
       // begin form
       String formName = "f1";
@@ -3584,7 +3625,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // begin text
       String dataProviderFormPart2Header =
-          EDStatic.dataProviderFormPart2HeaderAr[language]
+          EDStatic.messages
+              .dataProviderFormPart2HeaderAr[language]
               .replace("&fromInfo;", XML.encodeAsHTML(fromInfo))
               .replace(
                   "&safeEmail;", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)));
@@ -3602,7 +3644,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write("<span class=\"warningColor\">" + errorMsgSB + "</span> " + "<br>&nbsp;\n");
 
       // Global Metadata
-      writer.write(EDStatic.dataProviderFormPart2GlobalMetadataAr[language] /*
+      writer.write(EDStatic.messages.dataProviderFormPart2GlobalMetadataAr[language] /*
 "<h2>Global Metadata</h2>\n" +
 "Global metadata is information about the entire dataset. It is a set of\n" +
 "<kbd>attribute=value</kbd> pairs, for example,\n" +
@@ -3620,15 +3662,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               // Required
               "<tr>\n"
               + "  <td colspan=\"3\"><strong>"
-              + EDStatic.requiredAr[language]
+              + EDStatic.messages.requiredAr[language]
               + "</strong>\n"
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_titleAr[language]
+              + EDStatic.messages.dpf_titleAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_titleTooltipAr[language])
+                  language, tLoggedInAs, EDStatic.messages.dpf_titleTooltipAr[language])
               +
               //      "This is a short (&lt;=80 characters) description of the dataset. For
               // example," +
@@ -3639,10 +3681,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_summaryAr[language]
+              + EDStatic.messages.dpf_summaryAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_summaryTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_summaryTooltipAr[language]
                   // "This is a paragraph describing the dataset.  (&lt;=500 characters)" +
                   // "<br>The summary should answer these questions:" +
                   // "<br>&bull; Who created the dataset?" +
@@ -3662,10 +3704,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_creatorNameAr[language]
+              + EDStatic.messages.dpf_creatorNameAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_creatorNameTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_creatorNameTooltipAr[language]
                   // "This is the name of the primary person, group, institution," +
                   // "<br>or position that created the data. For example," +
                   // "<br><kbd>John Smith</kbd>"
@@ -3676,10 +3718,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_creatorTypeAr[language]
+              + EDStatic.messages.dpf_creatorTypeAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_creatorTypeTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_creatorTypeTooltipAr[language]
                   // "This identifies the creator_name (above) as a person," +
                   // "<br>group, institution, or position."
                   )
@@ -3689,10 +3731,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_creatorEmailAr[language]
+              + EDStatic.messages.dpf_creatorEmailAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_creatorEmailTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_creatorEmailTooltipAr[language]
                   // "This is the best contact email address for the creator of this data." +
                   // "<br>Use your judgment &mdash; the creator_email might be for a" +
                   // "<br>different entity than the creator_name." +
@@ -3704,10 +3746,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_institutionAr[language]
+              + EDStatic.messages.dpf_institutionAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_institutionTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_institutionTooltipAr[language]
                   // "This is the short/abbreviated form of the name of the primary" +
                   // "<br>organization that created the data. For example," +
                   // "<br><kbd>NOAA NMFS SWFSC</kbd>"
@@ -3718,10 +3760,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_infoUrlAr[language]
+              + EDStatic.messages.dpf_infoUrlAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_infoUrlTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_infoUrlTooltipAr[language]
                   // "This is a URL with information about this dataset." +
                   // "<br>For example, <kbd>http://spray.ucsd.edu</kbd>" +
                   // "<br>If there is no URL related to the dataset, provide" +
@@ -3733,20 +3775,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_licenseAr[language]
+              + EDStatic.messages.dpf_licenseAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
                   language,
                   tLoggedInAs,
-                  EDStatic.dpf_licenseTooltipAr[language].replace(
+                  EDStatic.messages.dpf_licenseTooltipAr[language].replace(
                       "&standardLicense;",
-                      String2.replaceAll(EDStatic.standardLicense, "\n", "<br>"))
+                      String2.replaceAll(EDStatic.messages.standardLicense, "\n", "<br>"))
                   // "This is the license and disclaimer for use of this data." +
                   // "<br>ERDDAP has a standard license, which you can use via
                   // <kbd>[standard]</kbd>" +
                   // "<br>You can either add to that or replace it. (&lt;=500 characters)" +
                   // "<br>The text of the standard license is:" +
-                  // "<br><kbd>" + String2.replaceAll(EDStatic.standardLicense, "\n", "<br>") +
+                  // "<br><kbd>" + String2.replaceAll(EDStatic.messages.standardLicense, "\n",
+                  // "<br>") +
                   // "</kbd>"
                   )
               + "&nbsp;"
@@ -3774,19 +3817,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               // Optional
               "<tr>\n"
               + "<td><strong>"
-              + EDStatic.optionalAr[language]
+              + EDStatic.messages.optionalAr[language]
               + "</strong>"
               + "<td>&nbsp;"
               + "<td>("
-              + EDStatic.dpf_provideIfAvailableAr[language]
+              + EDStatic.messages.dpf_provideIfAvailableAr[language]
               + ")"
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_acknowledgementAr[language]
+              + EDStatic.messages.dpf_acknowledgementAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_acknowledgementTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_acknowledgementTooltipAr[language]
                   // "Optional: This is the place to acknowledge various types of support for" +
                   // "<br>the project that produced this data. (&lt;=350 characters) For example," +
                   // "<br><kbd>This project received additional funding from the NOAA" +
@@ -3802,10 +3845,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_historyAr[language]
+              + EDStatic.messages.dpf_historyAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_historyTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_historyTooltipAr[language]
                   // "Optional: This is a list of the actions (one per line) which led to the
                   // creation of this data." +
                   // "<br>Ideally, each line includes a timestamp and a description of the action.
@@ -3827,7 +3870,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<td>id"
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_idTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_idTooltipAr[language]
                   // "Optional: This is an identifier for the dataset, as provided by" +
                   // "<br>its naming authority. The combination of \"naming authority\"" +
                   // "<br>and the \"id\" should be globally unique, but the id can be" +
@@ -3843,10 +3886,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_namingAuthorityAr[language]
+              + EDStatic.messages.dpf_namingAuthorityAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_namingAuthorityTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_namingAuthorityTooltipAr[language]
                   // "Optional: This is the organization that provided the id (above) for the
                   // dataset." +
                   // "<br>The naming authority should be uniquely specified by this attribute." +
@@ -3860,10 +3903,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_productVersionAr[language]
+              + EDStatic.messages.dpf_productVersionAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_productVersionTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_productVersionTooltipAr[language]
                   // "Optional: This is the version identifier of this data. For example, if you" +
                   // "<br>plan to add new data yearly, you might use the year as the version
                   // identifier." +
@@ -3875,10 +3918,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_referencesAr[language]
+              + EDStatic.messages.dpf_referencesAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_referencesTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_referencesTooltipAr[language]
                   // "Optional: This is one or more published or web-based references" +
                   // "<br>that describe the data or methods used to produce it. URL's and" +
                   // "<br>DOI's are recommend. (&lt;=500 characters) For example,\n" +
@@ -3897,10 +3940,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "<td>"
-              + EDStatic.dpf_commentAr[language]
+              + EDStatic.messages.dpf_commentAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.dpf_commentTooltipAr[language]
+                  language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
                   // "Optional: This is miscellaneous information about the data, not" +
                   // "<br>captured elsewhere. (&lt;=350 characters) For example," +
                   // "<br><kbd>No animals were harmed during the collection of this data.</kbd>"
@@ -3923,10 +3966,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // Submit
       writer.write(
-          EDStatic.dpf_submitAr[language]
+          EDStatic.messages
+              .dpf_submitAr[language]
               .replace(
                   "&widgetSubmitButton;",
-                  widgets.button("submit", EDStatic.submitAr[0], "", EDStatic.submitAr[0], ""))
+                  widgets.button(
+                      "submit",
+                      EDStatic.messages.submitAr[0],
+                      "",
+                      EDStatic.messages.submitAr[0],
+                      ""))
               .replace("&partNumberA;", "2")
               .replace("&partNumberB;", "3")
           // "<h2>Finished with part 2?</h2>\n" +
@@ -3984,9 +4033,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String dataTypeOptions[] = {
         "(unknown)", "String", "boolean", "byte", "short", "int", "long", "float", "double"
       };
-      String dataTypeHelp = EDStatic.dpf_dataTypeHelpAr[language];
+      String dataTypeHelp = EDStatic.messages.dpf_dataTypeHelpAr[language];
       int ioosUnknown = EDV.IOOS_CATEGORIES.indexOf("Unknown");
-      String ioosCategoryHelp = EDStatic.dpf_ioosCategoryHelpAr[language];
+      String ioosCategoryHelp = EDStatic.messages.dpf_ioosCategoryHelpAr[language];
 
       String tYourName = request.getParameter("yourName"),
           tEmailAddress = request.getParameter("emailAddress"),
@@ -4078,7 +4127,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
       if (errorMsgSB.length() > 0)
         errorMsgSB.insert(
-            0, EDStatic.dpf_fixProblemAr[language]
+            0, EDStatic.messages.dpf_fixProblemAr[language]
             // "<br>Please fix these problems, then 'Submit' this part of the form again.\n"
             );
 
@@ -4086,7 +4135,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // if this is a submission,
       boolean isSubmission =
-          EDStatic.submitAr[0].equals(request.getParameter(EDStatic.submitAr[0]));
+          EDStatic.messages.submitAr[0].equals(request.getParameter(EDStatic.messages.submitAr[0]));
       if (isSubmission && errorMsgSB.length() == 0) {
         // convert the info into pseudo datasets.xml
         StringBuilder content = new StringBuilder();
@@ -4186,12 +4235,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               tLoggedInAs,
               "dataProviderForm3.html", // was endOfRequest,
               queryString,
-              EDStatic.dataProviderFormP3Ar[language],
+              EDStatic.messages.dataProviderFormP3Ar[language],
               out);
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.dataProviderFormP3Ar[language]));
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP3Ar[language]));
 
       // begin form
       String formName = "f1";
@@ -4219,7 +4268,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // begin text
       writer.write(
-          EDStatic.dpf_part3HeaderAr[language]
+          EDStatic.messages
+              .dpf_part3HeaderAr[language]
               .replace("&fromInfo;", XML.encodeAsHTML(fromInfo))
               .replace(
                   "&safeEmail;", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)))
@@ -4237,7 +4287,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // Variable Metadata
       writer.write(
-          EDStatic.dpf_variableMetadataAr[language].replace(
+          EDStatic.messages.dpf_variableMetadataAr[language].replace(
               "&widgetSelectGroup;", widgets.select("group", "", 1, groupOptions, tGroup, ""))
           // "<h2>Variable Metadata</h2>\n" +
           // "Variable metadata is information that is specific to a given variable within\n" +
@@ -4280,11 +4330,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_sourceNameAr[language]
+                + EDStatic.messages.dpf_sourceNameAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_sourceNameTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_sourceNameTooltipAr[language]
                     // "This is the name of this variable currently used by the data source." +
                     // "<br>For example, <kbd>wt</kbd>" +
                     // "<br>This is case-sensitive."
@@ -4295,22 +4345,22 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_destinationNameAr[language]
+                + EDStatic.messages.dpf_destinationNameAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_destinationNameTooltipAr[language])
+                    language, tLoggedInAs, EDStatic.messages.dpf_destinationNameTooltipAr[language])
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.textField("destinationName" + var, "", 20, 60, tDestinationName[var], "")
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_longNameAr[language]
+                + EDStatic.messages.dpf_longNameAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_longNameTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_longNameTooltipAr[language]
                     // "This is a longer, written-out version of the destinationName." +
                     // "<br>For example, <kbd>Water Temperature</kbd>" +
                     // "<br>Among other uses, it will be used as an axis title on graphs." +
@@ -4324,11 +4374,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_standardNameAr[language]
+                + EDStatic.messages.dpf_standardNameAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_standardNameTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_standardNameTooltipAr[language]
                     // "Optional: This is the name from the CF Standard Name Table" +
                     // "<br>&nbsp;&nbsp;which is most appropriate for this variable.\n" +
                     // "<br>For example, <kbd>sea_water_temperature</kbd>." +
@@ -4346,13 +4396,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     40,
                     120,
                     tStandardName[var],
-                    EDStatic.commonStandardNames,
+                    EDStatic.messages.commonStandardNames,
                     "",
                     null)
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_dataTypeAr[language]
+                + EDStatic.messages.dpf_dataTypeAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(language, tLoggedInAs, dataTypeHelp)
@@ -4362,11 +4412,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_fillValueAr[language]
+                + EDStatic.messages.dpf_fillValueAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_fillValueTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_fillValueTooltipAr[language]
                     // "For numeric variables, this is the value that is used in the" +
                     // "<br>data file to indicate a missing value for this variable.\n" +
                     // "<br>For example, <kbd>-999</kbd> ." +
@@ -4385,22 +4435,22 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_unitsAr[language]
+                + EDStatic.messages.dpf_unitsAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_unitsTooltipAr[language])
+                    language, tLoggedInAs, EDStatic.messages.dpf_unitsTooltipAr[language])
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.textField("units" + var, "", 20, 80, tUnits[var], "")
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_rangeAr[language]
+                + EDStatic.messages.dpf_rangeAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_rangeTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_rangeTooltipAr[language]
                     // "For numeric variables, this specifies the typical range of values." +
                     // "<br>For example, <kbd>minimum=32.0</kbd> and <kbd>maximum=37.0</kbd> ." +
                     // "<br>The range should include about 98% of the values." +
@@ -4417,7 +4467,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_ioosCategoryAr[language]
+                + EDStatic.messages.dpf_ioosCategoryAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(language, tLoggedInAs, ioosCategoryHelp)
@@ -4428,11 +4478,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td>"
-                + EDStatic.dpf_commentAr[language]
+                + EDStatic.messages.dpf_commentAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.dpf_commentTooltipAr[language]
+                    language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
                     // "Optional: This is miscellaneous information about this variable, not
                     // captured" +
                     // "<br>elsewhere. For example," +
@@ -4454,10 +4504,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // Submit
       writer.write(
-          EDStatic.dpf_submitAr[language]
+          EDStatic.messages
+              .dpf_submitAr[language]
               .replace(
                   "&widgetSubmitButton;",
-                  widgets.button("submit", EDStatic.submitAr[0], "", EDStatic.submitAr[0], ""))
+                  widgets.button(
+                      "submit",
+                      EDStatic.messages.submitAr[0],
+                      "",
+                      EDStatic.messages.submitAr[0],
+                      ""))
               .replace("&partNumberA;", "3")
               .replace("&partNumberB;", "4")
 
@@ -4533,7 +4589,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               language, "Other Comments", "", tOtherComments, 500, errorMsgSB);
       if (errorMsgSB.length() > 0)
         errorMsgSB.insert(
-            0, EDStatic.dpf_fixProblemAr[language]
+            0, EDStatic.messages.dpf_fixProblemAr[language]
             // "<br>Please fix these problems, then 'Submit' this part of the form again.\n"
             );
 
@@ -4541,7 +4597,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // if this is a submission,
       boolean isSubmission =
-          EDStatic.submitAr[0].equals(request.getParameter(EDStatic.submitAr[0]));
+          EDStatic.messages.submitAr[0].equals(request.getParameter(EDStatic.messages.submitAr[0]));
       if (isSubmission && errorMsgSB.length() == 0) {
         // convert the info into pseudo datasets.xml
         String content =
@@ -4591,12 +4647,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               tLoggedInAs,
               "dataProviderForm4.html", // was endOfRequest,
               queryString,
-              EDStatic.dataProviderFormP4Ar[language],
+              EDStatic.messages.dataProviderFormP4Ar[language],
               out);
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.dataProviderFormP4Ar[language]));
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP4Ar[language]));
       // EDStatic.youAreHere(language, tLoggedInAs, "Data Provider Form - Part 4"));
 
       // begin form
@@ -4625,7 +4681,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // begin text
       writer.write(
-          EDStatic.dpf_part4HeaderAr[language]
+          EDStatic.messages
+                  .dpf_part4HeaderAr[language]
                   .replace("&fromInfo;", XML.encodeAsHTML(fromInfo))
                   .replace(
                       "&safeEmail", XML.encodeAsHTML(SSR.getSafeEmailAddress(EDStatic.adminEmail)))
@@ -4642,7 +4699,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // other comments
       writer.write(
-          EDStatic.dpf_otherCommentAr[language]
+          EDStatic.messages.dpf_otherCommentAr[language]
               + "\n"
               +
               // "<h2>Other Comments</h2>\n" +
@@ -4662,9 +4719,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // Submit
       writer.write(
-          EDStatic.dpf_finishPart4Ar[language].replace(
+          EDStatic.messages.dpf_finishPart4Ar[language].replace(
               "&widgetSubmitButton;",
-              widgets.button("submit", EDStatic.submitAr[0], "", EDStatic.submitAr[0], ""))
+              widgets.button(
+                  "submit", EDStatic.messages.submitAr[0], "", EDStatic.messages.submitAr[0], ""))
           // "<h2>Finished with part 4?</h2>\n" +
           // "Click\n" +
           // widgets.button("submit", "Submit", "", "Submit", "") +
@@ -4737,17 +4795,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               tLoggedInAs,
               "dataProviderFormDone.html", // was endOfRequest,
               queryString,
-              EDStatic.dataProviderFormDoneAr[language],
+              EDStatic.messages.dataProviderFormDoneAr[language],
               out);
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.dataProviderFormDoneAr[language]));
+                  language, tLoggedInAs, EDStatic.messages.dataProviderFormDoneAr[language]));
       // EDStatic.youAreHere(language, tLoggedInAs, "Data Provider Form - Done"));
 
       // begin text
       writer.write(
-          EDStatic.dpf_congratulationAr[language]
+          EDStatic.messages
+              .dpf_congratulationAr[language]
               .replace("&tTimestamp;", XML.encodeAsHTML(tTimestamp))
               .replaceAll("&tErddapUrl;", tErddapUrl)
               .replace("&tYourName;", XML.encodeAsHTML(tYourName))
@@ -4806,7 +4865,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.statusAr[language])
+              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.statusAr[language])
               + "<pre>");
       StringBuilder sb = new StringBuilder();
       EDStatic.addIntroStatistics(sb, EDStatic.showLoadErrorsOnStatusPage, this);
@@ -4882,19 +4941,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.encodedDefaultPIppQuery
               + "&#x26;searchFor=temperature";
       String htmlQueryUrlWithSpaces = htmlQueryUrl + "%20wind%20speed";
-      String griddapExample = tErddapUrl + "/griddap/" + EDStatic.EDDGridIdExample;
-      String tabledapExample = tErddapUrl + "/tabledap/" + EDStatic.EDDTableIdExample;
+      String griddapExample = tErddapUrl + "/griddap/" + EDStatic.messages.EDDGridIdExample;
+      String tabledapExample = tErddapUrl + "/tabledap/" + EDStatic.messages.EDDTableIdExample;
 
       String modifiedRestfulHTML =
-          EDStatic.restfulHTMLAr[language]
-              .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+          EDStatic.messages
+              .restfulHTMLAr[language]
+              .replaceAll(
+                  "&externalLinkHtml;", EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               .replaceAll("&htmlQueryUrl;", htmlQueryUrl)
               .replaceAll("&jsonQueryUrl;", jsonQueryUrl)
               .replaceAll("&htmlQueryUrlWithSpaces;", htmlQueryUrlWithSpaces)
               .replaceAll("&tErddapUrl;", tErddapUrl)
               .replaceAll(
                   "&acceptEncodingHtmlh3tErddapUrl;",
-                  EDStatic.acceptEncodingHtml(language, "h3", tErddapUrl))
+                  EDStatic.messages.acceptEncodingHtml(language, "h3", tErddapUrl))
               .replaceAll("&plainLinkExamples1;", plainLinkExamples(tErddapUrl, "/index", ""))
               .replaceAll(
                   "&plainLinkExamples2;",
@@ -4902,7 +4963,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               .replaceAll(
                   "&plainLinkExamples3;",
                   plainLinkExamples(
-                      tErddapUrl, "/info/" + EDStatic.EDDGridIdExample + "/index", ""))
+                      tErddapUrl, "/info/" + EDStatic.messages.EDDGridIdExample + "/index", ""))
               .replaceAll(
                   "&plainLinkExamples4;",
                   plainLinkExamples(
@@ -4938,15 +4999,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                       "/categorize/standard_name/time/index", // 8
                       EDStatic.encodedDefaultPIppQuery))
               .replaceAll("&encodedDefaultPIppQuery;", EDStatic.encodedDefaultPIppQuery)
-              .replaceAll("&advancedSearch;", EDStatic.advancedSearchAr[language]);
+              .replaceAll("&advancedSearch;", EDStatic.messages.advancedSearchAr[language]);
 
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.indexServicesAr[language])
+              + EDStatic.youAreHere(
+                  language, loggedInAs, EDStatic.messages.indexServicesAr[language])
               +
               // EDStatic.youAreHere(language, loggedInAs, "RESTful Web Services") +
               "<h2 style=\"text-align:center;\"><a class=\"selfLink\" id=\"WebService\" href=\"#WebService\" rel=\"bookmark\">"
-              + EDStatic.accessRESTFULAr[language]
+              + EDStatic.messages.accessRESTFULAr[language]
               + "</a></h2>\n"
               + modifiedRestfulHTML
           /*
@@ -5147,7 +5209,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "\n" +
 
           //compression
-          EDStatic.acceptEncodingHtml("h3", tErddapUrl) +
+          EDStatic.messages.acceptEncodingHtml("h3", tErddapUrl) +
           "\n" +
 
           //accessUrls
@@ -5166,7 +5228,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "  <br>" + tErddapUrl + "/info/<i>datasetID</i>/index<i>.fileType</i>\n" +
           "  <br>for example,\n" +
           "  <br>" + plainLinkExamples(tErddapUrl,
-              "/info/" + EDStatic.EDDGridIdExample + "/index", "") + //3
+              "/info/" + EDStatic.messages.EDDGridIdExample + "/index", "") + //3
           "  <br>&nbsp;\n" +
           "<li>To get the results of <strong>full text searches</strong> for datasets\n" +
           "  (using \"searchFor=wind%20speed\" as the example), use\n" +
@@ -5189,7 +5251,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "&amp;searchFor=wind%20speed") +
           "  <br>But experiment with\n" +
           "    <a href=\"" + tErddapUrl + "/search/advanced.html?" +
-              EDStatic.encodedDefaultPIppQuery + "\">" + EDStatic.advancedSearch + "</a>\n" +
+              EDStatic.encodedDefaultPIppQuery + "\">" + EDStatic.messages.advancedSearch + "</a>\n" +
           "    in a browser to figure out all of the optional parameters.\n" +
           "  (Your program or script may need to \n" +
           "    <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent-encode" +
@@ -5214,7 +5276,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       int tDasIndex = EDDTable.dataFileTypeNames.indexOf(".das");
       int tDdsIndex = EDDTable.dataFileTypeNames.indexOf(".dds");
       String restfulGetAllDataset =
-          EDStatic.restfulGetAllDatasetAr[language]
+          EDStatic.messages
+              .restfulGetAllDatasetAr[language]
               .replace(
                   "&plainLinkExamples1;",
                   plainLinkExamples(tErddapUrl, "/griddap/index", EDStatic.encodedAllPIppQuery))
@@ -5239,7 +5302,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (EDStatic.sosActive)
         writer.write(
             "  <li>"
-                + EDStatic.forSOSUseAr[language]
+                + EDStatic.messages.forSOSUseAr[language]
                 + "\n<br>"
                 +
                 // "  <li>For SOS: use\n<br>" +
@@ -5247,7 +5310,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (EDStatic.wcsActive)
         writer.write(
             "  <li>"
-                + EDStatic.forWCSUseAr[language]
+                + EDStatic.messages.forWCSUseAr[language]
                 + "\n<br>"
                 +
                 // "  <li>For WCS: use\n<br>" +
@@ -5255,19 +5318,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (EDStatic.wmsActive)
         writer.write(
             "  <li>"
-                + EDStatic.forWMSUseAr[language]
+                + EDStatic.messages.forWMSUseAr[language]
                 + "\n<br>"
                 +
                 // "  <li>For WMS: use\n<br>" +
                 plainLinkExamples(tErddapUrl, "/wms/index", EDStatic.encodedAllPIppQuery));
 
       String restfulHTMLContinued =
-          EDStatic.restfulHTMLContinuedAr[language]
+          EDStatic.messages
+              .restfulHTMLContinuedAr[language]
               .replaceAll("&tErddapUrl;", tErddapUrl)
               .replace(
                   "&dataFiletypeInfo1;",
                   XML.encodeAsHTMLAttribute(EDDTable.dataFileTypeInfo.get(tDdsIndex)))
-              .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+              .replaceAll(
+                  "&externalLinkHtml;", EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               .replaceAll("&griddapExample;", griddapExample)
               .replaceAll("&tabledapExample;", tabledapExample)
               .replace(
@@ -5324,7 +5389,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 "  </ul>\n"
                 */);
       if (EDStatic.sosActive || EDStatic.wcsActive || EDStatic.wmsActive) {
-        writer.write(EDStatic.restfulProtocolsAr[language] /*
+        writer.write(EDStatic.messages.restfulProtocolsAr[language] /*
                 "<li><a class=\"selfLink\" id=\"OtherProtocols\" href=\"#OtherProtocols\" rel=\"bookmark\"\n" +
                 ">ERDDAP's other protocols</a> also have web services that you can use.\n" +
                 "  See\n" +
@@ -5337,7 +5402,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "    <li><a rel=\"help\" href=\""
                   + tErddapUrl
                   + "/sos/documentation.html\">"
-                  + EDStatic.SOSDocumentationAr[language]
+                  + EDStatic.messages.SOSDocumentationAr[language]
                   + "</a>\n");
         if (EDStatic.wcsActive)
           writer.write(
@@ -5346,7 +5411,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "   <li><a rel=\"help\" href=\""
                   + tErddapUrl
                   + "/wcs/documentation.html\">"
-                  + EDStatic.WCSDocumentationAr[language]
+                  + EDStatic.messages.WCSDocumentationAr[language]
                   + "</a>\n");
         if (EDStatic.wmsActive)
           writer.write(
@@ -5355,7 +5420,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "    <li><a rel=\"help\" href=\""
                   + tErddapUrl
                   + "/wms/documentation.html\">"
-                  + EDStatic.WMSDocumentationAr[language]
+                  + EDStatic.messages.WMSDocumentationAr[language]
                   + "</a>\n");
         writer.write(
             """
@@ -5364,7 +5429,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 """);
       }
       String subscriptionOfferRss =
-          EDStatic.subscriptionOfferRssAr[language].replace("&tErddapUrl;", tErddapUrl);
+          EDStatic.messages.subscriptionOfferRssAr[language].replace("&tErddapUrl;", tErddapUrl);
       writer.write(
           subscriptionOfferRss
           /*
@@ -5376,7 +5441,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           */
           );
       String subscriptionOfferUrl =
-          EDStatic.subscriptionOfferUrlAr[language].replace("&tErddapUrl;", tErddapUrl);
+          EDStatic.messages.subscriptionOfferUrlAr[language].replace("&tErddapUrl;", tErddapUrl);
       if (EDStatic.subscriptionSystemActive)
         writer.write(
             subscriptionOfferUrl
@@ -5390,7 +5455,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             );
       writer.write(
           "<li>"
-              + EDStatic.converterWebServiceAr[language]
+              + EDStatic.messages.converterWebServiceAr[language]
               + "\n"
               +
               // "<li>ERDDAP offers several converters as web pages and as web services:\n" +
@@ -5399,59 +5464,59 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/oceanicAtmosphericAcronyms.html#computerProgram\">"
-                      + EDStatic.convertOAAcronymsToFromAr[language]
+                      + EDStatic.messages.convertOAAcronymsToFromAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/oceanicAtmosphericVariableNames.html#computerProgram\">"
-                      + EDStatic.convertOAVariableNamesToFromAr[language]
+                      + EDStatic.messages.convertOAVariableNamesToFromAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/fipscounty.html#computerProgram\">"
-                      + EDStatic.convertFipsCountyAr[language]
+                      + EDStatic.messages.convertFipsCountyAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/keywords.html#computerProgram\">"
-                      + EDStatic.convertKeywordsAr[language]
+                      + EDStatic.messages.convertKeywordsAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/time.html#computerProgram\">"
-                      + EDStatic.convertTimeAr[language]
+                      + EDStatic.messages.convertTimeAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/units.html#computerProgram\">"
-                      + EDStatic.convertUnitsAr[language]
+                      + EDStatic.messages.convertUnitsAr[language]
                       + "</a>\n"
                       + "  <li><a rel=\"bookmark\" href=\""
                       + tErddapUrl
                       + "/convert/urls.html#computerProgram\">"
-                      + EDStatic.convertURLsAr[language]
+                      + EDStatic.messages.convertURLsAr[language]
                       + "</a>\n"
                       + "    <br>&nbsp;\n"
                       + "  </ul>\n"
                   : "<br> ("
-                      + MessageFormat.format(EDStatic.disabledAr[language], "convert")
+                      + MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")
                       + ")\n<br>&nbsp;\n"));
       String outOfDateKeepTrack =
-          EDStatic.outOfDateKeepTrackAr[language].replace("&tErddapUrl;", tErddapUrl);
+          EDStatic.messages.outOfDateKeepTrackAr[language].replace("&tErddapUrl;", tErddapUrl);
       if (EDStatic.outOfDateDatasetsActive) writer.write(outOfDateKeepTrack /*
                 "<li>ERDDAP has a system to keep track of\n" +
                 "    <a rel=\"help\" href=\"" + tErddapUrl + "/outOfDateDatasets.html\">Out-Of-Date Datasets</a>.\n" +
                 "    See the Options at the bottom of that web page.\n" +
                 "  <br>&nbsp;\n"
                 */);
-      writer.write("</ul>\n" + EDStatic.additionalLinksAr[language] + "\n");
+      writer.write("</ul>\n" + EDStatic.messages.additionalLinksAr[language] + "\n");
       // "If you have suggestions for additional links, contact <kbd>bob dot simons at noaa dot
       // gov</kbd>.\n");
 
       // JavaPrograms
       // setup.html always from coastwatch's erddap
       writer.write(
-          EDStatic.javaProgramsHTMLAr[language]
+          EDStatic.messages.javaProgramsHTMLAr[language]
           /*
           "<h2><a class=\"selfLink\" id=\"JavaPrograms\" href=\"#JavaPrograms\" rel=\"bookmark\">Using ERDDAP as a Data Source within Your Java Program</a></h2>\n" +
           "As described above, since Java programs can access data available on the web, you can\n" +
@@ -5466,7 +5531,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           );
 
       // login
-      writer.write(EDStatic.loginHTMLAr[language] /*
+      writer.write(EDStatic.messages.loginHTMLAr[language] /*
                 "<h2><a class=\"selfLink\" id=\"login\" href=\"#login\" rel=\"bookmark\">Log in to access private datasets.</a></h2>\n" +
                 "Many ERDDAP installations don't have authentication enabled and thus\n" +
                 "don't provide any way for users to login, nor do they have any private datasets.\n" +
@@ -5483,7 +5548,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // erddap version
       writer.write(
-          EDStatic.erddapVersionHTMLAr[language]
+          EDStatic.messages
+              .erddapVersionHTMLAr[language]
               .replaceAll(
                   "&versionLink;", "<a href=\"&tErddapUrl;/version\">&tErddapUrl;/version</a>")
               .replaceAll(
@@ -5898,7 +5964,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "<div class=\"standard_width\">\n"
                 + EDStatic.youAreHere(
-                    language, loggedInAs, protocol, EDStatic.documentationAr[language]));
+                    language, loggedInAs, protocol, EDStatic.messages.documentationAr[language]));
         if (protocol.equals("griddap"))
           EDDGrid.writeGeneralDapHtmlInstructions(language, tErddapUrl, writer, true);
         else if (protocol.equals("tabledap"))
@@ -5991,7 +6057,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write("<div class=\"standard_width\">\n");
       try {
         writer.write(
-            EDStatic.youAreHere(language, loggedInAs, protocol, EDStatic.helpAr[language]));
+            EDStatic.youAreHere(
+                language, loggedInAs, protocol, EDStatic.messages.helpAr[language]));
         // writer.write(EDStatic.youAreHere(language, loggedInAs, protocol, "Help"));
         writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
         if (protocol.equals("griddap"))
@@ -6089,8 +6156,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], id),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], id)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], id),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], id)));
       return;
     }
     if (!dataset.isAccessibleTo(
@@ -6158,11 +6225,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             && // e.g., .jsonlCSV .jsonlKVP
             !fileTypeName.equals(".ncoJson"))
           throw new SimpleException(
-              EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.errorJsonpNotAllowedAr));
+              EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.errorJsonpNotAllowedAr));
         if (!String2.isJsonpNameSafe(jsonp))
           throw new SimpleException(
               EDStatic.bilingual(
-                  language, EDStatic.queryErrorAr, EDStatic.errorJsonpFunctionNameAr));
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.errorJsonpFunctionNameAr));
       }
     }
 
@@ -6372,13 +6444,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // beware malicious url, e.g., internal /../
     if (endOfRequestUrl.indexOf("/../") >= 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "/../ is not allowed!");
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + "/../ is not allowed!");
     if (endOfRequestUrl.startsWith("/") || endOfRequestUrl.indexOf("//") >= 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "// is not allowed!");
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + "// is not allowed!");
     if (endOfRequestUrl.indexOf('\\') >= 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "\\ is not allowed!");
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + "\\ is not allowed!");
 
     // is request for documentation.html?
     if (endOfRequestUrl.equals("documentation.html")) {
@@ -6389,7 +6464,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               loggedInAs,
               "files/documentation.html", // was endOfRequest,
               queryString,
-              "ERDDAP " + EDStatic.EDDFilesAr[language] + " " + EDStatic.documentationAr[language],
+              "ERDDAP "
+                  + EDStatic.messages.EDDFilesAr[language]
+                  + " "
+                  + EDStatic.messages.documentationAr[language],
               out);
       try {
         writer.write("<div class=\"standard_width\">\n");
@@ -6398,9 +6476,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 language,
                 loggedInAs,
                 "files/",
-                EDStatic.EDDFilesAr,
-                EDStatic.documentationAr[language]));
-        writer.write(EDStatic.filesDocumentation(language, tErddapUrl));
+                EDStatic.messages.EDDFilesAr,
+                EDStatic.messages.documentationAr[language]));
+        writer.write(EDStatic.messages.filesDocumentation(language, tErddapUrl));
         writer.write("""
 
                 </div>
@@ -6433,8 +6511,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], "\"\""),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], "\"\"")));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], "\"\""),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], "\"\"")));
       return;
 
     } else if (slashPoNP > 0) {
@@ -6569,17 +6647,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
         writer.write(
             "<div class=\"standard_width\">\n"
-                + EDStatic.youAreHere(language, loggedInAs, EDStatic.EDDFilesAr[language])
-                + EDStatic.filesDescriptionAr[language]
+                + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.EDDFilesAr[language])
+                + EDStatic.messages.filesDescriptionAr[language]
                 + "\n<br><span class=\"warningColor\">"
-                + EDStatic.warningAr[language]
+                + EDStatic.messages.warningAr[language]
                 + "</span> "
-                + EDStatic.filesWarningAr[language]
+                + EDStatic.messages.filesWarningAr[language]
                 + "\n"
                 + "(<a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/files/documentation.html\">"
-                + MessageFormat.format(EDStatic.indexDocumentationAr[language], "\"files\"")
+                + MessageFormat.format(
+                    EDStatic.messages.indexDocumentationAr[language], "\"files\"")
                 + "</a>"
                 + ", including <a rel=\"help\" href=\""
                 + tErddapUrl
@@ -6592,7 +6671,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 fullRequestUrl,
                 queryString, // may have sort instructions
                 EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/",
-                EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile,
+                EDStatic.imageDirUrl(loggedInAs, language)
+                    + EDStatic.messages.questionMarkImageFile,
                 true,
                 subDirNames,
                 subDirDes)); // addParentDir
@@ -6619,8 +6699,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], id),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], id)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], id),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], id)));
       return;
     }
 
@@ -6637,7 +6717,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
     if (!edd.accessibleViaFiles()) {
       if (verbose)
-        String2.log(EDStatic.resourceNotFoundAr[language] + "accessibleViaFilesDir=\"\"");
+        String2.log(EDStatic.messages.resourceNotFoundAr[language] + "accessibleViaFilesDir=\"\"");
       sendResourceNotFoundError(
           requestNumber, request, response, "This dataset is not accessible via /files/ .");
       return;
@@ -6671,8 +6751,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             response,
             EDStatic.bilingual(
                 language,
-                EDStatic.resourceNotFoundAr[0] + "directory=" + nextPath,
-                EDStatic.resourceNotFoundAr[language] + "directory=" + nextPath));
+                EDStatic.messages.resourceNotFoundAr[0] + "directory=" + nextPath,
+                EDStatic.messages.resourceNotFoundAr[language] + "directory=" + nextPath));
         return;
       }
       Table fileTable = (Table) o2[0];
@@ -6687,8 +6767,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             response,
             EDStatic.bilingual(
                 language,
-                EDStatic.resourceNotFoundAr[0] + "directory=" + nextPath,
-                EDStatic.resourceNotFoundAr[language] + "directory=" + nextPath));
+                EDStatic.messages.resourceNotFoundAr[0] + "directory=" + nextPath,
+                EDStatic.messages.resourceNotFoundAr[language] + "directory=" + nextPath));
         return;
       }
 
@@ -6734,13 +6814,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write("<div class=\"standard_width\">\n");
         writer.write(
             nextPath.length() == 0
-                ? EDStatic.youAreHere(language, loggedInAs, "files/", EDStatic.EDDFilesAr, id)
+                ? EDStatic.youAreHere(
+                    language, loggedInAs, "files/", EDStatic.messages.EDDFilesAr, id)
                 : "\n<h1>"
                     + EDStatic.erddapHref(language, tErddapUrl)
                     + "\n &gt; <a rel=\"contents\" href=\""
                     + XML.encodeAsHTMLAttribute(EDStatic.protocolUrl(tErddapUrl, "files"))
                     + "\">"
-                    + EDStatic.EDDFilesAr[language]
+                    + EDStatic.messages.EDDFilesAr[language]
                     + "</a>"
                     + "\n &gt; <a rel=\"contents\" href=\""
                     + XML.encodeAsHTMLAttribute(
@@ -6751,19 +6832,20 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     + "\n &gt; "
                     + XML.encodeAsXML(nextPath)
                     + "</h1>\n");
-        writer.write(EDStatic.filesDescriptionAr[language] + "\n");
+        writer.write(EDStatic.messages.filesDescriptionAr[language] + "\n");
         if (!(edd instanceof EDDTableFromFileNames))
           writer.write(
               "<br><span class=\"warningColor\">"
-                  + EDStatic.warningAr[language]
+                  + EDStatic.messages.warningAr[language]
                   + "</span> "
-                  + EDStatic.filesWarningAr[language]
+                  + EDStatic.messages.filesWarningAr[language]
                   + "\n");
         writer.write(
             " (<a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/files/documentation.html\">"
-                + MessageFormat.format(EDStatic.indexDocumentationAr[language], "\"files\"")
+                + MessageFormat.format(
+                    EDStatic.messages.indexDocumentationAr[language], "\"files\"")
                 + "</a>"
                 + ", including <a rel=\"help\" href=\""
                 + tErddapUrl
@@ -6778,7 +6860,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 fullRequestUrl,
                 queryString, // may have sort instructions
                 EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/",
-                EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile,
+                EDStatic.imageDirUrl(loggedInAs, language)
+                    + EDStatic.messages.questionMarkImageFile,
                 true,
                 subDirs,
                 null)); // addParentDir
@@ -6805,8 +6888,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.errorFileNotFoundAr[0], nameAndExt),
-              MessageFormat.format(EDStatic.errorFileNotFoundAr[language], nameAndExt)));
+              MessageFormat.format(EDStatic.messages.errorFileNotFoundAr[0], nameAndExt),
+              MessageFormat.format(EDStatic.messages.errorFileNotFoundAr[language], nameAndExt)));
       return;
     }
 
@@ -6909,8 +6992,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unsupportedFileTypeAr[0], fileTypeName),
-              MessageFormat.format(EDStatic.unsupportedFileTypeAr[language], fileTypeName)));
+              MessageFormat.format(EDStatic.messages.unsupportedFileTypeAr[0], fileTypeName),
+              MessageFormat.format(
+                  EDStatic.messages.unsupportedFileTypeAr[language], fileTypeName)));
       return;
     }
 
@@ -6946,7 +7030,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           ids.add(edd.datasetID());
         }
       }
-      description = EDStatic.EDDGridDapDescriptionAr[language];
+      description = EDStatic.messages.EDDGridDapDescriptionAr[language];
     } else if (protocol.equals("tabledap")) {
       StringArray tids = tableDatasetIDs();
       int ntids = tids.size();
@@ -6962,7 +7046,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           ids.add(edd.datasetID());
         }
       }
-      description = EDStatic.EDDTableDapDescriptionAr[language];
+      description = EDStatic.messages.EDDTableDapDescriptionAr[language];
     } else if (EDStatic.sosActive && protocol.equals("sos")) {
       StringArray tids = tableDatasetIDs();
       int ntids = tids.size();
@@ -6980,7 +7064,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
       }
       description =
-          EDStatic.sosDescriptionHtmlAr[language] + "\nFor details, see the 'S'OS links below.";
+          EDStatic.messages.sosDescriptionHtmlAr[language]
+              + "\nFor details, see the 'S'OS links below.";
     } else if (EDStatic.wcsActive && protocol.equals("wcs")) {
       StringArray tids = gridDatasetIDs();
       int ntids = tids.size();
@@ -6997,7 +7082,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           ids.add(edd.datasetID());
         }
       }
-      description = EDStatic.wcsDescriptionHtmlAr[language];
+      description = EDStatic.messages.wcsDescriptionHtmlAr[language];
     } else if (EDStatic.wmsActive && protocol.equals("wms")) {
       StringArray tids = gridDatasetIDs();
       int ntids = tids.size();
@@ -7015,7 +7100,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           ids.add(edd.datasetID());
         }
       }
-      description = EDStatic.wmsDescriptionHtmlAr[language];
+      description = EDStatic.messages.wmsDescriptionHtmlAr[language];
     } else {
       sendResourceNotFoundError(
           requestNumber,
@@ -7023,8 +7108,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownProtocolAr[0], protocol),
-              MessageFormat.format(EDStatic.unknownProtocolAr[language], protocol)));
+              MessageFormat.format(EDStatic.messages.unknownProtocolAr[0], protocol),
+              MessageFormat.format(EDStatic.messages.unknownProtocolAr[language], protocol)));
       return;
     }
 
@@ -7059,7 +7144,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       error =
           new String[] {
             MessageFormat.format(
-                EDStatic.noDatasetWithAr[language], "protocol=\"" + protocol + "\""),
+                EDStatic.messages.noDatasetWithAr[language], "protocol=\"" + protocol + "\""),
             ""
           };
     } else if (page > lastPage) {
@@ -7078,17 +7163,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // you can't use noLongLinesAtSpace for fear of  "<a <br>href..."
     if (protocol.equals("tabledap"))
       description +=
-          "\n" + MessageFormat.format(EDStatic.tabledapVideoIntroAr[language], tErddapUrl) + "\n";
+          "\n"
+              + MessageFormat.format(EDStatic.messages.tabledapVideoIntroAr[language], tErddapUrl)
+              + "\n";
     if (!protocol.equals("sos")) {
       String base =
-          // protocol.equals("tabledap")? EDStatic.EDDTableErddapUrlExample + "tabledap" :
+          // protocol.equals("tabledap")? EDStatic.messages.EDDTableErddapUrlExample + "tabledap" :
           // //2021-09-22 no, always go local
-          // protocol.equals("griddap")?  EDStatic.EDDGridErddapUrlExample  + "griddap" :
+          // protocol.equals("griddap")?  EDStatic.messages.EDDGridErddapUrlExample  + "griddap" :
           tErddapUrl + "/" + protocol;
       description +=
           "\n"
               + MessageFormat.format(
-                  EDStatic.seeProtocolDocumentationAr[language],
+                  EDStatic.messages.seeProtocolDocumentationAr[language],
                   base + "/documentation.html",
                   uProtocol)
               + "\n";
@@ -7099,7 +7186,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (pft >= 0) {
       if (error != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + error[0] + " " + error[1]);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                + error[0]
+                + " "
+                + error[1]);
 
       // make the plain table with the dataset list
       table = makePlainDatasetTable(language, loggedInAs, ids, sortByTitle, fileTypeName);
@@ -7128,11 +7218,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             protocol + "/index.html", // was endOfRequest,
             queryString,
-            MessageFormat.format(EDStatic.listOfDatasetsAr[language], uProtocol),
+            MessageFormat.format(EDStatic.messages.listOfDatasetsAr[language], uProtocol),
             out);
     try {
       String refine =
-          EDStatic.orRefineSearchWithAr[language]
+          EDStatic.messages.orRefineSearchWithAr[language]
               + getAdvancedSearchLink(
                   language,
                   loggedInAs,
@@ -7150,7 +7240,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "</h2>\n",
           //Or, View All Datasets
           "&nbsp;\n" +
-          "<br>" + getSearchFormHtml(language, request, loggedInAs, EDStatic.orCommaAr[language], ":\n<br>", "") +
+          "<br>" + getSearchFormHtml(language, request, loggedInAs, EDStatic.messages.orCommaAr[language], ":\n<br>", "") +
           "<br>" + getCategoryLinksHtml(request, tErddapUrl) +
           "<br>&nbsp;\n" +
           "<br>" + refine);
@@ -7179,14 +7269,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "\n"
                 + "<p>"
-                + EDStatic.restfulInformationFormatsAr[language]
+                + EDStatic.messages.restfulInformationFormatsAr[language]
                 + " \n("
                 + plainFileTypesString
                 + // not links, which would be indexed by search engines
                 ") <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/rest.html\">"
-                + EDStatic.restfulViaServiceAr[language]
+                + EDStatic.messages.restfulViaServiceAr[language]
                 + "</a>.\n");
       } else {
         writer.write(
@@ -7247,8 +7337,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "SOS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "SOS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "SOS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "SOS")));
     }
     /*
     This isn't finished!   Reference server (ndbcSOS) is in flux and ...
@@ -7302,8 +7392,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], tDatasetID),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], tDatasetID)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], tDatasetID),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], tDatasetID)));
       return;
     }
 
@@ -7415,10 +7505,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // if service= is present, it must be service=SOS     //technically, it is required
       String tService = queryMap.get("service");
       if (tService != null && !tService.equals("SOS"))
-        // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal
+        // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+        // "deal
         // with SOS error"
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "service='"
                 + tService
                 + "' must be 'SOS'.");
@@ -7455,11 +7546,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           String version = queryMap.get("version"); // map keys are lowercase
 
           if (version == null || !version.equals(EDDTable.sosVersion))
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "version='"
                     + version
                     + "' must be '"
@@ -7471,11 +7563,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           String outputFormat = queryMap.get("outputformat"); // map keys are lowercase
 
           if (outputFormat == null || !outputFormat.equals(EDDTable.sosDSOutputFormat))
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "outputFormat='"
                     + outputFormat
                     + "' must be '"
@@ -7486,11 +7579,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           String procedure = queryMap.get("procedure"); // map keys are lowercase
 
           if (procedure == null)
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "procedure=''.  Please specify a procedure.");
           String sensorGmlNameStart = eddTable.getSosGmlNameStart("sensor");
           String shortName =
@@ -7506,11 +7600,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           if (!shortName.equals(eddTable.datasetID())
               && // all
               eddTable.sosOfferings.indexOf(shortName) < 0) // 1 station
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "procedure="
                     + procedure
                     + " isn't a valid long or short sensor name.");
@@ -7523,9 +7618,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           //        sensor.equals(EDV.TIME_NAME) ||
           //
           // sensor.equals(eddTable.dataVariableDestinationNames()[eddTable.sosOfferingIndex]))
-          //    this format EDStatic.queryErrorAr[0] + "xxx=" is parsed by Erddap section "deal with
+          //    this format EDStatic.messages.queryErrorAr[0] + "xxx=" is parsed by Erddap section
+          // "deal with
           // SOS error"
-          //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          //    throw new SimpleException(EDStatic.simpleBilingual(language,
+          // EDStatic.messages.queryErrorAr)
           // +
           //        "procedure=" + procedure + " isn't valid because \"" + sensor + "\" isn't valid
           // sensor name.");
@@ -7547,11 +7644,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
           String fileTypeName = EDDTable.sosResponseFormatToFileTypeName(responseFormat);
           if (fileTypeName == null)
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "responseFormat="
                     + responseFormat
                     + " is invalid.");
@@ -7594,11 +7692,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           return;
         }
         default ->
-            // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+            // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap
+            // section
             // "deal
             // with SOS error"
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "request="
                     + tRequest
                     + " is not supported.");
@@ -7641,8 +7740,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         String locator = null; // default
 
         // catch InvalidParameterValue
-        // Look for EDStatic.queryErrorAr[language] + "xxx="
-        String qe = EDStatic.queryErrorAr[language];
+        // Look for EDStatic.messages.queryErrorAr[language] + "xxx="
+        String qe = EDStatic.messages.queryErrorAr[language];
         int qepo = error.indexOf(qe);
         int epo = error.indexOf('=');
         if (qepo >= 0 && epo > qepo && epo - qepo < 17 + 20) {
@@ -7702,8 +7801,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "SOS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "SOS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "SOS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "SOS")));
       return;
     }
 
@@ -7720,9 +7819,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.SOSAr[language])
+              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.SOSAr[language])
               + "\n"
-              + EDStatic.sosOverview1Ar[language]
+              + EDStatic.messages
+                  .sosOverview1Ar[language]
                   .replaceAll("&tErddapUrl;", tErddapUrl)
                   .replaceAll("&encodedDefaultPIppQuery;", EDStatic.encodedDefaultPIppQuery)
               +
@@ -7739,8 +7839,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "<p>" +
               */
               String2.replaceAll(
-                  EDStatic.sosLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
-              + EDStatic.sosOverview2Ar[language]
+                  EDStatic.messages.sosLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+              + EDStatic.messages
+                  .sosOverview2Ar[language]
                   .replace("&tErddapUrl;", tErddapUrl)
                   .replace("&encodedDefaultPIppQuery;", EDStatic.encodedDefaultPIppQuery)
               +
@@ -7802,8 +7903,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WCS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WCS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WCS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WCS")));
       return;
     }
 
@@ -7853,8 +7954,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], tDatasetID),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], tDatasetID)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], tDatasetID),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], tDatasetID)));
       return;
     }
 
@@ -7950,7 +8051,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String tService = queryMap.get("service");
       if (tService != null && !tService.equals("WCS"))
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "service='"
                 + tService
                 + "' must be 'WCS'.");
@@ -8005,7 +8106,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           int fi = String2.caseInsensitiveIndexOf(EDDGrid.wcsRequestFormats100, requestFormat);
           if (fi < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "format="
                     + requestFormat
                     + " isn't supported.");
@@ -8020,7 +8121,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               fileExtension = EDDGrid.imageFileTypeExtensions.get(efe);
             } else {
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "format="
                       + requestFormat
                       + " isn't supported!");
@@ -8045,7 +8146,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
         default ->
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "request='"
                     + tRequest
                     + "' is not supported.");
@@ -8118,8 +8219,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WCS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WCS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WCS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WCS")));
       return;
     }
 
@@ -8136,11 +8237,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.WCSAr[language])
+              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.WCSAr[language])
               +
               // EDStatic.youAreHere(language, loggedInAs, "Web Coverage Service (WCS)") +
               "\n"
-              + EDStatic.wcsOverview1Ar[language]
+              + EDStatic.messages
+                  .wcsOverview1Ar[language]
                   .replace("&tErddapUrl;", tErddapUrl)
                   .replace("&encodedDefaultPIppQuery;", EDStatic.encodedDefaultPIppQuery)
               +
@@ -8161,10 +8263,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "\n"
               + "<p>"
               + String2.replaceAll(
-                  EDStatic.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                  EDStatic.messages.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
               + "\n"
-              + EDStatic.wcsOverview2Ar[language].replace(
-                  "&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+              + EDStatic.messages.wcsOverview2Ar[language].replace(
+                  "&externalLinkHtml;", EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               +
               // "\n" +
               // "<p>WCS clients send HTTP POST or GET requests (specially formed URLs) to the WCS
@@ -8218,8 +8320,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
 
@@ -8316,8 +8418,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], tDatasetID),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], tDatasetID)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], tDatasetID),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], tDatasetID)));
       return;
     }
 
@@ -8400,9 +8502,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // error
     throw new SimpleException(
-        EDStatic.queryErrorAr[0]
+        EDStatic.messages.queryErrorAr[0]
             + MessageFormat.format(
-                EDStatic.queryErrorInvalidAr[0], "endEnd=" + String2.toJson(endEnd)));
+                EDStatic.messages.queryErrorInvalidAr[0], "endEnd=" + String2.toJson(endEnd)));
   }
 
   /**
@@ -8434,8 +8536,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
 
@@ -8448,7 +8550,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // must be service=WMS     but I don't require it
       // String tService = queryMap.get("service");
       // if (tService == null || !tService.equals("WMS"))
-      //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+      //    throw new SimpleException(EDStatic.simpleBilingual(language,
+      // EDStatic.messages.queryErrorAr) +
       //        "service='" + tService + "' must be 'WMS'.");
 
       // deal with different request=
@@ -8470,7 +8573,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // if (tRequest.equals("GetFeatureInfo")) { //optional, not yet supported
 
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "request='"
               + tRequest
               + "' isn't supported.");
@@ -8542,8 +8645,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
 
@@ -8638,7 +8741,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "/wms/"
               + EDStatic.wmsSampleDatasetID
               + "/index.html\">"
-              + EDStatic.likeThisAr[language]
+              + EDStatic.messages.likeThisAr[language]
               + "</a>";
       String datasetListRef =
           "  See the <a rel=\"bookmark\" href=\""
@@ -8656,24 +8759,29 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           // see almost identical documentation at ...
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, "wms", EDStatic.documentationAr[language])
+              + EDStatic.youAreHere(
+                  language, loggedInAs, "wms", EDStatic.messages.documentationAr[language])
               +
               // EDStatic.youAreHere(language, loggedInAs, "wms", "Documentation") +
               String2.replaceAll(
-                  EDStatic.wmsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                  EDStatic.messages.wmsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
               + "\n"
               + datasetListRef
               +
               // "<p>\n" +
-              EDStatic.WMSDocumentation1Ar[language]
-                  .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+              EDStatic.messages
+                  .WMSDocumentation1Ar[language]
+                  .replaceAll(
+                      "&externalLinkHtml;",
+                      EDStatic.messages.externalLinkHtml(language, tErddapUrl))
                   .replaceAll("&tErddapUrl;", tErddapUrl)
                   .replace("&WMSSERVER;", EDD.WMS_SERVER)
                   .replace("&e0;", e0)
                   .replaceAll("&datasetListRef;", datasetListRef)
                   .replaceAll(
                       "&makeAGraphRef;",
-                      EDStatic.magAr[language]) // was link to embed.html link but this is better
+                      EDStatic.messages
+                          .magAr[language]) // was link to embed.html link but this is better
                   .replaceAll("&makeAGraphListRef;", makeAGraphListRef)
                   .replaceAll("&likeThis;", likeThis)
                   .replace(
@@ -8763,9 +8871,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // GetCapabilities
       writer.write(
-          EDStatic.WMSGetCapabilitiesAr[language]
+          EDStatic.messages
+                  .WMSGetCapabilitiesAr[language]
                   .replaceAll("&tWmsGetCapabilities130;", tWmsGetCapabilities130)
-                  .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+                  .replaceAll(
+                      "&externalLinkHtml;",
+                      EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               +
               // "<h2><a class=\"selfLink\" id=\"GetCapabilities\" href=\"#GetCapabilities\"
               // rel=\"bookmark\">Forming GetCapabilities URLs</a></h2>\n" +
@@ -8818,13 +8929,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // getMap
       writer.write(
-          EDStatic.WMSGetMapAr[language]
+          EDStatic.messages
+                  .WMSGetMapAr[language]
                   .replaceAll("&tErddapUrl;", tErddapUrl)
                   .replaceAll("&tWmsOpaqueExample130;", tWmsOpaqueExample130)
                   .replaceAll(
                       "&tWmsOpaqueExample130Replaced;",
                       String2.replaceAll(tWmsOpaqueExample130, "&", "<wbr>&"))
-                  .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+                  .replaceAll(
+                      "&externalLinkHtml;",
+                      EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               +
               // "<h2><a class=\"selfLink\" id=\"GetMap\" href=\"#GetMap\" rel=\"bookmark\">Forming
               // GetMap URLs</a></h2>\n" +
@@ -9037,7 +9151,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "\n");
 
       // notes
-      writer.write(EDStatic.WMSNotesAr[language]);
+      writer.write(EDStatic.messages.WMSNotesAr[language]);
 
       writer.write(
           // 1.3.0 examples
@@ -9070,7 +9184,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "  </tr>\n"
               + "  <tr>\n"
               + "    <td class=\"N\"><strong> In <a rel=\"bookmark\" href=\"https://leafletjs.com\">Leaflet"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a> </strong></td> \n"
               + "    <td><a href=\""
               + tErddapUrl
@@ -9111,7 +9225,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "  </tr>\n"
               + "  <tr>\n"
               + "    <td class=\"N\"><strong> In <a rel=\"bookmark\" href=\"https://leafletjs.com\">Leaflet"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a> </strong></td> \n"
               + "    <td><a href=\""
               + tErddapUrl
@@ -9152,7 +9266,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "  </tr>\n"
               + "  <tr>\n"
               + "    <td class=\"N\"><strong> In <a rel=\"bookmark\" href=\"https://leafletjs.com\">Leaflet"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a> </strong></td> \n"
               + "    <td><a href=\""
               + tErddapUrl
@@ -9205,8 +9319,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
 
@@ -9295,7 +9409,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               return;
             } else {
               String2.log(
-                  EDStatic.errorInternalAr[0]
+                  EDStatic.messages.errorInternalAr[0]
                       + "\"/griddap/\" should have been in "
                       + "EDDGridFromErddap.getNextLocalSourceErddapUrl()="
                       + tUrl
@@ -9319,7 +9433,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (tVersion == null) tVersion = "1.3.0";
       if (!tVersion.equals("1.1.0") && !tVersion.equals("1.1.1") && !tVersion.equals("1.3.0"))
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "VERSION="
                 + tVersion
                 + " must be '1.1.0', '1.1.1', or '1.3.0'.");
@@ -9368,13 +9482,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         exceptions = "XML"; // fall back
         if (tVersion.equals("1.1.0") || tVersion.equals("1.1.1"))
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "EXCEPTIONS="
                   + oExceptions
                   + " must be one of 'application/vnd.ogc.se_xml', 'application/vnd.ogc.se_blank', or 'application/vnd.ogc.se_inimage'.");
         else // 1.3.0+
         throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "EXCEPTIONS="
                   + oExceptions
                   + " must be one of 'XML', 'BLANK', or 'INIMAGE'.");
@@ -9383,7 +9497,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (width < 2 || width > EDD.WMS_MAX_WIDTH) {
         exceptions = "XML"; // fall back
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "WIDTH="
                 + width
                 + " must be between 2 and "
@@ -9393,7 +9507,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (height < 2 || height > EDD.WMS_MAX_HEIGHT) {
         exceptions = "XML"; // fall back
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "HEIGHT="
                 + height
                 + " must be between 2 and "
@@ -9403,7 +9517,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (format == null || !format.equalsIgnoreCase("image/png")) {
         exceptions = "XML"; // fall back
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "FORMAT="
                 + format
                 + " must be image/png.");
@@ -9426,7 +9540,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
       if (layers.length > EDD.WMS_MAX_LAYERS)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The number of LAYERS="
                 + layers.length
                 + " must not be more than "
@@ -9447,7 +9561,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String styles[] = String2.split(stylesCsv, ',');
       if (layers.length != styles.length)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The number of STYLES="
                 + styles.length
                 + " must equal the number of LAYERS="
@@ -9459,7 +9573,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       crs = "CRS:84";
       if (!crs.equals("CRS:84") && !crs.equals("EPSG:4326")) {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "SRS="
                 + crs
                 + " must be EPSG:4326"
@@ -9475,12 +9589,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       if (bboxCsv == null || bboxCsv.length() == 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "BBOX must be specified.");
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                + "BBOX must be specified.");
       // bboxCsv = "-180,-90,180,90";  //be lenient, default to full range
       double bbox[] = String2.toDoubleArray(String2.split(bboxCsv, ','));
       if (bbox.length != 4)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "BBOX length="
                 + bbox.length
                 + " must be 4.");
@@ -9493,13 +9608,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           || !Double.isFinite(maxx)
           || !Double.isFinite(maxy))
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "invalid number in BBOX="
                 + bboxCsv
                 + ".");
       if (minx >= maxx)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "BBOX minx="
                 + minx
                 + " must be < maxx="
@@ -9507,7 +9622,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + ".");
       if (miny >= maxy)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "BBOX miny="
                 + miny
                 + " must be < maxy="
@@ -9614,7 +9729,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         int spo = layers[layeri].indexOf(EDD.WMS_SEPARATOR);
         if (spo <= 0 || spo >= layers[layeri].length() - 1)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "LAYER="
                   + layers[layeri]
                   + " is invalid (invalid separator position).");
@@ -9623,7 +9738,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         EDDGrid eddGrid = gridDatasetHashMap.get(datasetID);
         if (eddGrid == null)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "LAYER="
                   + layers[layeri]
                   + " is invalid (dataset not found).");
@@ -9636,21 +9751,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
         if (eddGrid.accessibleViaWMS().length() > 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "LAYER="
                   + layers[layeri]
                   + " is invalid (not accessible via WMS).");
         int dvi = String2.indexOf(eddGrid.dataVariableDestinationNames(), destVar);
         if (dvi < 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "LAYER="
                   + layers[layeri]
                   + " is invalid (variable not found).");
         EDV tDataVariable = eddGrid.dataVariables()[dvi];
         if (!tDataVariable.hasColorBarMinMax())
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "LAYER="
                   + layers[layeri]
                   + " is invalid (variable doesn't have valid colorBarMinimum/Maximum).");
@@ -9659,7 +9774,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         if (!styles[layeri].isEmpty()
             && !styles[layeri].equalsIgnoreCase("default")) { // nonstandard?  but allow it
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For LAYER="
                   + layers[layeri]
                   + ", STYLE="
@@ -9777,7 +9892,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         double minData = tDataVariable.combinedAttributes().getDouble("colorBarMinimum");
         double maxData = tDataVariable.combinedAttributes().getDouble("colorBarMaximum");
         String palette = tDataVariable.combinedAttributes().getString("colorBarPalette");
-        if (String2.indexOf(EDStatic.palettes, palette) < 0)
+        if (String2.indexOf(EDStatic.messages.palettes, palette) < 0)
           palette = Math2.almostEqual(3, -minData, maxData) ? "BlueWhiteRed" : "Rainbow";
         int nSections = tDataVariable.combinedAttributes().getInt("colorBarNSections");
         if (nSections > 100) nSections = -1;
@@ -9945,8 +10060,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
 
@@ -9956,7 +10071,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tVersion == null) tVersion = "1.3.0";
     if (!tVersion.equals("1.1.0") && !tVersion.equals("1.1.1") && !tVersion.equals("1.3.0"))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "In an ERDDAP WMS getCapabilities query, VERSION="
               + tVersion
               + " is not supported.");
@@ -9980,8 +10095,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.notAvailableAr[0], tDatasetID),
-              MessageFormat.format(EDStatic.notAvailableAr[language], tDatasetID)));
+              MessageFormat.format(EDStatic.messages.notAvailableAr[0], tDatasetID),
+              MessageFormat.format(EDStatic.messages.notAvailableAr[language], tDatasetID)));
       return;
     }
     if (!eddGrid.isAccessibleTo(roles) && !eddGrid.graphsAccessibleToPublic()) {
@@ -10694,8 +10809,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "WMS"),
-              MessageFormat.format(EDStatic.disabledAr[language], "WMS")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "WMS"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "WMS")));
       return;
     }
     boolean wmsClientActive = EDStatic.wmsClientActive;
@@ -10703,7 +10818,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
     if (!tVersion.equals("1.1.0") && !tVersion.equals("1.1.1") && !tVersion.equals("1.3.0"))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "WMS version="
               + tVersion
               + " must be 1.1.0, 1.1.1, or 1.3.0.");
@@ -10738,13 +10853,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     int timei = eddGrid.timeIndex();
     if (loni < 0 || lati < 0)
       throw new SimpleException(
-          EDStatic.resourceNotFoundAr[language]
+          EDStatic.messages.resourceNotFoundAr[language]
               + "datasetID="
               + tDatasetID
               + " doesn't have longitude and latitude dimensions.");
     if (eddGrid.accessibleViaWMS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + eddGrid.accessibleViaWMS());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + eddGrid.accessibleViaWMS());
 
     EDVGridAxis gaa[] = eddGrid.axisVariables();
     String options[][] = new String[gaa.length][];
@@ -10920,7 +11036,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "/griddap/"
               + tDatasetID
               + ".graph\">"
-              + EDStatic.magAr[language]
+              + EDStatic.messages.magAr[language]
               + "</a>";
       writer.write(
           EDStatic.startBodyHtml(
@@ -10938,14 +11054,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "\n<p><span class=\"warningColor\">"
                 + MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[language],
+                    EDStatic.messages.noXxxBecauseAr[language],
                     "Leaflet",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[language], "Leaflet"))
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[language], "Leaflet"))
                 + "</span>\n\n");
       } else if (!thisWmsClientActive) {
         writer.write(
             "\n<p><span class=\"warningColor\">"
-                + MessageFormat.format(EDStatic.noXxxAr[language], "Leaflet")
+                + MessageFormat.format(EDStatic.messages.noXxxAr[language], "Leaflet")
                 + "</span>\n\n");
       } else {
         // write all the leaflet stuff
@@ -10955,7 +11071,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             "<br>"
                 + String2.replaceAll( // these are actually Leaflet instructions
                     String2.replaceAll(
-                        EDStatic.wmsInstructionsAr[language], "&wmsVersion;", tVersion),
+                        EDStatic.messages.wmsInstructionsAr[language], "&wmsVersion;", tVersion),
                     "&erddapUrl;",
                     tErddapUrl));
         StringBuilder tAxisConstraintsSB = new StringBuilder();
@@ -11109,7 +11225,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<h2><a class=\"selfLink\" id=\"description\" href=\"#description\" rel=\"bookmark\">What</a> is WMS?</h2>\n"
               + String2.replaceAll(
-                  EDStatic.wmsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                  EDStatic.messages.wmsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
               + "\n"
               + datasetListRef
               + "\n"
@@ -11118,10 +11234,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<li> <strong>In theory, anyone can download, install, and use WMS client software.</strong>\n"
               + "  <br>Some clients are: \n"
               + "    <a href=\"https://www.esri.com/software/arcgis/\">ArcGIS"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a> and\n"
               + "    <a href=\"http://udig.refractions.net//\">uDig"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a>. \n"
               + "  To make a client work, you would install the software on your computer.\n"
               + "  Then, you would enter the URL of the WMS service into the client.\n"
@@ -11141,21 +11257,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n"
               + "    and selecting the .kml file type (an OGC\n"
               + "  standard) to load images into <a href=\"https://www.google.com/earth/\">Google Earth"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a> provides\n"
               + "     a good (non-WMS) map client.\n"
               + makeAGraphListRef
               + "<li> <strong>Web page authors can embed a WMS client in a web page.</strong>\n"
               + "  <br>For the map above, ERDDAP is using \n"
               + "    <a rel=\"bookmark\" href=\"https://leafletjs.com\">Leaflet"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a>, which is a very versatile WMS client.\n"
               + "  Leaflet doesn't automatically deal with dimensions other than longitude and latitude\n"
               + "  (e.g., time), so you will have to write JavaScript (or other scripting code) to do that.\n"
               + "  (Adventurous JavaScript programmers can look at the Souce Code for this web page.)\n"
               + "  Another commonly used JavaScript WMS client is\n"
               + "    <a rel=\"bookmark\" href=\"https://openlayers.org/\">OpenLayers"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a>.\n"
               + "  <br>&nbsp;\n"
               + "<li> <strong>A person with a browser or a computer program can generate special WMS URLs.</strong>\n"
@@ -11233,7 +11349,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
     String fileIconsDir = EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/";
     String questionMarkUrl =
-        EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile;
+        EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile;
 
     String urlParts[] =
         String2.split(
@@ -11267,7 +11383,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (verbose) String2.log(startFailureLog + reason);
       EDStatic.tally.add(startTallySinceStartup, reason);
       EDStatic.tally.add(startTallySinceDailyReport, reason);
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[0] + reason);
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[0] + reason);
       sendResourceNotFoundError(requestNumber, request, response, reason);
       return;
     }
@@ -11325,7 +11441,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (verbose) String2.log(startFailureLog + reason);
       EDStatic.tally.add(startTallySinceStartup, reason);
       EDStatic.tally.add(startTallySinceDailyReport, reason);
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[0] + reason);
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[0] + reason);
       sendResourceNotFoundError(requestNumber, request, response, reason);
       return;
     }
@@ -11385,7 +11501,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (verbose) String2.log(startFailureLog + reason);
       EDStatic.tally.add(startTallySinceStartup, reason);
       EDStatic.tally.add(startTallySinceDailyReport, reason);
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[0] + reason);
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[0] + reason);
       sendResourceNotFoundError(requestNumber, request, response, reason);
       return;
     }
@@ -11503,7 +11619,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (verbose) String2.log(startFailureLog + reason);
       EDStatic.tally.add(startTallySinceStartup, reason);
       EDStatic.tally.add(startTallySinceDailyReport, reason);
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[0] + reason);
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[0] + reason);
       sendResourceNotFoundError(requestNumber, request, response, reason);
       return;
     }
@@ -11513,7 +11629,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (verbose) String2.log(startFailureLog + reason);
     EDStatic.tally.add(startTallySinceStartup, reason);
     EDStatic.tally.add(startTallySinceDailyReport, reason);
-    if (verbose) String2.log(EDStatic.resourceNotFoundAr[0] + reason);
+    if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[0] + reason);
     sendResourceNotFoundError(requestNumber, request, response, reason);
   }
 
@@ -11609,8 +11725,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "GeoServices REST"),
-              MessageFormat.format(EDStatic.disabledAr[language], "GeoServices REST")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "GeoServices REST"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "GeoServices REST")));
       return;
     }
 
@@ -11766,7 +11882,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   // which ESRI makes freely reusable under the Open Web Foundation Agreement
                   "<p>"
                   + String2.replaceAll(
-                      EDStatic.geoServicesDescriptionAr[language], "&erddapUrl;", tErddapUrl)
+                      EDStatic.messages.geoServicesDescriptionAr[language],
+                      "&erddapUrl;",
+                      tErddapUrl)
                   + "\n"
                   +
                   // then mimic ESRI servers  (except for <div>)
@@ -12010,7 +12128,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // just "/rest/services/[tDatasetID]/[tDestName]"
     if (nUrlParts == 4) {
       if (verbose)
-        String2.log(EDStatic.resourceNotFoundAr[language] + "nParts=" + nUrlParts + " !=4");
+        String2.log(
+            EDStatic.messages.resourceNotFoundAr[language] + "nParts=" + nUrlParts + " !=4");
       sendResourceNotFoundError(requestNumber, request, response, "nQueryParts!=4");
       return;
     }
@@ -12019,7 +12138,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // ensure urlParts[4]=ImageServer
     if (!urlParts[4].equals("ImageServer")) {
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "ImageServer expected");
+      if (verbose)
+        String2.log(EDStatic.messages.resourceNotFoundAr[language] + "ImageServer expected");
       sendResourceNotFoundError(requestNumber, request, response, "ImageServer expected");
       return;
     }
@@ -12813,7 +12933,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           } else {
             if (verbose)
               String2.log(
-                  EDStatic.resourceNotFoundAr[language] + "!isFile " + actualDir + tFileName);
+                  EDStatic.messages.resourceNotFoundAr[language]
+                      + "!isFile "
+                      + actualDir
+                      + tFileName);
             sendResourceNotFoundError(requestNumber, request, response, "file doesn't exist");
             return;
           }
@@ -12821,7 +12944,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
         } else {
           if (verbose)
-            String2.log(EDStatic.resourceNotFoundAr[language] + "nParts=" + nUrlParts + " !=7");
+            String2.log(
+                EDStatic.messages.resourceNotFoundAr[language] + "nParts=" + nUrlParts + " !=7");
           sendResourceNotFoundError(requestNumber, request, response, "incorrect nParts");
           return;
         }
@@ -12840,7 +12964,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
       default -> {
         if (verbose)
-          String2.log(EDStatic.resourceNotFoundAr[language] + "unknown [5]=" + urlParts[5]);
+          String2.log(
+              EDStatic.messages.resourceNotFoundAr[language] + "unknown [5]=" + urlParts[5]);
         sendResourceNotFoundError(requestNumber, request, response, "");
         return;
       }
@@ -12881,7 +13006,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         || !String2.isPrintable(requestUrl)
         || requestUrl.indexOf("%0") >= 0) { // percent-encoded ASCII char <16, e.g., %00
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "Some characters are never allowed in requests.");
     }
     String dir = File2.getWebInfParentDirectory() + protocol + "/";
@@ -12995,7 +13120,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             + fileSize
             + (range == null ? "" : ", Range request=" + String2.annotatedString(range));
     String extLC = File2.getExtension(fileNameAndExt).toLowerCase();
-    boolean rangeRequestAllowed = String2.indexOf(EDStatic.extensionsNoRangeRequests, extLC) < 0;
+    boolean rangeRequestAllowed =
+        String2.indexOf(EDStatic.messages.extensionsNoRangeRequests, extLC) < 0;
     if (range != null) {
       if (!rangeRequestAllowed) {
         String2.log(msg);
@@ -13158,7 +13284,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             requestNumber,
             request,
             response,
-            EDStatic.bilingual(language, EDStatic.rssNoAr[0], EDStatic.rssNoAr[language]));
+            EDStatic.bilingual(
+                language, EDStatic.messages.rssNoAr[0], EDStatic.messages.rssNoAr[language]));
         return;
       }
     }
@@ -13181,7 +13308,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           requestNumber,
           request,
           response,
-          EDStatic.bilingual(language, EDStatic.rssNoAr[0], EDStatic.rssNoAr[language]));
+          EDStatic.bilingual(
+              language, EDStatic.messages.rssNoAr[0], EDStatic.messages.rssNoAr[language]));
       return;
     }
 
@@ -13353,9 +13481,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], EDStatic.outOfDateDatasetsAr[0]),
               MessageFormat.format(
-                  EDStatic.disabledAr[language], EDStatic.outOfDateDatasetsAr[language])));
+                  EDStatic.messages.disabledAr[0], EDStatic.messages.outOfDateDatasetsAr[0]),
+              MessageFormat.format(
+                  EDStatic.messages.disabledAr[language],
+                  EDStatic.messages.outOfDateDatasetsAr[language])));
       return;
     }
 
@@ -13367,7 +13497,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String start = "outOfDateDatasets.";
     if (!endOfRequest.startsWith(start))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "An outOfDateDatasets request must start with \""
               + start
               + "\".");
@@ -13378,7 +13508,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       isPlainType = true;
     } else {
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "The fileType must be one of "
               + plainFileTypesString
               + ".");
@@ -13389,7 +13519,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         (EDDTableFromAllDatasets) tableDatasetHashMap.get(EDDTableFromAllDatasets.DATASET_ID);
     if (allDatasets == null)
       throw new SimpleException(
-          EDStatic.resourceNotFoundAr[language] + "outOfDateDatasets is currently not available.");
+          EDStatic.messages.resourceNotFoundAr[language]
+              + "outOfDateDatasets is currently not available.");
 
     // parse queryString
     StringArray resultsVars = new StringArray();
@@ -13434,7 +13565,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // generate html response
-    String shortTitle = EDStatic.outOfDateDatasetsAr[language];
+    String shortTitle = EDStatic.messages.outOfDateDatasetsAr[language];
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
@@ -13504,21 +13635,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // write html response
       writer.write("<div class=\"standard_width\">");
       writer.write(EDStatic.youAreHere(language, loggedInAs, shortTitle));
-      writer.write(XML.encodeAsHTML(EDStatic.advc_outOfDateAr[language]));
+      writer.write(XML.encodeAsHTML(EDStatic.messages.advc_outOfDateAr[language]));
       writer.write("\n<p>");
       if (table.nRows() == 0) {
         writer.write(
             "["
-                + MessageFormat.format(EDStatic.nMatchingAr[language], "0")
+                + MessageFormat.format(EDStatic.messages.nMatchingAr[language], "0")
                 + " "
-                + EDStatic.advn_outOfDateAr[language]
+                + EDStatic.messages.advn_outOfDateAr[language]
                 + "]");
       } else {
         writer.write(
-            MessageFormat.format(EDStatic.nMatchingAr[language], "" + table.nRows())
+            MessageFormat.format(EDStatic.messages.nMatchingAr[language], "" + table.nRows())
                 + " "
                 + MessageFormat.format(
-                    EDStatic.generatedAtAr[language],
+                    EDStatic.messages.generatedAtAr[language],
                     "<span class=\"N\">" + currentTimeZulu + "</span>")
                 + "\n<br>");
         table.saveAsHtmlTable(
@@ -13536,18 +13667,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<p>"
               + MessageFormat.format(
-                  EDStatic.generatedAtAr[language],
+                  EDStatic.messages.generatedAtAr[language],
                   "<span class=\"N\">" + currentTimeZulu + "</span>")
               + "\n<br>"
-              + MessageFormat.format(EDStatic.autoRefreshAr[language], "" + refreshEveryNMinutes)
+              + MessageFormat.format(
+                  EDStatic.messages.autoRefreshAr[language], "" + refreshEveryNMinutes)
               + "\n");
 
       // addConstraints
       writer.write(
           "<h3><a class=\"selfLink\" id=\"Options\" href=\"#Options\" rel=\"bookmark\">"
-              + EDStatic.optionsAr[language]
+              + EDStatic.messages.optionsAr[language]
               + "</a></h3>\n"
-              + XML.encodeAsHTML(EDStatic.addConstraintsAr[language])
+              + XML.encodeAsHTML(EDStatic.messages.addConstraintsAr[language])
               + "<br><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/"
@@ -13557,20 +13689,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "/"
               + start
               + "html?&amp;outOfDate&gt;=0.5</a> .\n"
-              + String2.replaceAll(EDStatic.percentEncodeAr[language], "&erddapUrl;", tErddapUrl));
+              + String2.replaceAll(
+                  EDStatic.messages.percentEncodeAr[language], "&erddapUrl;", tErddapUrl));
 
       // list plain file types
       writer.write(
           "\n"
               + "<p>"
-              + EDStatic.restfulInformationFormatsAr[language]
+              + EDStatic.messages.restfulInformationFormatsAr[language]
               + " \n("
               + plainFileTypesString
               + // not links, which would be indexed by search engines
               ") <a rel=\"help\" href=\""
               + tErddapUrl
               + "/rest.html\">"
-              + EDStatic.restfulViaServiceAr[language]
+              + EDStatic.messages.restfulViaServiceAr[language]
               + "</a>.\n");
 
       writer.write("</div>\n");
@@ -13613,8 +13746,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "SlideSorter"),
-              MessageFormat.format(EDStatic.disabledAr[language], "SlideSorter")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "SlideSorter"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "SlideSorter")));
       return;
     }
 
@@ -13630,7 +13763,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String gapPx = gap + "px";
     int defaultContentWidth = 360;
     String bgColor = "#ffffff"; // before ERDDAP v2: was "#d7dcdd" here; ERDDAP was "#ccccff";
-    String ssBePatientAlt = "alt=\"" + EDStatic.ssBePatientAr[language] + "\" ";
+    String ssBePatientAlt = "alt=\"" + EDStatic.messages.ssBePatientAr[language] + "\" ";
 
     // DON'T use GET-style params, use POST-style (request.getParameter)
 
@@ -13650,7 +13783,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "slidesorter.html", // was endOfRequest,
             queryString,
-            EDStatic.slideSorterAr[language],
+            EDStatic.messages.slideSorterAr[language],
             out);
     try {
       writer.write(HtmlWidgets.dragDropScript(EDStatic.imageDirUrl(loggedInAs, language)));
@@ -13658,9 +13791,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           EDStatic.youAreHereWithHelp(
               language,
               loggedInAs,
-              EDStatic.slideSorterAr[language],
+              EDStatic.messages.slideSorterAr[language],
               "<div class=\"standard_max_width\">"
-                  + EDStatic.ssInstructionsHtmlAr[language]
+                  + EDStatic.messages.ssInstructionsHtmlAr[language]
                   + "</div>"));
       writer.write(HtmlWidgets.ifJavaScriptDisabled + "\n");
 
@@ -13766,8 +13899,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           ext = pngExts[tSize];
           tUrl = preExt + pngExts[tSize] + qAndPost;
 
-          contentWidth = EDStatic.imageWidths[tSize];
-          contentHeight = EDStatic.imageHeights[tSize];
+          contentWidth = EDStatic.messages.imageWidths[tSize];
+          contentHeight = EDStatic.messages.imageHeights[tSize];
           content =
               "<img src=\""
                   + XML.encodeAsHTMLAttribute(tUrl)
@@ -13793,13 +13926,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               || lcExt.equals(".jpeg")
               || lcExt.equals(".jpg")) {
             // give all images a fixed square size
-            contentWidth = EDStatic.imageWidths[tSize];
+            contentWidth = EDStatic.messages.imageWidths[tSize];
             contentHeight = contentWidth;
           } else {
             // everything else is html content
             // sizes: small, wide, wide&high
-            contentWidth = EDStatic.imageWidths[tSize == 0 ? 1 : 2];
-            contentHeight = EDStatic.imageWidths[tSize] * 3 / 4; // yes, widths; make wide
+            contentWidth = EDStatic.messages.imageWidths[tSize == 0 ? 1 : 2];
+            contentHeight = EDStatic.messages.imageWidths[tSize] * 3 / 4; // yes, widths; make wide
           }
           content =
               "<iframe src=\""
@@ -14031,8 +14164,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             widgets.button(
                 "button",
                 "submit" + newSlide,
-                EDStatic.clickToSubmitAr[language],
-                EDStatic.submitAr[language], // button label
+                EDStatic.messages.clickToSubmitAr[language],
+                EDStatic.messages.submitAr[language], // button label
                 "style=\"cursor:default;\" onClick=\"setHidden(); " + dFormName + ".submit();\""));
         writer.write(
             "</td>\n"
@@ -14121,12 +14254,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           widgets.button(
               "button",
               "submit" + newSlide,
-              EDStatic.clickToSubmitAr[language],
-              EDStatic.submitAr[language], // button label
+              EDStatic.messages.clickToSubmitAr[language],
+              EDStatic.messages.submitAr[language], // button label
               "style=\"cursor:default;\" onClick=\"setHidden(); " + dFormName + ".submit();\""));
       writer.write(
           "<a class=\"selfLink\" id=\"instructions\" href=\"#instructions\" rel=\"bookmark\">&nbsp;</a><p>");
-      writer.write(EDStatic.ssInstructionsHtmlAr[language]);
+      writer.write(EDStatic.messages.ssInstructionsHtmlAr[language]);
       writer.write("</div>\n");
 
       // end form
@@ -14283,11 +14416,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               EDStatic.bilingual(
                   language, // or SC_NO_CONTENT error?
                   MessageFormat.format(
-                      EDStatic.searchWithQueryAr[0],
+                      EDStatic.messages.searchWithQueryAr[0],
                       fileTypeName,
                       "?page=1&itemsPerPage=1000&searchFor=wind+temperature"),
                   MessageFormat.format(
-                      EDStatic.searchWithQueryAr[language],
+                      EDStatic.messages.searchWithQueryAr[language],
                       fileTypeName,
                       "?page=1&itemsPerPage=1000&searchFor=wind+temperature")));
           return;
@@ -14340,13 +14473,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 loggedInAs,
                 "search/index.html", // was endOfRequest,
                 queryString,
-                EDStatic.searchTitleAr[language],
+                EDStatic.messages.searchTitleAr[language],
                 out);
         try {
           // you are here    Search
           writer.write(
               "<div class=\"standard_width\">\n"
-                  + EDStatic.youAreHere(language, loggedInAs, EDStatic.searchTitleAr[language]));
+                  + EDStatic.youAreHere(
+                      language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
           // youAreHereTable);
 
           // display the search form
@@ -14375,7 +14509,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 nMatchingHtml
                     + "\n"
                     + "<span class=\"N\">("
-                    + EDStatic.orRefineSearchWithAr[language]
+                    + EDStatic.messages.orRefineSearchWithAr[language]
                     + getAdvancedSearchLink(language, loggedInAs, queryString)
                     + ")</span>\n"
                     + "<br>&nbsp;\n"); // necessary for the blank line before the table (not <p>)
@@ -14396,14 +14530,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             writer.write(
                 "\n"
                     + "<p>"
-                    + EDStatic.restfulInformationFormatsAr[language]
+                    + EDStatic.messages.restfulInformationFormatsAr[language]
                     + " \n("
                     + plainFileTypesString
                     + // not links, which would be indexed by search engines
                     ") <a rel=\"help\" href=\""
                     + tErddapUrl
                     + "/rest.html\">"
-                    + EDStatic.restfulViaServiceAr[language]
+                    + EDStatic.messages.restfulViaServiceAr[language]
                     + "</a>.\n");
 
           } else {
@@ -14435,7 +14569,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // show the results in other file types
       if (error != null)
         throw new SimpleException(
-            EDStatic.resourceNotFoundAr[language] + error[0] + " " + error[1]);
+            EDStatic.messages.resourceNotFoundAr[language] + error[0] + " " + error[1]);
 
       Table table =
           makePlainDatasetTable(language, loggedInAs, datasetIDs, sortByTitle, fileTypeName);
@@ -14473,13 +14607,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               loggedInAs,
               "search/index.html", // was endOfRequest,
               queryString,
-              EDStatic.searchTitleAr[language],
+              EDStatic.messages.searchTitleAr[language],
               out);
       try {
         // you are here      Search
         writer.write(
             "<div class=\"standard_width\">\n"
-                + EDStatic.youAreHere(language, loggedInAs, EDStatic.searchTitleAr[language]));
+                + EDStatic.youAreHere(
+                    language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
         // youAreHereTable);
 
         // write (error and) search form
@@ -14595,8 +14730,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               niceProtocol,
               out);
       String openSearchDescription =
-          EDStatic.openSearchDescriptionAr[language]
-              .replaceAll("&externalLinkHtml;", EDStatic.externalLinkHtml(language, tErddapUrl))
+          EDStatic.messages
+              .openSearchDescriptionAr[language]
+              .replaceAll(
+                  "&externalLinkHtml;", EDStatic.messages.externalLinkHtml(language, tErddapUrl))
               .replaceAll("&niceProtocol;", niceProtocol)
               .replaceAll("&descriptionUrl;", descriptionUrl)
               .replaceAll("&sampleUrl;", sampleUrl)
@@ -14747,7 +14884,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</SyndicationRight>\n"
                 + "  <AdultContent>false</AdultContent>\n"
                 + "  <Language>"
-                + EDStatic.langCodeAr[language]
+                + EDStatic.messages.langCodeAr[language]
                 + "</Language>\n"
                 + "  <InputEncoding>UTF-8</InputEncoding>\n"
                 + "  <OutputEncoding>UTF-8</OutputEncoding>\n"
@@ -15104,13 +15241,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "/search/advanced.html"
                 + EDStatic.questionQuery(paramString))
         + "\">"
-        + String2.replaceAll(EDStatic.advancedSearchAr[language], " ", "&nbsp;")
+        + String2.replaceAll(EDStatic.messages.advancedSearchAr[language], " ", "&nbsp;")
         + "</a>&nbsp;"
         + EDStatic.htmlTooltipImage(
             language,
             loggedInAs,
             "<div class=\"narrow_max_width\">"
-                + EDStatic.advancedSearchTooltipAr[language]
+                + EDStatic.messages.advancedSearchTooltipAr[language]
                 + "</div>")
         + "</span>";
   }
@@ -15155,7 +15292,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (!endOfRequestUrl.equals("advanced.html")
         && !endsWithPlainFileType(endOfRequestUrl, "advanced")) {
       // unsupported fileType
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "!advanced");
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[language] + "!advanced");
       sendResourceNotFoundError(requestNumber, request, response, "");
       return;
     }
@@ -15200,7 +15337,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         maxLon = td;
       } else {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "minLon="
                 + minLon
                 + " > maxLon="
@@ -15214,7 +15351,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         maxLat = td;
       } else {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "minLat="
                 + minLat
                 + " > maxLat="
@@ -15270,7 +15407,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         maxTimeD = td;
       } else {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "minTime="
                 + minTimeParam
                 + " > maxTime="
@@ -15319,11 +15456,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // protocol
     StringBuilder protocolTooltip =
         new StringBuilder(
-            EDStatic.protocolSearch2HtmlAr[language]
+            EDStatic.messages.protocolSearch2HtmlAr[language]
                 + "\n<p><strong>griddap</strong> - "
-                + EDStatic.EDDGridDapDescriptionAr[language]
+                + EDStatic.messages.EDDGridDapDescriptionAr[language]
                 + "\n<p><strong>tabledap</strong> - "
-                + EDStatic.EDDTableDapDescriptionAr[language]);
+                + EDStatic.messages.EDDTableDapDescriptionAr[language]);
     StringArray protocols = new StringArray();
     protocols.add(ANY);
     protocols.add("griddap");
@@ -15331,17 +15468,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (EDStatic.wmsActive) {
       protocols.add("WMS");
       protocolTooltip.append(
-          "\n<p><strong>WMS</strong> - " + EDStatic.wmsDescriptionHtmlAr[language]);
+          "\n<p><strong>WMS</strong> - " + EDStatic.messages.wmsDescriptionHtmlAr[language]);
     }
     if (EDStatic.wcsActive) {
       protocols.add("WCS");
       protocolTooltip.append(
-          "\n<p><strong>WCS</strong> - " + EDStatic.wcsDescriptionHtmlAr[language]);
+          "\n<p><strong>WCS</strong> - " + EDStatic.messages.wcsDescriptionHtmlAr[language]);
     }
     if (EDStatic.sosActive) {
       protocols.add("SOS");
       protocolTooltip.append(
-          "\n<p><strong>SOS</strong> - " + EDStatic.sosDescriptionHtmlAr[language]);
+          "\n<p><strong>SOS</strong> - " + EDStatic.messages.sosDescriptionHtmlAr[language]);
     }
     String tProt = request.getParameter("protocol");
     int whichProtocol = protocols.indexOfIgnoreCase(tProt);
@@ -15385,7 +15522,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               loggedInAs,
               "search/advanced.html", // was endOfRequest,
               queryString,
-              EDStatic.advancedSearchAr[language],
+              EDStatic.messages.advancedSearchAr[language],
               out);
       try {
         HtmlWidgets widgets =
@@ -15400,16 +15537,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.youAreHere(
                     language,
                     loggedInAs,
-                    EDStatic.advancedSearchAr[language]
+                    EDStatic.messages.advancedSearchAr[language]
                         + " "
                         + EDStatic.htmlTooltipImage(
                             language,
                             loggedInAs,
                             "<div class=\"narrow_max_width\">"
-                                + EDStatic.advancedSearchTooltipAr[language]
+                                + EDStatic.messages.advancedSearchTooltipAr[language]
                                 + "</div>"))
                 + "\n\n"
-                + EDStatic.advancedSearchDirectionsAr[language]
+                + EDStatic.messages.advancedSearchDirectionsAr[language]
                 + "\n"
                 + HtmlWidgets.ifJavaScriptDisabled
                 + "\n"
@@ -15423,15 +15560,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         // full text search...
         writer.write(
             "<p><strong>"
-                + EDStatic.searchFullTextHtmlAr[language]
+                + EDStatic.messages.searchFullTextHtmlAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.searchHintsTooltipAr[language])
+                    language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language])
                 + "\n"
                 + "<br>"
                 + widgets.textField(
                     "searchFor",
-                    MessageFormat.format(EDStatic.searchTipAr[language], "noaa wind"),
+                    MessageFormat.format(EDStatic.messages.searchTipAr[language], "noaa wind"),
                     70,
                     255,
                     searchFor,
@@ -15446,13 +15583,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 widgets.beginTable("class=\"compact nowrap\"")
                 + "<tr>\n"
                 + "  <td colspan=\"2\"><strong>"
-                + EDStatic.categoryTitleHtmlAr[language]
+                + EDStatic.messages.categoryTitleHtmlAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
                     language,
                     loggedInAs,
                     "<div class=\"narrow_max_width\">"
-                        + EDStatic.advancedSearchCategoryTooltipAr[language]
+                        + EDStatic.messages.advancedSearchCategoryTooltipAr[language]
                         + "</div>")
                 + "  </td>\n"
                 + "</tr>\n"
@@ -15483,9 +15620,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
 
         // bounding box...
-        String mapTooltip = EDStatic.advancedSearchMapTooltipAr[language];
-        String lonTooltip = mapTooltip + EDStatic.advancedSearchLonTooltipAr[language];
-        String timeTooltip = EDStatic.advancedSearchTimeTooltipAr[language];
+        String mapTooltip = EDStatic.messages.advancedSearchMapTooltipAr[language];
+        String lonTooltip = mapTooltip + EDStatic.messages.advancedSearchLonTooltipAr[language];
+        String timeTooltip = EDStatic.messages.advancedSearchTimeTooltipAr[language];
         String twoClickMap[] =
             HtmlWidgets.myTwoClickMap540Big(
                 language,
@@ -15503,13 +15640,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 // lon lat time ranges
                 "<tr>\n"
                 + "  <td colspan=\"2\"><strong>"
-                + EDStatic.advancedSearchBoundsAr[language]
+                + EDStatic.messages.advancedSearchBoundsAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
                     language,
                     loggedInAs,
                     "<div class=\"standard_max_width\">"
-                        + EDStatic.advancedSearchRangeTooltipAr[language]
+                        + EDStatic.messages.advancedSearchRangeTooltipAr[language]
                         + "<p>"
                         + lonTooltip
                         + "</div>")
@@ -15520,13 +15657,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 // max lat
                 "<tr>\n"
                 + "  <td class=\"N\">"
-                + EDStatic.advancedSearchMaxLatAr[language]
+                + EDStatic.messages.advancedSearchMaxLatAr[language]
                 + "</td>\n"
                 + "  <td>&nbsp;=&nbsp;"
                 + "    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n"
                 + widgets.textField(
                     "maxLat",
-                    EDStatic.advancedSearchMaxLatAr[language] + " (-90 to 90)<p>" + mapTooltip,
+                    EDStatic.messages.advancedSearchMaxLatAr[language]
+                        + " (-90 to 90)<p>"
+                        + mapTooltip,
                     8,
                     12,
                     (Double.isNaN(maxLat) ? "" : "" + maxLat),
@@ -15539,13 +15678,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 // min max lon
                 "<tr>\n"
                 + "  <td class=\"N\">"
-                + EDStatic.advancedSearchMinMaxLonAr[language]
+                + EDStatic.messages.advancedSearchMinMaxLonAr[language]
                 + "</td>\n"
                 + "  <td>&nbsp;=&nbsp;"
                 + widgets.textField(
                     "minLon",
                     "<div class=\"standard_max_width\">"
-                        + EDStatic.advancedSearchMinLonAr[language]
+                        + EDStatic.messages.advancedSearchMinLonAr[language]
                         + "<p>"
                         + lonTooltip
                         + "</div>",
@@ -15557,7 +15696,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + widgets.textField(
                     "maxLon",
                     "<div class=\"standard_max_width\">"
-                        + EDStatic.advancedSearchMaxLonAr[language]
+                        + EDStatic.messages.advancedSearchMaxLonAr[language]
                         + "<p>"
                         + lonTooltip
                         + "</div>",
@@ -15572,13 +15711,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 // min lat
                 "<tr>\n"
                 + "  <td class=\"N\">"
-                + EDStatic.advancedSearchMinLatAr[language]
+                + EDStatic.messages.advancedSearchMinLatAr[language]
                 + "</td>\n"
                 + "  <td>&nbsp;=&nbsp;"
                 + "    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n"
                 + widgets.textField(
                     "minLat",
-                    EDStatic.advancedSearchMinLatAr[language] + " (-90 to 90)<p>" + mapTooltip,
+                    EDStatic.messages.advancedSearchMinLatAr[language]
+                        + " (-90 to 90)<p>"
+                        + mapTooltip,
                     8,
                     12,
                     (Double.isNaN(minLat) ? "" : "" + minLat),
@@ -15588,8 +15729,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     "button",
                     "",
                     "",
-                    EDStatic.advancedSearchClearHelpAr[language],
-                    EDStatic.advancedSearchClearAr[language],
+                    EDStatic.messages.advancedSearchClearHelpAr[language],
+                    EDStatic.messages.advancedSearchClearAr[language],
                     "onClick='f1.minLon.value=\"\"; f1.maxLon.value=\"\"; "
                         + "f1.minLat.value=\"\"; f1.maxLat.value=\"\"; "
                         + "((document.all)? document.all.rubberBand : "
@@ -15618,12 +15759,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 // time
                 "<tr>\n"
                 + "  <td class=\"N\">"
-                + EDStatic.advancedSearchMinTimeAr[language]
+                + EDStatic.messages.advancedSearchMinTimeAr[language]
                 + "</td>\n"
                 + "  <td>&nbsp;=&nbsp;"
                 + widgets.textField(
                     "minTime",
-                    EDStatic.advancedSearchMinTimeAr[language] + "<p>" + timeTooltip,
+                    EDStatic.messages.advancedSearchMinTimeAr[language] + "<p>" + timeTooltip,
                     27,
                     40,
                     minTimeParam,
@@ -15632,12 +15773,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</tr>\n"
                 + "<tr>\n"
                 + "  <td class=\"N\">"
-                + EDStatic.advancedSearchMaxTimeAr[language]
+                + EDStatic.messages.advancedSearchMaxTimeAr[language]
                 + "</td>\n"
                 + "  <td>&nbsp;=&nbsp;"
                 + widgets.textField(
                     "maxTime",
-                    EDStatic.advancedSearchMaxTimeAr[language] + "<p>" + timeTooltip,
+                    EDStatic.messages.advancedSearchMaxTimeAr[language] + "<p>" + timeTooltip,
                     27,
                     40,
                     maxTimeParam,
@@ -15656,9 +15797,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     "submit",
                     null,
                     null,
-                    EDStatic.searchClickTipAr[language],
+                    EDStatic.messages.searchClickTipAr[language],
                     "<span style=\"font-size:large;\"><strong>"
-                        + EDStatic.searchButtonAr[language]
+                        + EDStatic.messages.searchButtonAr[language]
                         + "</strong></span>",
                     "")
                 + "\n"
@@ -15891,7 +16032,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         // display datasets
         writer.write(
             // "<br>&nbsp;\n" +
-            "<hr>\n" + "<h2>" + EDStatic.advancedSearchResultsAr[language] + "</h2>\n");
+            "<hr>\n" + "<h2>" + EDStatic.messages.advancedSearchResultsAr[language] + "</h2>\n");
         if (searchPerformed) {
           if (resultsTable.nRows() == 0) {
             writer.write(
@@ -15899,10 +16040,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     + XML.encodeAsHTML(MustBe.THERE_IS_NO_DATA)
                     + "</strong>\n"
                     + (searchFor.length() > 0
-                        ? "<br>" + EDStatic.searchSpellingAr[language] + "\n"
+                        ? "<br>" + EDStatic.messages.searchSpellingAr[language] + "\n"
                         : "")
                     + "<br>"
-                    + EDStatic.advancedSearchFewerCriteriaAr[language]
+                    + EDStatic.messages.advancedSearchFewerCriteriaAr[language]
                     + "\n"
                     + "</div>\n"); // which controls width
           } else {
@@ -15936,24 +16077,24 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             writer.write(
                 "\n"
                     + "<p>"
-                    + EDStatic.restfulInformationFormatsAr[language]
+                    + EDStatic.messages.restfulInformationFormatsAr[language]
                     + " \n("
                     + plainFileTypesString
                     + // not links, which would be indexed by search engines
                     ") <a rel=\"help\" href=\""
                     + tErddapUrl
                     + "/rest.html\">"
-                    + EDStatic.restfulViaServiceAr[language]
+                    + EDStatic.messages.restfulViaServiceAr[language]
                     + "</a>.\n"
                     + "<p>"
-                    + EDStatic.advancedSearchErrorHandlingAr[language]
+                    + EDStatic.messages.advancedSearchErrorHandlingAr[language]
                     + "\n");
           }
         } else {
           writer.write(
               MessageFormat.format(
-                  EDStatic.advancedSearchNoCriteriaAr[language],
-                  EDStatic.searchButtonAr[language],
+                  EDStatic.messages.advancedSearchNoCriteriaAr[language],
+                  EDStatic.messages.searchButtonAr[language],
                   tErddapUrl,
                   "" + pipp[1]));
         }
@@ -15991,11 +16132,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.advancedSearchWithCriteriaAr[0], fileTypeName),
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.advancedSearchWithCriteriaAr[language], fileTypeName)));
+                        EDStatic.messages.advancedSearchWithCriteriaAr[0], fileTypeName),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.advancedSearchWithCriteriaAr[language], fileTypeName)));
       }
     }
   }
@@ -16280,7 +16422,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         throw new SimpleException(
-            EDStatic.resourceNotFoundAr[language] + EDStatic.searchNotAvailableAr[language], t);
+            EDStatic.messages.resourceNotFoundAr[language]
+                + EDStatic.messages.searchNotAvailableAr[language],
+            t);
       }
     }
 
@@ -16480,11 +16624,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           //    EDStatic.encodedPassThroughPIppQueryPage1(request) + "\">" +
           // EDStatic.viewAllDatasetsHtml + "</a>\n" +
           //// Or, search text
-          // "<p>" + getSearchFormHtml(language, request, loggedInAs, EDStatic.orCommaAr[language],
+          // "<p>" + getSearchFormHtml(language, request, loggedInAs,
+          // EDStatic.messages.orCommaAr[language],
           // ":\n<br>", "") +
           // Use <p> below if other options above are enabled.
           "<span class=\"N\">("
-              + EDStatic.orRefineSearchWithAr[language]
+              + EDStatic.messages.orRefineSearchWithAr[language]
               + getAdvancedSearchLink(
                   language,
                   loggedInAs,
@@ -16492,7 +16637,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + ")</span>\n";
 
     String youAreHere =
-        EDStatic.youAreHere(language, loggedInAs, EDStatic.categoryTitleHtmlAr[language]);
+        EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.categoryTitleHtmlAr[language]);
     // String youAreHereTable =
     //    getYouAreHereTable(youAreHere, refine) +
     //    "\n" + HtmlWidgets.ifJavaScriptDisabled + "\n";
@@ -16533,7 +16678,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               fileTypeName);
         } else {
           if (verbose)
-            String2.log(EDStatic.resourceNotFoundAr[language] + "not index" + fileTypeName);
+            String2.log(
+                EDStatic.messages.resourceNotFoundAr[language] + "not index" + fileTypeName);
           sendResourceNotFoundError(requestNumber, request, response, "");
           return;
         }
@@ -16639,7 +16785,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         } else {
           if (verbose)
             String2.log(
-                EDStatic.resourceNotFoundAr[language] + "unknown categoryName=" + categoryName);
+                EDStatic.messages.resourceNotFoundAr[language]
+                    + "unknown categoryName="
+                    + categoryName);
           sendResourceNotFoundError(requestNumber, request, response, "");
           return;
         }
@@ -16664,7 +16812,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 writer,
                 request,
                 MessageFormat.format(
-                    EDStatic.categoryNotAnOptionAr[language], attributeInURL, categoryName));
+                    EDStatic.messages.categoryNotAnOptionAr[language],
+                    attributeInURL,
+                    categoryName));
             writer.write("<hr>\n");
           }
           writer.write("<p>");
@@ -16823,7 +16973,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "<h3>3) "
                 + MessageFormat.format(
-                    EDStatic.resultsOfSearchForAr[language],
+                    EDStatic.messages.resultsOfSearchForAr[language],
                     "\n<span class=\"N\"><kbd>"
                         + attributeInURL
                         + " = "
@@ -16853,14 +17003,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "\n"
                 + "<p>"
-                + EDStatic.restfulInformationFormatsAr[language]
+                + EDStatic.messages.restfulInformationFormatsAr[language]
                 + " \n("
                 + plainFileTypesString
                 + // not links, which would be indexed by search engines
                 ") <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/rest.html\">"
-                + EDStatic.restfulViaServiceAr[language]
+                + EDStatic.messages.restfulViaServiceAr[language]
                 + "</a>.\n");
 
         writer.write("</div>\n");
@@ -16876,7 +17026,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "end of doCategorize");
+    if (verbose)
+      String2.log(EDStatic.messages.resourceNotFoundAr[language] + "end of doCategorize");
     sendResourceNotFoundError(requestNumber, request, response, "");
   }
 
@@ -16936,8 +17087,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unsupportedFileTypeAr[0], fileTypeName),
-              MessageFormat.format(EDStatic.unsupportedFileTypeAr[language], fileTypeName)));
+              MessageFormat.format(EDStatic.messages.unsupportedFileTypeAr[0], fileTypeName),
+              MessageFormat.format(
+                  EDStatic.messages.unsupportedFileTypeAr[language], fileTypeName)));
       return;
     }
     EDStatic.tally.add("Info File Type (since startup)", fileTypeName);
@@ -17005,7 +17157,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 "info/index.html", // was endOfRequest,
                 queryString,
                 MessageFormat.format(
-                    EDStatic.listOfDatasetsAr[language], EDStatic.listAllAr[language]),
+                    EDStatic.messages.listOfDatasetsAr[language],
+                    EDStatic.messages.listAllAr[language]),
                 out);
         try {
           // you are here  View All Datasets
@@ -17044,13 +17197,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                       language,
                       loggedInAs,
                       MessageFormat.format(
-                          EDStatic.listOfDatasetsAr[language], EDStatic.listAllAr[language]))
+                          EDStatic.messages.listOfDatasetsAr[language],
+                          EDStatic.messages.listAllAr[language]))
                   + secondLine
                   + nMatchingHtml);
 
           /*//Or, search text
           "&nbsp;\n" +
-          "<br>" + getSearchFormHtml(language, request, loggedInAs, EDStatic.orCommaAr[language], ":\n<br>", "") +
+          "<br>" + getSearchFormHtml(language, request, loggedInAs, EDStatic.messages.orCommaAr[language], ":\n<br>", "") +
           //Or, by category
           "<p>" + getCategoryLinksHtml(request, tErddapUrl) +
           //Or,
@@ -17070,14 +17224,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             writer.write(
                 "\n"
                     + "<p>"
-                    + EDStatic.restfulInformationFormatsAr[language]
+                    + EDStatic.messages.restfulInformationFormatsAr[language]
                     + " \n("
                     + plainFileTypesString
                     + // not links, which would be indexed by search engines
                     ") <a rel=\"help\" href=\""
                     + tErddapUrl
                     + "/rest.html\">"
-                    + EDStatic.restfulViaServiceAr[language]
+                    + EDStatic.messages.restfulViaServiceAr[language]
                     + "</a>.\n");
           }
 
@@ -17126,7 +17280,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } else {
         if (error != null)
           throw new SimpleException(
-              EDStatic.resourceNotFoundAr[language] + error[0] + " " + error[1]);
+              EDStatic.messages.resourceNotFoundAr[language] + error[0] + " " + error[1]);
 
         Table table = makePlainDatasetTable(language, loggedInAs, tIDs, sortByTitle, fileTypeName);
         sendPlainTable(
@@ -17150,8 +17304,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.infoRequestFormAr[0], EDStatic.warName),
-              MessageFormat.format(EDStatic.infoRequestFormAr[language], EDStatic.warName)));
+              MessageFormat.format(EDStatic.messages.infoRequestFormAr[0], EDStatic.warName),
+              MessageFormat.format(
+                  EDStatic.messages.infoRequestFormAr[language], EDStatic.warName)));
       return;
     }
     String tID = parts[0];
@@ -17164,8 +17319,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[0], tID),
-              MessageFormat.format(EDStatic.unknownDatasetIDAr[language], tID)));
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[0], tID),
+              MessageFormat.format(EDStatic.messages.unknownDatasetIDAr[language], tID)));
       return;
     }
     if (!edd.isAccessibleTo(EDStatic.getRoles(loggedInAs)) && !edd.graphsAccessibleToPublic()) {
@@ -17303,7 +17458,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "info/" + tID + "/index.html", // was endOfRequest,
               queryString,
               MessageFormat.format(
-                  EDStatic.infoAboutFromAr[language], edd.title(), edd.institution()),
+                  EDStatic.messages.infoAboutFromAr[language], edd.title(), edd.institution()),
               out);
       try {
         writer.write("<div class=\"wide_max_width\">\n"); // not standard_width
@@ -17317,7 +17472,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         dsTable.saveAsHtmlTable(writer, "commonBGColor", null, 1, false, -1, false, false);
 
         // html format the valueSA values
-        String externalLinkHtml = EDStatic.externalLinkHtml(language, tErddapUrl);
+        String externalLinkHtml = EDStatic.messages.externalLinkHtml(language, tErddapUrl);
         for (int i = 0; i < valueSA.size(); i++) {
           String s = valueSA.get(i);
           if (String2.isUrl(s)) {
@@ -17336,7 +17491,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
 
         // display the info table
-        writer.write("<h2>" + EDStatic.infoTableTitleHtmlAr[language] + "</h2>");
+        writer.write("<h2>" + EDStatic.messages.infoTableTitleHtmlAr[language] + "</h2>");
 
         // ******** custom table writer (to change color on "variable" rows)
         writer.write("<table class=\"erd commonBGColor\">\n");
@@ -17371,14 +17526,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "\n"
                 + "<p>"
-                + EDStatic.restfulInformationFormatsAr[language]
+                + EDStatic.messages.restfulInformationFormatsAr[language]
                 + " \n("
                 + plainFileTypesString
                 + // not links, which would be indexed by search engines
                 ") <a rel=\"help\" href=\""
                 + tErddapUrl
                 + "/rest.html\">"
-                + EDStatic.restfulViaServiceAr[language]
+                + EDStatic.messages.restfulViaServiceAr[language]
                 + "</a>.\n");
 
         // jsonld
@@ -17414,7 +17569,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "end of doInfo");
+    if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[language] + "end of doInfo");
     sendResourceNotFoundError(requestNumber, request, response, "");
   }
 
@@ -17823,8 +17978,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "subscriptions"),
-              MessageFormat.format(EDStatic.disabledAr[language], "subscriptions")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "subscriptions"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "subscriptions")));
       return;
     }
 
@@ -17897,7 +18052,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         return;
       }
       default -> {
-        if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "end of Subscriptions");
+        if (verbose)
+          String2.log(EDStatic.messages.resourceNotFoundAr[language] + "end of Subscriptions");
         sendResourceNotFoundError(requestNumber, request, response, "");
         return;
       }
@@ -17912,18 +18068,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "subscriptions/index.html", // was endOfRequest,
             queryString,
-            EDStatic.subscriptionsTitleAr[language],
+            EDStatic.messages.subscriptionsTitleAr[language],
             out);
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.subscriptionsTitleAr[language])
-              + EDStatic.subscription0HtmlAr[language]
-              + MessageFormat.format(EDStatic.subscription1HtmlAr[language], tErddapUrl)
+              + EDStatic.youAreHere(
+                  language, loggedInAs, EDStatic.messages.subscriptionsTitleAr[language])
+              + EDStatic.messages.subscription0HtmlAr[language]
+              + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n");
       writer.write(
           "<p><strong>"
-              + EDStatic.optionsAr[language]
+              + EDStatic.messages.optionsAr[language]
               + ":</strong>\n"
               + "<ul>\n"
               + "<li> <a rel=\"bookmark\" href=\""
@@ -17931,28 +18088,28 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "/"
               + Subscriptions.ADD_HTML
               + "\">"
-              + EDStatic.subscriptionAddAr[language]
+              + EDStatic.messages.subscriptionAddAr[language]
               + "</a>\n"
               + "<li> <a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/"
               + Subscriptions.VALIDATE_HTML
               + "\">"
-              + EDStatic.subscriptionValidateAr[language]
+              + EDStatic.messages.subscriptionValidateAr[language]
               + "</a>\n"
               + "<li> <a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/"
               + Subscriptions.LIST_HTML
               + "\">"
-              + EDStatic.subscriptionListAr[language]
+              + EDStatic.messages.subscriptionListAr[language]
               + "</a>\n"
               + "<li> <a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/"
               + Subscriptions.REMOVE_HTML
               + "\">"
-              + EDStatic.subscriptionRemoveAr[language]
+              + EDStatic.messages.subscriptionRemoveAr[language]
               + "</a>\n"
               + "</ul>\n");
       writer.write("</div>\n");
@@ -17978,7 +18135,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   private String requestSubscriptionListHtml(int language, String tErddapUrl, String tEmail) {
     return "<br>&nbsp;\n"
         + "<p>"
-        + EDStatic.subscriptionEmailListAr[language].replace(
+        + EDStatic.messages.subscriptionEmailListAr[language].replace(
             "&subListUrl;",
             tErddapUrl
                 + "/"
@@ -18022,8 +18179,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "subscriptions"),
-              MessageFormat.format(EDStatic.disabledAr[language], "subscriptions")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "subscriptions"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "subscriptions")));
       return;
     }
 
@@ -18050,12 +18207,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tEmail.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionEmailUnspecifiedAr[language]
               + "</span>\n";
     } else if (tEmail.length() > Subscriptions.EMAIL_LENGTH) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailTooLongAr[language]
+              + EDStatic.messages.subscriptionEmailTooLongAr[language]
               + "</span>\n";
     } else if (!String2.isEmailAddress(tEmail)
         || // tests syntax
@@ -18063,13 +18220,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         || tEmail.startsWith("your.email")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailInvalidAr[language]
+              + EDStatic.messages.subscriptionEmailInvalidAr[language]
               + "</span>\n";
     } else if (EDStatic.subscriptions.testEmailValid(tEmail).length()
         > 0) { // tests syntax and blacklist
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailOnBlacklistAr[language]
+              + EDStatic.messages.subscriptionEmailOnBlacklistAr[language]
               + "</span>\n";
     }
     if (trouble.length() > 0)
@@ -18079,19 +18236,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tDatasetID.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionIDUnspecifiedAr[language]
               + "</span>\n";
     } else if (tDatasetID.length() > Subscriptions.DATASETID_LENGTH) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDTooLongAr[language]
+              + EDStatic.messages.subscriptionIDTooLongAr[language]
               + "</span>\n";
       tDatasetID =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
     } else if (!String2.isFileNameSafe(tDatasetID)) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDInvalidAr[language]
+              + EDStatic.messages.subscriptionIDInvalidAr[language]
               + "</span>\n";
       tDatasetID =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18106,7 +18263,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (edd == null) {
         trouble +=
             "<li><span class=\"warningColor\">"
-                + EDStatic.subscriptionIDInvalidAr[language]
+                + EDStatic.messages.subscriptionIDInvalidAr[language]
                 + "</span>\n";
         tDatasetID =
             ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18125,7 +18282,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     } else if (tAction.length() > Subscriptions.ACTION_LENGTH) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionUrlTooLongAr[language]
+              + EDStatic.messages.subscriptionUrlTooLongAr[language]
               + "</span>\n";
       tAction =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18144,14 +18301,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         || tAction.startsWith("https://192.168.")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionUrlInvalidAr[language]
+              + EDStatic.messages.subscriptionUrlInvalidAr[language]
               + "</span>\n";
       tAction =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
     } else if (tAction.indexOf('<') >= 0 || tAction.indexOf('>') >= 0) { // prevent e.g., <script>
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionUrlInvalidAr[language]
+              + EDStatic.messages.subscriptionUrlInvalidAr[language]
               + "</span>\n";
       tAction =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18168,7 +18325,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "subscriptions/add.html", // was endOfRequest,
             queryString,
-            EDStatic.subscriptionAddAr[language],
+            EDStatic.messages.subscriptionAddAr[language],
             out);
     try {
       writer.write(
@@ -18179,19 +18336,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   language,
                   loggedInAs,
                   protocol,
-                  EDStatic.subscriptionsTitleAr,
-                  EDStatic.subscriptionAddAr[language])
-              + EDStatic.subscription0HtmlAr[language]
-              + MessageFormat.format(EDStatic.subscription1HtmlAr[language], tErddapUrl)
+                  EDStatic.messages.subscriptionsTitleAr,
+                  EDStatic.messages.subscriptionAddAr[language])
+              + EDStatic.messages.subscription0HtmlAr[language]
+              + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n"
-              + MessageFormat.format(EDStatic.subscription2HtmlAr[language], tErddapUrl)
+              + MessageFormat.format(EDStatic.messages.subscription2HtmlAr[language], tErddapUrl)
               + "\n");
 
       if (trouble.length() > 0) {
         if (tShowErrors)
           writer.write(
               "<p><span class=\"warningColor\">"
-                  + EDStatic.subscriptionAddErrorAr[language]
+                  + EDStatic.messages.subscriptionAddErrorAr[language]
                   + "</span>\n"
                   + "<ul>\n"
                   + trouble
@@ -18211,12 +18368,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.tally.add("Subscriptions (since startup)", "Add successful");
             EDStatic.tally.add("Subscriptions (since last daily report)", "Add successful");
           }
-          writer.write(EDStatic.subscriptionAddSuccessAr[language] + "\n");
+          writer.write(EDStatic.messages.subscriptionAddSuccessAr[language] + "\n");
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(
               "<p><span class=\"warningColor\">"
-                  + EDStatic.subscriptionAddErrorAr[language]
+                  + EDStatic.messages.subscriptionAddErrorAr[language]
                   + "\n<br>"
                   + XML.encodeAsHTML(MustBe.getShortErrorMessage(t))
                   + "</span>\n");
@@ -18231,41 +18388,41 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
 
       // show the form
-      String urlTT = EDStatic.subscriptionUrlHtmlAr[language];
+      String urlTT = EDStatic.messages.subscriptionUrlHtmlAr[language];
       writer.write(
           widgets.beginForm("addSub", "GET", tErddapUrl + "/" + Subscriptions.ADD_HTML, "")
-              + MessageFormat.format(EDStatic.subscriptionAddHtmlAr[language], tErddapUrl)
+              + MessageFormat.format(EDStatic.messages.subscriptionAddHtmlAr[language], tErddapUrl)
               + "\n"
               + widgets.beginTable("class=\"compact nowrap\"")
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theDatasetIDAr[language]
+              + EDStatic.messages.theDatasetIDAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField(
                   "datasetID",
-                  "For example, " + EDStatic.EDDGridIdExample,
+                  "For example, " + EDStatic.messages.EDDGridIdExample,
                   30,
                   Subscriptions.DATASETID_LENGTH,
                   tDatasetID,
                   "")
               + " ("
-              + EDStatic.requiredAr[language]
+              + EDStatic.messages.requiredAr[language]
               + ")</td>\n"
               + "</tr>\n"
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.yourEmailAddressAr[language]
+              + EDStatic.messages.yourEmailAddressAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("email", "", 53, Subscriptions.EMAIL_LENGTH, tEmail, "")
               + " ("
-              + EDStatic.requiredAr[language]
+              + EDStatic.messages.requiredAr[language]
               + ")</td>\n"
               + "</tr>\n"
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theUrlActionAr[language]
+              + EDStatic.messages.theUrlActionAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("action", urlTT, 53, Subscriptions.ACTION_LENGTH, tAction, "")
@@ -18273,7 +18430,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "    "
               + EDStatic.htmlTooltipImage(language, loggedInAs, urlTT)
               + "  ("
-              + EDStatic.optionalAr[language]
+              + EDStatic.messages.optionalAr[language]
               + ")</td>\n"
               + "</tr>\n"
               + "<tr>\n"
@@ -18281,18 +18438,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.button(
                   "submit",
                   null,
-                  EDStatic.clickToSubmitAr[language],
-                  EDStatic.submitAr[language],
+                  EDStatic.messages.clickToSubmitAr[language],
+                  EDStatic.messages.submitAr[language],
                   "")
               + "\n"
               + "    <br>"
-              + EDStatic.subscriptionAdd2Ar[language]
+              + EDStatic.messages.subscriptionAdd2Ar[language]
               + "\n"
               + "  </td>\n"
               + "</tr>\n"
               + widgets.endTable()
               + widgets.endForm()
-              + EDStatic.subscriptionAbuseAr[language]
+              + EDStatic.messages.subscriptionAbuseAr[language]
               + "\n");
 
       // link to list of subscriptions
@@ -18344,8 +18501,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "subscriptions"),
-              MessageFormat.format(EDStatic.disabledAr[language], "subscriptions")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "subscriptions"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "subscriptions")));
       return;
     }
 
@@ -18360,12 +18517,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tEmail.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionEmailUnspecifiedAr[language]
               + "</span>\n";
     } else if (tEmail.length() > Subscriptions.EMAIL_LENGTH) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailTooLongAr[language]
+              + EDStatic.messages.subscriptionEmailTooLongAr[language]
               + "</span>\n";
     } else if (!String2.isEmailAddress(tEmail)
         || // tests syntax
@@ -18373,13 +18530,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         || tEmail.startsWith("your.email")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailInvalidAr[language]
+              + EDStatic.messages.subscriptionEmailInvalidAr[language]
               + "</span>\n";
     } else if (EDStatic.subscriptions.testEmailValid(tEmail).length()
         > 0) { // tests syntax and blacklist
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionEmailOnBlacklistAr[language]
+              + EDStatic.messages.subscriptionEmailOnBlacklistAr[language]
               + "</span>\n";
     }
     if (trouble.length() > 0)
@@ -18397,7 +18554,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "subscriptions/list.html", // was endOfRequest,
             queryString,
-            EDStatic.subscriptionListAr[language],
+            EDStatic.messages.subscriptionListAr[language],
             out);
     try {
       writer.write(
@@ -18406,17 +18563,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   language,
                   loggedInAs,
                   protocol,
-                  EDStatic.subscriptionsTitleAr,
-                  EDStatic.subscriptionListAr[language])
-              + EDStatic.subscription0HtmlAr[language]
-              + MessageFormat.format(EDStatic.subscription1HtmlAr[language], tErddapUrl)
+                  EDStatic.messages.subscriptionsTitleAr,
+                  EDStatic.messages.subscriptionListAr[language])
+              + EDStatic.messages.subscription0HtmlAr[language]
+              + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n");
 
       if (queryString != null && queryString.length() > 0) {
         if (trouble.length() > 0) {
           writer.write(
               "<p><span class=\"warningColor\">"
-                  + EDStatic.subscriptionListErrorAr[language]
+                  + EDStatic.messages.subscriptionListErrorAr[language]
                   + "</span>\n"
                   + "<ul>\n"
                   + trouble
@@ -18429,7 +18586,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             String tError = EDStatic.email(tEmail, "Subscriptions List", tList);
             if (tError.length() > 0) throw new SimpleException(tError);
 
-            writer.write(EDStatic.subscriptionListSuccessAr[language] + "\n");
+            writer.write(EDStatic.messages.subscriptionListSuccessAr[language] + "\n");
             // end of document
             writer.write("</div>\n");
             endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -18442,7 +18599,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.rethrowClientAbortException(t); // first thing in catch{}
             writer.write(
                 "<p><span class=\"warningColor\">"
-                    + EDStatic.subscriptionListErrorAr[language]
+                    + EDStatic.messages.subscriptionListErrorAr[language]
                     + "\n"
                     + "<br>"
                     + XML.encodeAsHTML(MustBe.getShortErrorMessage(t))
@@ -18460,12 +18617,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // show the form
       writer.write(
           widgets.beginForm("listSub", "GET", tErddapUrl + "/" + Subscriptions.LIST_HTML, "")
-              + MessageFormat.format(EDStatic.subscriptionListHtmlAr[language], tErddapUrl)
+              + MessageFormat.format(EDStatic.messages.subscriptionListHtmlAr[language], tErddapUrl)
               + "\n"
               + widgets.beginTable("class=\"compact\"")
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.yourEmailAddressAr[language]
+              + EDStatic.messages.yourEmailAddressAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("email", "", 60, Subscriptions.EMAIL_LENGTH, tEmail, "")
@@ -18476,14 +18633,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.button(
                   "submit",
                   null,
-                  EDStatic.clickToSubmitAr[language],
-                  EDStatic.submitAr[language],
+                  EDStatic.messages.clickToSubmitAr[language],
+                  EDStatic.messages.submitAr[language],
                   "")
               + "</td>\n"
               + "</tr>\n"
               + widgets.endTable()
               + widgets.endForm()
-              + EDStatic.subscriptionAbuseAr[language]
+              + EDStatic.messages.subscriptionAbuseAr[language]
               + "\n");
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -18529,8 +18686,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "subscriptions"),
-              MessageFormat.format(EDStatic.disabledAr[language], "subscriptions")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "subscriptions"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "subscriptions")));
       return;
     }
 
@@ -18547,12 +18704,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tSubscriptionID.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionIDUnspecifiedAr[language]
               + "</span>\n";
     } else if (!tSubscriptionID.matches("[0-9]{1,10}")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDInvalidAr[language]
+              + EDStatic.messages.subscriptionIDInvalidAr[language]
               + "</span>\n";
       tSubscriptionID =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18561,12 +18718,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tKey.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionKeyUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionKeyUnspecifiedAr[language]
               + "</span>\n";
     } else if (!tKey.matches("[0-9]{1,10}")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionKeyInvalidAr[language]
+              + EDStatic.messages.subscriptionKeyInvalidAr[language]
               + "</span>\n";
       tKey = ""; // Security: if it was bad, don't show it in form (could be malicious java script)
     }
@@ -18582,7 +18739,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "subscriptions/validate.html", // was endOfRequest,
             queryString,
-            EDStatic.subscriptionValidateAr[language],
+            EDStatic.messages.subscriptionValidateAr[language],
             out);
     try {
       writer.write(
@@ -18591,17 +18748,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   language,
                   loggedInAs,
                   protocol,
-                  EDStatic.subscriptionsTitleAr,
-                  EDStatic.subscriptionValidateAr[language])
-              + EDStatic.subscription0HtmlAr[language]
-              + MessageFormat.format(EDStatic.subscription1HtmlAr[language], tErddapUrl)
+                  EDStatic.messages.subscriptionsTitleAr,
+                  EDStatic.messages.subscriptionValidateAr[language])
+              + EDStatic.messages.subscription0HtmlAr[language]
+              + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n");
 
       if (queryString != null && queryString.length() > 0) {
         if (trouble.length() > 0) {
           writer.write(
               "<p><span class=\"warningColor\">"
-                  + EDStatic.subscriptionValidateErrorAr[language]
+                  + EDStatic.messages.subscriptionValidateErrorAr[language]
                   + "</span>\n"
                   + "<ul>\n"
                   + trouble
@@ -18616,14 +18773,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             if (message.length() > 0) {
               writer.write(
                   "<p><span class=\"warningColor\">"
-                      + EDStatic.subscriptionValidateErrorAr[language]
+                      + EDStatic.messages.subscriptionValidateErrorAr[language]
                       + "\n"
                       + "<br>"
                       + message
                       + "</span>\n");
 
             } else {
-              writer.write(EDStatic.subscriptionValidateSuccessAr[language] + "\n");
+              writer.write(EDStatic.messages.subscriptionValidateSuccessAr[language] + "\n");
 
               // tally
               EDStatic.tally.add("Subscriptions (since startup)", "Validate successful");
@@ -18633,7 +18790,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.rethrowClientAbortException(t); // first thing in catch{}
             writer.write(
                 "<p><span class=\"warningColor\">"
-                    + EDStatic.subscriptionValidateErrorAr[language]
+                    + EDStatic.messages.subscriptionValidateErrorAr[language]
                     + "\n"
                     + "<br>"
                     + XML.encodeAsHTML(MustBe.getShortErrorMessage(t))
@@ -18651,12 +18808,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           widgets.beginForm(
                   "validateSub", "GET", tErddapUrl + "/" + Subscriptions.VALIDATE_HTML, "")
-              + MessageFormat.format(EDStatic.subscriptionValidateHtmlAr[language], tErddapUrl)
+              + MessageFormat.format(
+                  EDStatic.messages.subscriptionValidateHtmlAr[language], tErddapUrl)
               + "\n"
               + widgets.beginTable("class=\"compact\"")
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theSubscriptionIDAr[language]
+              + EDStatic.messages.theSubscriptionIDAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("subscriptionID", "", 15, 15, tSubscriptionID, "")
@@ -18664,7 +18822,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theKeyAr[language]
+              + EDStatic.messages.theKeyAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("key", "", 15, 15, tKey, "")
@@ -18675,8 +18833,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.button(
                   "submit",
                   null,
-                  EDStatic.clickToSubmitAr[language],
-                  EDStatic.submitAr[language],
+                  EDStatic.messages.clickToSubmitAr[language],
+                  EDStatic.messages.submitAr[language],
                   "")
               + "</td>\n"
               + "</tr>\n"
@@ -18729,8 +18887,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "subscriptions"),
-              MessageFormat.format(EDStatic.disabledAr[language], "subscriptions")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "subscriptions"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "subscriptions")));
       return;
     }
 
@@ -18747,12 +18905,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tSubscriptionID.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionIDUnspecifiedAr[language]
               + "</span>\n";
     } else if (!tSubscriptionID.matches("[0-9]{1,10}")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionIDInvalidAr[language]
+              + EDStatic.messages.subscriptionIDInvalidAr[language]
               + "</span>\n";
       tSubscriptionID =
           ""; // Security: if it was bad, don't show it in form (could be malicious java script)
@@ -18761,12 +18919,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (tKey.length() == 0) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionKeyUnspecifiedAr[language]
+              + EDStatic.messages.subscriptionKeyUnspecifiedAr[language]
               + "</span>\n";
     } else if (!tKey.matches("[0-9]{1,10}")) {
       trouble +=
           "<li><span class=\"warningColor\">"
-              + EDStatic.subscriptionKeyInvalidAr[language]
+              + EDStatic.messages.subscriptionKeyInvalidAr[language]
               + "</span>\n";
       tKey = ""; // Security: if it was bad, don't show it in form (could be malicious java script)
     }
@@ -18782,7 +18940,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             loggedInAs,
             "subscriptions/remove.html", // was endOfRequest,
             queryString,
-            EDStatic.subscriptionRemoveAr[language],
+            EDStatic.messages.subscriptionRemoveAr[language],
             out);
     try {
       writer.write(
@@ -18791,17 +18949,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   language,
                   loggedInAs,
                   protocol,
-                  EDStatic.subscriptionsTitleAr,
-                  EDStatic.subscriptionRemoveAr[language])
-              + EDStatic.subscription0HtmlAr[language]
-              + MessageFormat.format(EDStatic.subscription1HtmlAr[language], tErddapUrl)
+                  EDStatic.messages.subscriptionsTitleAr,
+                  EDStatic.messages.subscriptionRemoveAr[language])
+              + EDStatic.messages.subscription0HtmlAr[language]
+              + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n");
 
       if (queryString != null && queryString.length() > 0) {
         if (trouble.length() > 0) {
           writer.write(
               "<p><span class=\"warningColor\">"
-                  + EDStatic.subscriptionRemoveErrorAr[language]
+                  + EDStatic.messages.subscriptionRemoveErrorAr[language]
                   + "</span>\n"
                   + "<ul>\n"
                   + trouble
@@ -18816,12 +18974,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             if (message.length() > 0)
               writer.write(
                   "<p><span class=\"warningColor\">"
-                      + EDStatic.subscriptionRemoveErrorAr[language]
+                      + EDStatic.messages.subscriptionRemoveErrorAr[language]
                       + "\n"
                       + "<br>"
                       + message
                       + "</span>\n");
-            else writer.write(EDStatic.subscriptionRemoveSuccessAr[language] + "\n");
+            else writer.write(EDStatic.messages.subscriptionRemoveSuccessAr[language] + "\n");
 
             // tally
             EDStatic.tally.add("Subscriptions (since startup)", "Remove successful");
@@ -18830,7 +18988,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.rethrowClientAbortException(t); // first thing in catch{}
             writer.write(
                 "<p><span class=\"warningColor\">"
-                    + EDStatic.subscriptionRemoveErrorAr[language]
+                    + EDStatic.messages.subscriptionRemoveErrorAr[language]
                     + "\n"
                     + "<br>"
                     + XML.encodeAsHTML(MustBe.getShortErrorMessage(t))
@@ -18849,12 +19007,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // show the form
       writer.write(
           widgets.beginForm("removeSub", "GET", tErddapUrl + "/" + Subscriptions.REMOVE_HTML, "")
-              + MessageFormat.format(EDStatic.subscriptionRemoveHtmlAr[language], tErddapUrl)
+              + MessageFormat.format(
+                  EDStatic.messages.subscriptionRemoveHtmlAr[language], tErddapUrl)
               + "\n"
               + widgets.beginTable("class=\"compact\"")
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theSubscriptionIDAr[language]
+              + EDStatic.messages.theSubscriptionIDAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("subscriptionID", "", 15, 15, tSubscriptionID, "")
@@ -18862,7 +19021,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</tr>\n"
               + "<tr>\n"
               + "  <td>"
-              + EDStatic.theKeyAr[language]
+              + EDStatic.messages.theKeyAr[language]
               + ":&nbsp;</td>\n"
               + "  <td>"
               + widgets.textField("key", "", 15, 15, tKey, "")
@@ -18873,8 +19032,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.button(
                   "submit",
                   null,
-                  EDStatic.clickToSubmitAr[language],
-                  EDStatic.submitAr[language],
+                  EDStatic.messages.clickToSubmitAr[language],
+                  EDStatic.messages.submitAr[language],
                   "")
               + "</td>\n"
               + "</tr>\n"
@@ -18885,7 +19044,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           requestSubscriptionListHtml(language, tErddapUrl, "")
               + "<br>"
-              + EDStatic.subscriptionRemove2Ar[language]
+              + EDStatic.messages.subscriptionRemove2Ar[language]
               + "\n");
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -18931,8 +19090,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -18983,7 +19142,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         String2.log(MustBe.throwableToString(t));
-        throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+        throw new SimpleException(
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
       }
       return;
 
@@ -19031,7 +19191,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         String2.log(MustBe.throwableToString(t));
-        throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+        throw new SimpleException(
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
       }
       return;
 
@@ -19064,7 +19225,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         String2.log(MustBe.throwableToString(t));
-        throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+        throw new SimpleException(
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
       }
       return;
 
@@ -19152,7 +19314,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           queryString);
       return;
     } else {
-      if (verbose) String2.log(EDStatic.resourceNotFoundAr[language] + "end of convert");
+      if (verbose) String2.log(EDStatic.messages.resourceNotFoundAr[language] + "end of convert");
       sendResourceNotFoundError(requestNumber, request, response, "");
       return;
     }
@@ -19171,10 +19333,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.convertAr[language])
+              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.convertAr[language])
               +
               // EDStatic.youAreHere(language, loggedInAs, "convert") +
-              EDStatic.convertHtmlAr[language]
+              EDStatic.messages.convertHtmlAr[language]
               + "\n"
               +
               // "<p>Options:\n" +
@@ -19182,56 +19344,56 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/oceanicAtmosphericAcronyms.html\"><strong>"
-              + EDStatic.acronymsAr[language]
+              + EDStatic.messages.acronymsAr[language]
               + "</strong></a> - "
-              + EDStatic.convertOAAcronymsToFromAr[language]
+              + EDStatic.messages.convertOAAcronymsToFromAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/fipscounty.html\"><strong>"
-              + EDStatic.FIPSCountyCodesAr[language]
+              + EDStatic.messages.FIPSCountyCodesAr[language]
               + "</strong></a> - "
-              + EDStatic.convertFipsCountyAr[language]
+              + EDStatic.messages.convertFipsCountyAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/interpolate.html\"><strong>"
-              + EDStatic.interpolateAr[language]
+              + EDStatic.messages.interpolateAr[language]
               + "</strong></a> - "
-              + EDStatic.convertInterpolateAr[language]
+              + EDStatic.messages.convertInterpolateAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/keywords.html\"><strong>"
-              + EDStatic.keywordsAr[language]
+              + EDStatic.messages.keywordsAr[language]
               + "</strong></a> - "
-              + EDStatic.convertKeywordsAr[language]
+              + EDStatic.messages.convertKeywordsAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/time.html\"><strong>"
-              + EDStatic.timeAr[language]
+              + EDStatic.messages.timeAr[language]
               + "</strong></a> - "
-              + EDStatic.convertTimeAr[language]
+              + EDStatic.messages.convertTimeAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/units.html\"><strong>"
-              + EDStatic.unitsAr[language]
+              + EDStatic.messages.unitsAr[language]
               + "</strong></a> - "
-              + EDStatic.convertUnitsAr[language]
+              + EDStatic.messages.convertUnitsAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/urls.html\"><strong>URLs</strong></a> - "
-              + EDStatic.convertURLsAr[language]
+              + EDStatic.messages.convertURLsAr[language]
               + "\n"
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/oceanicAtmosphericVariableNames.html\"><strong>"
-              + EDStatic.variableNamesAr[language]
+              + EDStatic.messages.variableNamesAr[language]
               + "</strong></a> - "
-              + EDStatic.convertOAVariableNamesToFromAr[language]
+              + EDStatic.messages.convertOAVariableNamesToFromAr[language]
               + "\n"
               + "</ul>\n");
       writer.write("</div>\n");
@@ -19276,8 +19438,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -19310,7 +19472,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       String2.log(MustBe.throwableToString(t));
-      throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+      throw new SimpleException(
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
     }
     if (toCode) {
       // process code=,   a toCode query
@@ -19349,7 +19512,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\") at the end of the URL.";
       if (tError != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + tError);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + tError);
 
       // respond to a valid request
       OutputStream out =
@@ -19394,15 +19557,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.FIPSCountyCodesAr[language]
+                  + EDStatic.messages.FIPSCountyCodesAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertFipsCountyAr[language]
+              + EDStatic.messages.convertFipsCountyAr[language]
               + "</h2>\n"
-              + EDStatic.convertFipsCountyIntroAr[language]
+              + EDStatic.messages.convertFipsCountyIntroAr[language]
               + "\n");
 
       // Convert from Code to County
@@ -19411,7 +19574,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n"
               + widgets.beginForm("getCounty", "GET", tErddapUrl + "/convert/fipscounty.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToACountyNameAr[language],
+                  EDStatic.messages.convertToACountyNameAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "code",
@@ -19429,7 +19592,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Convert",
                   "",
-                  "<strong>" + EDStatic.convertAr[language] + "</strong>",
+                  "<strong>" + EDStatic.messages.convertAr[language] + "</strong>",
                   "")
               + "\n");
 
@@ -19458,7 +19621,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("getCode", "GET", tErddapUrl + "/convert/fipscounty.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToAFIPSCodeAr[language],
+                  EDStatic.messages.convertToAFIPSCodeAr[language],
                   "</strong>\n"
                       + widgets.select(
                           "county",
@@ -19470,7 +19633,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                       + "\n<strong>")
               + "\n&nbsp;&nbsp;"
               +
-              // widgets.button("submit", null, "", EDStatic.convertAr[language], "") +
+              // widgets.button("submit", null, "", EDStatic.messages.convertAr[language], "") +
               "\n");
 
       if (toCode) {
@@ -19493,10 +19656,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<p><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/fipscounty.html\">"
-              + EDStatic.resetTheFormAr[language]
+              + EDStatic.messages.resetTheFormAr[language]
               + "</a>\n"
               + "<p>"
-              + EDStatic.convertBypassAr[language]
+              + EDStatic.messages.convertBypassAr[language]
               + "\n");
 
       // get the entire list
@@ -19506,11 +19669,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + plainLinkExamples(tErddapUrl, "/convert/fipscounty", ""));
 
       // notes
-      writer.write(EDStatic.convertFipsCountyNotesAr[language]);
+      writer.write(EDStatic.messages.convertFipsCountyNotesAr[language]);
 
       // Info about .txt fips service option
       writer.write(
-          MessageFormat.format(EDStatic.convertFipsCountyServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertFipsCountyServiceAr[language], tErddapUrl)
+              + "\n");
 
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -19555,8 +19719,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -19589,7 +19753,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       String2.log(MustBe.throwableToString(t));
-      throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+      throw new SimpleException(
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
     }
     StringArray acronymSA = (StringArray) oaTable.getColumn(0);
     StringArray fullNameSA = (StringArray) oaTable.getColumn(1);
@@ -19636,7 +19801,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\") at the end of the URL.";
       if (tError != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + tError);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + tError);
 
       // respond to a valid request
       OutputStream out =
@@ -19681,15 +19846,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.convertOAAcronymsAr[language]
+                  + EDStatic.messages.convertOAAcronymsAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertOAAcronymsToFromAr[language]
+              + EDStatic.messages.convertOAAcronymsToFromAr[language]
               + "</h2>\n"
-              + EDStatic.convertOAAcronymsIntroAr[language]
+              + EDStatic.messages.convertOAAcronymsIntroAr[language]
               + "\n");
 
       // Convert from Acronym to FullName
@@ -19699,7 +19864,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.beginForm(
                   "getFullName", "GET", tErddapUrl + "/convert/oceanicAtmosphericAcronyms.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToAFullNameAr[language],
+                  EDStatic.messages.convertToAFullNameAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "acronym",
@@ -19717,7 +19882,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Convert",
                   "",
-                  "<strong>" + EDStatic.convertAr[language] + "</strong>",
+                  "<strong>" + EDStatic.messages.convertAr[language] + "</strong>",
                   "")
               + "\n");
 
@@ -19748,7 +19913,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.beginForm(
                   "getAcronym", "GET", tErddapUrl + "/convert/oceanicAtmosphericAcronyms.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToAnAcronymAr[language],
+                  EDStatic.messages.convertToAnAcronymAr[language],
                   "<br></strong>\n"
                       + widgets.select(
                           "fullName",
@@ -19780,10 +19945,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<p><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/oceanicAtmosphericAcronyms.html\">"
-              + EDStatic.resetTheFormAr[language]
+              + EDStatic.messages.resetTheFormAr[language]
               + "</a>\n"
               + "<p>"
-              + EDStatic.convertBypassAr[language]
+              + EDStatic.messages.convertBypassAr[language]
               + "\n");
 
       // get the entire list
@@ -19793,11 +19958,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + plainLinkExamples(tErddapUrl, "/convert/oceanicAtmosphericAcronyms", ""));
 
       // notes
-      writer.write(EDStatic.convertOAAcronymsNotesAr[language]);
+      writer.write(EDStatic.messages.convertOAAcronymsNotesAr[language]);
 
       // Info about .txt fips service option
       writer.write(
-          MessageFormat.format(EDStatic.convertOAAcronymsServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertOAAcronymsServiceAr[language], tErddapUrl)
+              + "\n");
 
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -19844,8 +20010,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -19879,7 +20045,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       String2.log(MustBe.throwableToString(t));
-      throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + t);
+      throw new SimpleException(
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + t);
     }
     StringArray variableNameSA = (StringArray) oaTable.getColumn(0);
     StringArray fullNameSA = (StringArray) oaTable.getColumn(1);
@@ -19926,7 +20093,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\") at the end of the URL.";
       if (tError != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + tError);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + tError);
 
       // respond to a valid request
       OutputStream out =
@@ -19971,15 +20138,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.convertOAVariableNamesAr[language]
+                  + EDStatic.messages.convertOAVariableNamesAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertOAVariableNamesToFromAr[language]
+              + EDStatic.messages.convertOAVariableNamesToFromAr[language]
               + "</h2>\n"
-              + EDStatic.convertOAVariableNamesIntroAr[language]
+              + EDStatic.messages.convertOAVariableNamesIntroAr[language]
               + "\n");
 
       // Convert from VariableName to FullName
@@ -19992,7 +20159,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   tErddapUrl + "/convert/oceanicAtmosphericVariableNames.html",
                   "")
               + MessageFormat.format(
-                  EDStatic.convertToFullNameAr[language],
+                  EDStatic.messages.convertToFullNameAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "variableName",
@@ -20012,7 +20179,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Convert",
                   "",
-                  "<strong>" + EDStatic.convertAr[language] + "</strong>",
+                  "<strong>" + EDStatic.messages.convertAr[language] + "</strong>",
                   "")
               + "\n");
 
@@ -20047,7 +20214,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   tErddapUrl + "/convert/oceanicAtmosphericVariableNames.html",
                   "")
               + MessageFormat.format(
-                  EDStatic.convertToVariableNameAr[language],
+                  EDStatic.messages.convertToVariableNameAr[language],
                   "</strong>\n"
                       + widgets.select(
                           "fullName",
@@ -20059,7 +20226,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                       + "\n<strong>")
               + "\n&nbsp;&nbsp;"
               +
-              // widgets.button("submit", null, "", EDStatic.convertAr[language], "") +
+              // widgets.button("submit", null, "", EDStatic.messages.convertAr[language], "") +
               "\n");
 
       if (toVariableName) {
@@ -20082,10 +20249,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<p><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/oceanicAtmosphericVariableNames.html\">"
-              + EDStatic.resetTheFormAr[language]
+              + EDStatic.messages.resetTheFormAr[language]
               + "</a>\n"
               + "<p>"
-              + EDStatic.convertBypassAr[language]
+              + EDStatic.messages.convertBypassAr[language]
               + "\n");
 
       // get the entire list
@@ -20095,11 +20262,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + plainLinkExamples(tErddapUrl, "/convert/oceanicAtmosphericVariableNames", ""));
 
       // notes
-      writer.write(EDStatic.convertOAVariableNamesNotesAr[language]);
+      writer.write(EDStatic.messages.convertOAVariableNamesNotesAr[language]);
 
       // Info about .txt service option
       writer.write(
-          MessageFormat.format(EDStatic.convertOAVariableNamesServiceAr[language], tErddapUrl)
+          MessageFormat.format(
+                  EDStatic.messages.convertOAVariableNamesServiceAr[language], tErddapUrl)
               + "\n");
 
       writer.write("</div>\n");
@@ -20145,8 +20313,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -20207,7 +20375,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\") at the end of the URL.";
       if (tError != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + tError);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + tError);
 
       // respond to a valid request
       OutputStream out =
@@ -20248,15 +20416,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.keywordsAr[language]
+                  + EDStatic.messages.keywordsAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertKeywordsAr[language]
+              + EDStatic.messages.convertKeywordsAr[language]
               + "</h2>\n"
-              + EDStatic.convertKeywordsIntroAr[language]
+              + EDStatic.messages.convertKeywordsIntroAr[language]
               + "\n");
 
       // Convert from CF to GCMD
@@ -20266,11 +20434,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n"
               + widgets.beginForm("getGCMD", "GET", tErddapUrl + "/convert/keywords.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToGCMDAr[language],
+                  EDStatic.messages.convertToGCMDAr[language],
                   "</strong>\n<br>"
                       + widgets.select(
                           "cf",
-                          EDStatic.convertKeywordsCfTooltipAr[language],
+                          EDStatic.messages.convertKeywordsCfTooltipAr[language],
                           1,
                           CfToFromGcmd.cfNames,
                           String2.indexOf(CfToFromGcmd.cfNames, selectedCF),
@@ -20303,11 +20471,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("getCF", "GET", tErddapUrl + "/convert/keywords.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToCFStandardNamesAr[language],
+                  EDStatic.messages.convertToCFStandardNamesAr[language],
                   "</strong>\n<br>"
                       + widgets.select(
                           "gcmd",
-                          EDStatic.convertKeywordsGcmdTooltipAr[language],
+                          EDStatic.messages.convertKeywordsGcmdTooltipAr[language],
                           1,
                           CfToFromGcmd.gcmdKeywords,
                           String2.indexOf(CfToFromGcmd.gcmdKeywords, selectedGCMD),
@@ -20340,11 +20508,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<li><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/keywords.html\">"
-              + EDStatic.resetTheFormAr[language]
+              + EDStatic.messages.resetTheFormAr[language]
               + "</a>\n"
               + "  <br>&nbsp;\n"
               + "<li>"
-              + EDStatic.convertBypassAr[language]
+              + EDStatic.messages.convertBypassAr[language]
               + "\n"
               + "  <br>&nbsp;\n"
               +
@@ -20359,14 +20527,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "  <br>"
               + plainLinkExamples(tErddapUrl, "/convert/keywordsCf", "")
               + "  <br>Source: <a rel=\"bookmark\" href=\"https://cfconventions.org/Data/cf-standard-names/18/build/cf-standard-name-table.html\">Version 18, dated 22 July 2011"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a>.\n"
               + "  <br>&nbsp;\n"
               + "<li>View/download the entire GCMD Science Keywords list in these file types:"
               + "  <br>"
               + plainLinkExamples(tErddapUrl, "/convert/keywordsGcmd", "")
               + "  <br>Source: <a rel=\"bookmark\" href=\"https://wiki.earthdata.nasa.gov/display/CMR/GCMD+Keyword+Access\">the version dated 2008-02-05"
-              + EDStatic.externalLinkHtml(language, tErddapUrl)
+              + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
               + "</a>.\n"
               + "    The requested citation is<kbd>\n"
               + "  <br>Olsen, L.M., G. Major, K. Shein, J. Scialdone, R. Vogel, S. Leicester,\n"
@@ -20377,11 +20545,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       // notes
-      writer.write(EDStatic.convertKeywordsNotesAr[language]);
+      writer.write(EDStatic.messages.convertKeywordsNotesAr[language]);
 
       // Info about .txt time service option
       writer.write(
-          MessageFormat.format(EDStatic.convertKeywordsServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertKeywordsServiceAr[language], tErddapUrl)
+              + "\n");
 
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -20443,8 +20612,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -20534,15 +20703,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.interpolateAr[language]
+                  + EDStatic.messages.interpolateAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertInterpolateAr[language]
+              + EDStatic.messages.convertInterpolateAr[language]
               + "</h2>\n"
-              + MessageFormat.format(EDStatic.convertInterpolateIntroAr[language], idVarExample));
+              + MessageFormat.format(
+                  EDStatic.messages.convertInterpolateIntroAr[language], idVarExample));
 
       // convert
       String tableCSV = "tableCSV";
@@ -20553,9 +20723,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.beginForm(formName, "GET", tErddapUrl + "/convert/interpolate.html", "")
               + widgets.beginTable("class=\"compact\"")
               + "<tr><td>"
-              + EDStatic.convertInterpolateTLLTableAr[language]
+              + EDStatic.messages.convertInterpolateTLLTableAr[language]
               + EDStatic.htmlTooltipImage(
-                  language, loggedInAs, EDStatic.convertInterpolateTLLTableHelpAr[language])
+                  language,
+                  loggedInAs,
+                  EDStatic.messages.convertInterpolateTLLTableHelpAr[language])
               + "</td>\n"
               +
               // default maxHttpHeaderSize (in server.xml) is 4096 bytes
@@ -20565,12 +20737,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</textarea>"
               + "</td></tr>\n"
               + "<tr><td>"
-              + EDStatic.convertInterpolateDatasetIDVariableAr[language]
+              + EDStatic.messages.convertInterpolateDatasetIDVariableAr[language]
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
                   MessageFormat.format(
-                      EDStatic.convertInterpolateDatasetIDVariableHelpAr[language], idVarExample))
+                      EDStatic.messages.convertInterpolateDatasetIDVariableHelpAr[language],
+                      idVarExample))
               + "</td>\n"
               + "<td class=\"N\">"
               + widgets.textField(
@@ -20583,7 +20756,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + // other
               "</td></tr>\n"
               + "<tr><td>&nbsp;&nbsp;&nbsp;"
-              + EDStatic.optionsAr[language]
+              + EDStatic.messages.optionsAr[language]
               + ":"
               + "</td>\n"
               + "<td class=\"N\">&nbsp;&nbsp;&nbsp;"
@@ -20633,7 +20806,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "\n"
               + "</td></tr>\n"
               + "<tr><td>"
-              + EDStatic.EDDFileTypeAr[language]
+              + EDStatic.messages.EDDFileTypeAr[language]
               + "</td>\n"
               + "<td>"
               + widgets.select("fileType", "", 1, plainFileTypes, 1, "")
@@ -20643,8 +20816,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   "button",
                   null,
                   "Convert",
-                  EDStatic.clickToSubmitAr[language],
-                  "<strong>" + EDStatic.convertAr[language] + "</strong>",
+                  EDStatic.messages.clickToSubmitAr[language],
+                  "<strong>" + EDStatic.messages.convertAr[language] + "</strong>",
                   "onclick=\"var d = document;\n"
                       + "window.location='"
                       + tErddapUrl
@@ -20658,16 +20831,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.endForm()
               + "\n");
 
-      writer.write("<br>&nbsp;\n" + "<p>" + EDStatic.convertBypassAr[language] + "\n");
+      writer.write("<br>&nbsp;\n" + "<p>" + EDStatic.messages.convertBypassAr[language] + "\n");
 
       // notes
-      writer.write("<p>" + EDStatic.convertInterpolateNotesAr[language] + "\n");
+      writer.write("<p>" + EDStatic.messages.convertInterpolateNotesAr[language] + "\n");
 
       // Info about service / plainFileType option.
       // Safest to just point to jplMURSST41 at coastwatch ERDDAP.
       writer.write(
           MessageFormat.format(
-                  EDStatic.convertInterpolateServiceAr[language],
+                  EDStatic.messages.convertInterpolateServiceAr[language],
                   """
                           <pre><a rel="help" \
                           href="https://coastwatch.pfeg.noaa.gov/erddap/convert/interpolate.htmlTable?TimeLatLonTable=time%2Clatitude%2Clongitude%0A2020-01-01T06%3A00%3A00Z%2C35.580%2C-122.550%0A2020-01-01T12%3A00%3A00Z%2C35.576%2C-122.553%0A2020-01-01T18%3A00%3A00Z%2C35.572%2C-122.568%0A2020-01-02T00%3A00%3A00Z%2C35.569%2C-122.571%0A&amp;requestCSV=jplMURSST41%2Fanalysed_sst%2FBilinear%2F4"\
@@ -20715,14 +20888,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (debugMode) String2.log("\n*** interpolate");
     if (!String2.isSomething(TLLTable))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + MessageFormat.format(
-                  EDStatic.queryErrorInvalidAr[language], "TimeLatLonTable (nothing)"));
+                  EDStatic.messages.queryErrorInvalidAr[language], "TimeLatLonTable (nothing)"));
     if (!String2.isSomething(requestCSV))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + MessageFormat.format(
-                  EDStatic.queryErrorInvalidAr[language], "requestCSV (nothing)"));
+                  EDStatic.messages.queryErrorInvalidAr[language], "requestCSV (nothing)"));
 
     // split requestCSV
     // poor man's enumeration of INTERPOLATE_ALGORITHMS
@@ -20757,13 +20930,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorInvalidAr[0],
+                        EDStatic.messages.queryErrorInvalidAr[0],
                         "datasetID/variable/algorithm/nearby value=\"" + requestParts[dv] + "\""),
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorInvalidAr[language],
+                        EDStatic.messages.queryErrorInvalidAr[language],
                         "datasetID/variable/algorithm/nearby value=\"" + requestParts[dv] + "\"")));
       datasetIDs[dv] = tParts[0];
       variable[dv] = tParts[1];
@@ -20775,15 +20948,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorInvalidAr[0], "algorithm in " + requestParts[dv])
+                        EDStatic.messages.queryErrorInvalidAr[0],
+                        "algorithm in " + requestParts[dv])
                     + " (must be one of "
                     + String2.toCSSVString(INTERPOLATE_ALGORITHMS)
                     + ")",
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorInvalidAr[language], "algorithm in " + requestParts[dv])
+                        EDStatic.messages.queryErrorInvalidAr[language],
+                        "algorithm in " + requestParts[dv])
                     + " (must be one of "
                     + String2.toCSSVString(INTERPOLATE_ALGORITHMS)
                     + ")"));
@@ -20802,13 +20977,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryErrorInvalidAr[0],
+                            EDStatic.messages.queryErrorInvalidAr[0],
                             "For algorithm=Bilinear, 'nearby' must be 4."),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryErrorInvalidAr[language],
+                            EDStatic.messages.queryErrorInvalidAr[language],
                             "For algorithm=Bilinear, 'nearby' must be 4.")));
           is3D[dv] = false;
           radius[dv] = 1;
@@ -20822,12 +20997,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorInvalidAr[0], "'nearby' value in " + requestParts[dv]),
-                  EDStatic.queryErrorAr[language]
+                          EDStatic.messages.queryErrorInvalidAr[0],
+                          "'nearby' value in " + requestParts[dv]),
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorInvalidAr[language],
+                          EDStatic.messages.queryErrorInvalidAr[language],
                           "'nearby' value in " + requestParts[dv])));
         }
       }
@@ -20841,9 +21017,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                MessageFormat.format(EDStatic.errorNotFoundAr[0], "datasetID=" + datasetIDs[dv]),
                 MessageFormat.format(
-                    EDStatic.errorNotFoundAr[language], "datasetID=" + datasetIDs[dv])));
+                    EDStatic.messages.errorNotFoundAr[0], "datasetID=" + datasetIDs[dv]),
+                MessageFormat.format(
+                    EDStatic.messages.errorNotFoundAr[language], "datasetID=" + datasetIDs[dv])));
       edv[dv] =
           eddGrid[dv].findDataVariableByDestinationName(
               variable[dv]); // throws SimpleException if not found
@@ -20873,26 +21050,28 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
-                  + MessageFormat.format(EDStatic.queryErrorInvalidAr[0], "TimeLatLonTable"),
-              EDStatic.queryErrorAr[language]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.queryErrorInvalidAr[language], "TimeLatLonTable")));
+                      EDStatic.messages.queryErrorInvalidAr[0], "TimeLatLonTable"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.queryErrorInvalidAr[language], "TimeLatLonTable")));
     }
     int nRows = sourceTable.nRows();
     if (nRows == 0)
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.queryErrorInvalidAr[0], "TimeLatLonTable (nRows=0)"),
-              EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorInvalidAr[0], "TimeLatLonTable (nRows=0)"),
+              EDStatic.messages.queryErrorAr[language]
                   + MessageFormat.format(
-                      EDStatic.queryErrorInvalidAr[language], "TimeLatLonTable (nRows=0)")));
+                      EDStatic.messages.queryErrorInvalidAr[language],
+                      "TimeLatLonTable (nRows=0)")));
     if (nRows > 100) // I don't object to more, but there is more danger of a timeout.
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "The TLLTable must not have more than 100 rows.");
 
     // manual simplify
@@ -20928,7 +21107,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             new DoubleArray(sourceTimePA); // assume they are already epoch seconds. String->double
       } else {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "Unrecognized string time format in 'time' column.");
       }
     } else {
@@ -21450,7 +21629,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
           } else {
             throw new SimpleException(
-                EDStatic.errorInternalAr[0]
+                EDStatic.messages.errorInternalAr[0]
                     + "Unexpected algorithm="
                     + INTERPOLATE_ALGORITHMS[algorithm[dv]]);
           }
@@ -21514,8 +21693,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -21541,16 +21720,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String answerUnits = "";
     String numberTooltip =
         "<div class=\"narrow_max_width\">"
-            + MessageFormat.format(EDStatic.convertTimeNumberTooltipAr[language], defaultN)
+            + MessageFormat.format(EDStatic.messages.convertTimeNumberTooltipAr[language], defaultN)
             + "</div>";
     String stringTimeTooltip =
         "<div class=\"narrow_max_width\">"
             + MessageFormat.format(
-                EDStatic.convertTimeStringTimeTooltipAr[language], defaultIsoTime)
+                EDStatic.messages.convertTimeStringTimeTooltipAr[language], defaultIsoTime)
             + "</div>";
     String unitsTooltip =
         "<div class=\"narrow_max_width\">"
-            + EDStatic.convertTimeUnitsTooltipAr[language]
+            + EDStatic.messages.convertTimeUnitsTooltipAr[language]
             + "</div>";
 
     // only 0 or 1 of these will be true
@@ -21580,7 +21759,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     String tError = null;
     if (queryStringTime.length() > 0 && queryIsoTime.length() > 0)
-      tError = EDStatic.convertTimeTwoTimeErrorAr[language];
+      tError = EDStatic.messages.convertTimeTwoTimeErrorAr[language];
 
     // a query either succeeds (and sets all answer...)
     //  or fails (doesn't change answer... and sets tError)
@@ -21591,7 +21770,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       int sincePo = queryUnits.toLowerCase().indexOf(" since ");
       if (sincePo <= 0) {
-        unitsError = EDStatic.convertTimeNoSinceErrorAr[language];
+        unitsError = EDStatic.messages.convertTimeNoSinceErrorAr[language];
       } else {
         answerUnits = Calendar2.cleanUpNumericTimeUnits(queryUnits);
         tbf = Calendar2.getTimeBaseAndFactor(answerUnits);
@@ -21599,7 +21778,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       answerUnits = "";
-      unitsError = EDStatic.convertTimeUnitsErrorAr[language];
+      unitsError = EDStatic.messages.convertTimeUnitsErrorAr[language];
     }
 
     // do the calculation
@@ -21608,7 +21787,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       if (cleanString) {
         answerFormat = Calendar2.tryToFindFormat(queryStringTime);
         answerIsoTime = Calendar2.tryToIsoString(queryStringTime);
-        if (answerIsoTime.length() == 0) tError = EDStatic.convertTimeStringFormatErrorAr[language];
+        if (answerIsoTime.length() == 0)
+          tError = EDStatic.messages.convertTimeStringFormatErrorAr[language];
 
       } else if (cleanUnits) {
         // answerUnits already set
@@ -21621,14 +21801,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           // process stringTime=,   a toNumeric query
           queryIsoTime = Calendar2.tryToIsoString(queryStringTime);
           if (queryIsoTime.length() == 0)
-            tError = EDStatic.convertTimeStringFormatErrorAr[language];
+            tError = EDStatic.messages.convertTimeStringFormatErrorAr[language];
         }
 
         if (tError == null) {
           // process isoTime=,   a toNumeric query
           epochSeconds = Calendar2.safeIsoStringToEpochSeconds(queryIsoTime);
           if (Double.isNaN(epochSeconds)) {
-            tError = EDStatic.convertTimeIsoFormatErrorAr[language];
+            tError = EDStatic.messages.convertTimeIsoFormatErrorAr[language];
           } else {
             // success
             answerIsoTime = queryIsoTime;
@@ -21645,7 +21825,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         // process n=,   a toString query
         double tN = String2.parseDouble(queryN);
         if (Double.isNaN(tN)) {
-          tError = EDStatic.convertTimeNumberErrorAr[language];
+          tError = EDStatic.messages.convertTimeNumberErrorAr[language];
         } else if (unitsError != null) {
           tError = unitsError;
         } else {
@@ -21656,7 +21836,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           // epochSeconds + " " +
           //    tbf[0] + ", " + tbf[1] + ", " + tN);
           if (answerIsoTime.length() == 0)
-            tError = EDStatic.convertTimeNumericTimeErrorAr[language];
+            tError = EDStatic.messages.convertTimeNumericTimeErrorAr[language];
           else
             answerN =
                 tN == Math2.roundToLong(tN)
@@ -21675,10 +21855,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // throw exception?
       if (tError == null && !cleanString && !cleanUnits && !toNumeric && !toString)
-        tError = EDStatic.convertTimeParametersErrorAr[language];
+        tError = EDStatic.messages.convertTimeParametersErrorAr[language];
       if (tError != null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + tError);
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + tError);
 
       // respond to a valid request
       OutputStream out =
@@ -21722,15 +21902,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.timeAr[language]
+                  + EDStatic.messages.timeAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertTimeAr[language]
+              + EDStatic.messages.convertTimeAr[language]
               + "</h2>\n"
-              + EDStatic.convertTimeIntroAr[language]
+              + EDStatic.messages.convertTimeIntroAr[language]
               + "\n");
 
       // Convert from a String Time to Numeric Time n units
@@ -21738,7 +21918,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("toNumeric", "GET", tErddapUrl + "/convert/time.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToNumericTimeAr[language],
+                  EDStatic.messages.convertToNumericTimeAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "stringTime",
@@ -21764,7 +21944,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           "")
                       + ".")
               + "\n<br>"
-              + widgets.htmlButton("submit", null, "Convert", "", EDStatic.convertAr[language], "")
+              + widgets.htmlButton(
+                  "submit", null, "Convert", "", EDStatic.messages.convertAr[language], "")
               + "\n");
 
       if (toNumeric) {
@@ -21792,7 +21973,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("toString", "GET", tErddapUrl + "/convert/time.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToStringTimeAr[language],
+                  EDStatic.messages.convertToStringTimeAr[language],
                   "</strong>\n<br>"
                       + widgets.textField(
                           "n",
@@ -21813,7 +21994,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           "")
                       + "\n<br><strong>")
               + "\n"
-              + widgets.htmlButton("submit", null, "Convert", "", EDStatic.convertAr[language], "")
+              + widgets.htmlButton(
+                  "submit", null, "Convert", "", EDStatic.messages.convertAr[language], "")
               + "\n");
 
       if (toString) {
@@ -21838,7 +22020,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("cleanString", "GET", tErddapUrl + "/convert/time.html", "")
               + MessageFormat.format(
-                  EDStatic.convertAnyStringTimeAr[language],
+                  EDStatic.messages.convertAnyStringTimeAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "stringTime",
@@ -21849,7 +22031,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           "")
                       + "\n<br><strong>")
               + "\n"
-              + widgets.htmlButton("submit", null, "Convert", "", EDStatic.convertAr[language], "")
+              + widgets.htmlButton(
+                  "submit", null, "Convert", "", EDStatic.messages.convertAr[language], "")
               + "\n");
 
       if (cleanString) {
@@ -21871,7 +22054,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br>"
               + widgets.beginForm("cleanUnits", "GET", tErddapUrl + "/convert/time.html", "")
               + MessageFormat.format(
-                  EDStatic.convertToProperTimeUnitsAr[language],
+                  EDStatic.messages.convertToProperTimeUnitsAr[language],
                   "</strong>\n"
                       + widgets.textField(
                           "units",
@@ -21882,7 +22065,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           "")
                       + "\n<br><strong>")
               + "\n"
-              + widgets.htmlButton("submit", null, "Convert", "", EDStatic.convertAr[language], "")
+              + widgets.htmlButton(
+                  "submit", null, "Convert", "", EDStatic.messages.convertAr[language], "")
               + "\n");
 
       if (cleanUnits) {
@@ -21903,23 +22087,24 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<br><a rel=\"bookmark\" href=\""
               + tErddapUrl
               + "/convert/time.html\">"
-              + EDStatic.resetTheFormAr[language]
+              + EDStatic.messages.resetTheFormAr[language]
               + "</a>\n"
               + "<p>"
-              + EDStatic.convertBypassAr[language]
+              + EDStatic.messages.convertBypassAr[language]
               + "\n");
 
       // notes
       writer.write(
           MessageFormat.format(
-                  EDStatic.convertTimeNotesAr[language],
+                  EDStatic.messages.convertTimeNotesAr[language],
                   tErddapUrl,
-                  EDStatic.convertTimeUnitsHelpAr[language])
+                  EDStatic.messages.convertTimeUnitsHelpAr[language])
               + "\n");
 
       // Info about .txt time service option
       writer.write(
-          MessageFormat.format(EDStatic.convertTimeServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertTimeServiceAr[language], tErddapUrl)
+              + "\n");
 
       writer.write("</div>\n");
       endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
@@ -21964,8 +22149,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -22002,7 +22187,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // throw exception?
       if (tStandardizeUdunits.length() == 0 && tUdunits.length() == 0 && tUcum.length() == 0) {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "Missing parameter (STANDARDIZE_UDUNITS, UDUNITS or UCUM).");
       }
 
@@ -22048,22 +22233,22 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; "
-                  + EDStatic.unitsAr[language]
+                  + EDStatic.messages.unitsAr[language]
                   + "</h1>\n")
               + "<h2>"
-              + EDStatic.convertUnitsAr[language]
+              + EDStatic.messages.convertUnitsAr[language]
               + "</h2>\n"
-              + EDStatic.convertUnitsIntroAr[language]);
+              + EDStatic.messages.convertUnitsIntroAr[language]);
 
       // convert to ucum
       writer.write(
           "<br>"
               + // necessary for the blank line before start of form (not <p>)
               widgets.beginForm("getUcum", "GET", tErddapUrl + "/convert/units.html", "")
-              + EDStatic.convertFromUDUNITSToUCUMAr[language]
+              + EDStatic.messages.convertFromUDUNITSToUCUMAr[language]
               + "\n"
               + "<br>UDUNITS:\n"
               + widgets.textField(
@@ -22079,7 +22264,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   "")
               + " "
               + widgets.htmlButton(
-                  "submit", null, "Convert to UCUM", "", EDStatic.convertToUCUMAr[language], "")
+                  "submit",
+                  null,
+                  "Convert to UCUM",
+                  "",
+                  EDStatic.messages.convertToUCUMAr[language],
+                  "")
               + "\n");
 
       if (tUdunits.length() == 0) writer.write("<br>&nbsp;\n");
@@ -22097,7 +22287,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<br>"
               + widgets.beginForm("getUdunits", "GET", tErddapUrl + "/convert/units.html", "")
-              + EDStatic.convertFromUCUMToUDUNITSAr[language]
+              + EDStatic.messages.convertFromUCUMToUDUNITSAr[language]
               + "\n"
               + "<br>UCUM:\n"
               + widgets.textField(
@@ -22113,7 +22303,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Convert to UDUNITS",
                   "",
-                  EDStatic.convertToUDUNITSAr[language],
+                  EDStatic.messages.convertToUDUNITSAr[language],
                   "")
               + "\n");
 
@@ -22135,9 +22325,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + // necessary for the blank line before start of form (not <p>)
               widgets.beginForm("standarizeUdunits", "GET", tErddapUrl + "/convert/units.html", "")
               + "<strong>"
-              + EDStatic.orCommaAr[language]
+              + EDStatic.messages.orCommaAr[language]
               + "</strong>\n"
-              + EDStatic.convertStandardizeUDUNITSAr[language]
+              + EDStatic.messages.convertStandardizeUDUNITSAr[language]
               + "\n"
               + "<br>UDUNITS:\n"
               + widgets.textField(
@@ -22157,7 +22347,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Standardize UDUNITS",
                   "",
-                  EDStatic.convertStandardizeUDUNITSAr[language],
+                  EDStatic.messages.convertStandardizeUDUNITSAr[language],
                   "")
               + "\n");
 
@@ -22172,25 +22362,28 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       writer.write(widgets.endForm() + "\n");
 
-      writer.write("<p>" + EDStatic.convertBypassAr[language] + "\n");
+      writer.write("<p>" + EDStatic.messages.convertBypassAr[language] + "\n");
 
       // notes
-      writer.write(EDStatic.convertUnitsNotesAr[language]);
+      writer.write(EDStatic.messages.convertUnitsNotesAr[language]);
       writer.write('\n');
 
       // Info about service / .txt option
       writer.write(
-          MessageFormat.format(EDStatic.convertUnitsServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertUnitsServiceAr[language], tErddapUrl)
+              + "\n");
       writer.write('\n');
 
       // info about syntax differences
-      writer.write(EDStatic.convertUnitsComparisonAr[language]);
+      writer.write(EDStatic.messages.convertUnitsComparisonAr[language]);
       writer.write('\n');
 
       // info about tabledap unitsFilter &units("UCUM")
       writer.write(
           MessageFormat.format(
-                  EDStatic.convertUnitsFilterAr[language], tErddapUrl, EDStatic.units_standard)
+                  EDStatic.messages.convertUnitsFilterAr[language],
+                  tErddapUrl,
+                  EDStatic.units_standard)
               + "\n");
 
       writer.write("</div>\n");
@@ -22236,8 +22429,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           response,
           EDStatic.bilingual(
               language,
-              MessageFormat.format(EDStatic.disabledAr[0], "convert"),
-              MessageFormat.format(EDStatic.disabledAr[language], "convert")));
+              MessageFormat.format(EDStatic.messages.disabledAr[0], "convert"),
+              MessageFormat.format(EDStatic.messages.disabledAr[language], "convert")));
       return;
     }
 
@@ -22255,7 +22448,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // throw exception?
       if (rText.length() == 0) {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "Missing parameter (text).");
       }
 
@@ -22298,20 +22491,20 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTMLAttribute(
                       EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
                   + "\">"
-                  + EDStatic.convertAr[language]
+                  + EDStatic.messages.convertAr[language]
                   + "</a>"
                   + "\n &gt; URLs</h1>\n")
               + "<h2>"
-              + EDStatic.convertURLsAr[language]
+              + EDStatic.messages.convertURLsAr[language]
               + "</h2>\n"
-              + EDStatic.convertURLsIntroAr[language]);
+              + EDStatic.messages.convertURLsIntroAr[language]);
 
       // convert
       writer.write(
           "<p>"
               + widgets.beginForm("convertURLs", "GET", tErddapUrl + "/convert/urls.html", "")
               + "<strong>"
-              + EDStatic.convertURLsAr[language]
+              + EDStatic.messages.convertURLsAr[language]
               + "</strong>\n"
               + "<br>"
               + "<textarea name=\"text\" cols=\"80\" rows=\"6\" maxlength=\"1000\" wrap=\"soft\">"
@@ -22323,7 +22516,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   null,
                   "Convert",
                   "",
-                  "<strong>" + EDStatic.convertAr[language] + "</strong>",
+                  "<strong>" + EDStatic.messages.convertAr[language] + "</strong>",
                   "")
               + "\n");
 
@@ -22334,12 +22527,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(widgets.endForm() + "\n");
 
       // notes
-      writer.write(EDStatic.convertURLsNotesAr[language]);
+      writer.write(EDStatic.messages.convertURLsNotesAr[language]);
       writer.write('\n');
 
       // Info about service / .txt option
       writer.write(
-          MessageFormat.format(EDStatic.convertURLsServiceAr[language], tErddapUrl) + "\n");
+          MessageFormat.format(EDStatic.messages.convertURLsServiceAr[language], tErddapUrl)
+              + "\n");
       writer.write('\n');
 
       writer.write("</div>\n");
@@ -22524,7 +22718,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (brPo < 0) brPo = error.length();
     writer.write(
         "<span class=\"warningColor\">"
-            + EDStatic.errorTitleAr[language]
+            + EDStatic.messages.errorTitleAr[language]
             + ": "
             + error.substring(0, brPo)
             + "</span>"
@@ -22572,7 +22766,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     widgets.enterTextSubmitsForm = true;
     StringBuilder sb = new StringBuilder();
     sb.append(widgets.beginForm("search", "GET", tErddapUrl + "/search/index.html", ""));
-    sb.append(pretext + EDStatic.searchDoFullTextHtmlAr[language] + posttext);
+    sb.append(pretext + EDStatic.messages.searchDoFullTextHtmlAr[language] + posttext);
     int pipp[] = EDStatic.getRequestedPIpp(request);
     sb.append(widgets.hidden("page", "1")); // new search always resets to page 1
     sb.append(widgets.hidden("itemsPerPage", "" + pipp[1]));
@@ -22581,22 +22775,23 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     sb.append(
         widgets.textField(
             "searchFor",
-            MessageFormat.format(EDStatic.searchTipAr[language], "noaa wind"),
+            MessageFormat.format(EDStatic.messages.searchTipAr[language], "noaa wind"),
             40,
             255,
             searchFor,
             ""));
     widgets.htmlTooltips = true;
     sb.append(
-        EDStatic.htmlTooltipImage(language, loggedInAs, EDStatic.searchHintsTooltipAr[language]));
+        EDStatic.htmlTooltipImage(
+            language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language]));
     widgets.htmlTooltips = false;
     sb.append(
         widgets.htmlButton(
             "submit",
             null,
             null,
-            EDStatic.searchClickTipAr[language],
-            EDStatic.searchButtonAr[language],
+            EDStatic.messages.searchClickTipAr[language],
+            EDStatic.messages.searchButtonAr[language],
             ""));
     widgets.htmlTooltips = true;
     sb.append("\n");
@@ -22668,7 +22863,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     int cn = catTable.nRows();
     StringBuilder sb =
         new StringBuilder(
-            EDStatic.orCommaAr[language] + EDStatic.categoryTitleHtmlAr[language] + ":");
+            EDStatic.messages.orCommaAr[language]
+                + EDStatic.messages.categoryTitleHtmlAr[language]
+                + ":");
     for (int row = 0; row < cn; row++) {
       if (row % 4 == 0) sb.append("\n<br>");
       sb.append(catTable.getStringData(0, row) + (row < cn - 1 ? ", \n" : "\n"));
@@ -22703,14 +22900,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       for (int row = 0; row < n; row++)
         sb.append(table.getStringData(0, row) + (row < n - 1 ? ", \n" : ""));
       sb.append(")\n");
-      String tCategoryHtml = String2.replaceAll(EDStatic.categoryHtmlAr[language], "<br>", "");
+      String tCategoryHtml =
+          String2.replaceAll(EDStatic.messages.categoryHtmlAr[language], "<br>", "");
       writer.write(
           "<h3>"
-              + EDStatic.categoryTitleHtmlAr[language]
+              + EDStatic.messages.categoryTitleHtmlAr[language]
               + "</h3>\n"
               + MessageFormat.format(tCategoryHtml, sb.toString())
               + "\n"
-              + EDStatic.category3HtmlAr[language]
+              + EDStatic.messages.category3HtmlAr[language]
               + "\n");
       return;
     }
@@ -22718,13 +22916,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // categorize page
     String tCategoryHtml =
         String2.replaceAll(
-            MessageFormat.format(EDStatic.categoryHtmlAr[language], ""),
+            MessageFormat.format(EDStatic.messages.categoryHtmlAr[language], ""),
             "  ",
             " "); // {0}="" leads to 2 adjacent spaces
     writer.write(
-        // "<h3>" + EDStatic.categoryTitleHtml + "</h3>\n" +
+        // "<h3>" + EDStatic.messages.categoryTitleHtml + "</h3>\n" +
         "<h3>1) "
-            + EDStatic.categoryPickAttributeAr[language]
+            + EDStatic.messages.categoryPickAttributeAr[language]
             + "&nbsp;"
             + EDStatic.htmlTooltipImage(language, loggedInAs, tCategoryHtml)
             + "</h3>\n");
@@ -22773,10 +22971,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     String values[] = categoryInfo(attribute).toArray();
     writer.write(
         "<h3>2) "
-            + MessageFormat.format(EDStatic.categorySearchHtmlAr[language], attributeInURL)
+            + MessageFormat.format(EDStatic.messages.categorySearchHtmlAr[language], attributeInURL)
             + ":&nbsp;"
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.categoryClickHtmlAr[language])
+                language, loggedInAs, EDStatic.messages.categoryClickHtmlAr[language])
             + "</h3>\n");
     if (values.length == 0) {
       writer.write(MustBe.THERE_IS_NO_DATA);
@@ -23065,24 +23263,24 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (EDStatic.wmsActive) table.addColumn("W<br>M<br>S", wmsCol);
     if (EDStatic.filesActive) table.addColumn("Source<br>Data<br>Files", filesCol);
     String accessTip =
-        EDStatic.dtAccessibleAr[language]
+        EDStatic.messages.dtAccessibleAr[language]
             + // "You are logged in and ...
             "<br>\"public\" = "
-            + EDStatic.dtAccessiblePublicAr[language];
+            + EDStatic.messages.dtAccessiblePublicAr[language];
     if (isLoggedIn)
       accessTip +=
           "<br>\"yes\" = "
-              + EDStatic.dtAccessibleYesAr[language]
+              + EDStatic.messages.dtAccessibleYesAr[language]
               + // "You are logged in and ...
               (EDStatic.listPrivateDatasets
-                  ? "<br>\"no\" = " + EDStatic.dtAccessibleNoAr[language]
+                  ? "<br>\"no\" = " + EDStatic.messages.dtAccessibleNoAr[language]
                   : ""); // "You are logged in and ...
     if (EDStatic.authentication.length() > 0
         && !isLoggedIn
         && // this erddap supports logging in
         EDStatic.listPrivateDatasets)
-      accessTip += "<br>\"log in \" = " + EDStatic.dtAccessibleLogInAr[language];
-    accessTip += "<br>\"graphs\" = " + EDStatic.dtAccessibleGraphsAr[language];
+      accessTip += "<br>\"log in \" = " + EDStatic.messages.dtAccessibleLogInAr[language];
+    accessTip += "<br>\"graphs\" = " + EDStatic.messages.dtAccessibleGraphsAr[language];
     if (EDStatic.authentication.length() > 0)
       table.addColumn(
           "Acces-<br>sible<br>" + EDStatic.htmlTooltipImage(language, loggedInAs, accessTip),
@@ -23094,7 +23292,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.erddapHttpsUrl(language)
                 + "/login.html\" "
                 + "title=\""
-                + EDStatic.dtLogInAr[language]
+                + EDStatic.messages.dtLogInAr[language]
                 + "\">log in</a>";
     table.addColumn("Title", titleCol);
     int sortOn = table.addColumn("Plain Title", plainTitleCol);
@@ -23109,7 +23307,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (EDStatic.subscriptionSystemActive) table.addColumn("E<br>mail", emailCol);
     table.addColumn("Institution", institutionCol);
     table.addColumn("Dataset ID", idCol);
-    String externalLinkHtml = EDStatic.externalLinkHtml(language, tErddapUrl);
+    String externalLinkHtml = EDStatic.messages.externalLinkHtml(language, tErddapUrl);
     for (int i = 0; i < datasetIDs.size(); i++) {
       String tId = datasetIDs.get(i);
       EDD edd = gridDatasetHashMap.get(tId);
@@ -23132,7 +23330,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + tId
               + ".html\" "
               + "title=\""
-              + MessageFormat.format(EDStatic.dtDAFAr[language], edd.dapProtocol())
+              + MessageFormat.format(EDStatic.messages.dtDAFAr[language], edd.dapProtocol())
               + "\" "
               + ">data</a>&nbsp;";
       gdCol.add(isAccessible && edd instanceof EDDGrid ? daps : "&nbsp;");
@@ -23145,7 +23343,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + ".subset\" "
                   + "title=\""
-                  + EDStatic.dtSubsetAr[language]
+                  + EDStatic.messages.dtSubsetAr[language]
                   + "\" "
                   + ">set</a>"
               : "&nbsp;");
@@ -23162,7 +23360,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + ".graph\" "
                   + "title=\""
-                  + EDStatic.dtMAGAr[language]
+                  + EDStatic.messages.dtMAGAr[language]
                   + "\" "
                   + ">graph</a>"
               : "&nbsp;");
@@ -23175,7 +23373,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + "/index.html\" "
                   + "title=\""
-                  + EDStatic.dtSOSAr[language]
+                  + EDStatic.messages.dtSOSAr[language]
                   + "\" >"
                   + "S</a>&nbsp;"
               : "&nbsp;");
@@ -23188,7 +23386,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + "/index.html\" "
                   + "title=\""
-                  + EDStatic.dtWCSAr[language]
+                  + EDStatic.messages.dtWCSAr[language]
                   + "\" >"
                   + "C</a>&nbsp;"
               : "&nbsp;");
@@ -23202,7 +23400,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + "/index.html\" "
                   + "title=\""
-                  + EDStatic.dtWMSAr[language]
+                  + EDStatic.messages.dtWMSAr[language]
                   + "\" >"
                   + "M</a>&nbsp;"
               : "&nbsp;");
@@ -23215,7 +23413,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + tId
                   + "/\" "
                   + "title=\""
-                  + EDStatic.dtFilesAr[language]
+                  + EDStatic.messages.dtFilesAr[language]
                   + "\" >"
                   + "files</a>&nbsp;"
               : "&nbsp;");
@@ -23258,7 +23456,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           + ".xml\" "
                           + "title=\""
                           + XML.encodeAsHTMLAttribute(
-                              MessageFormat.format(EDStatic.metadataDownloadAr[language], "FGDC"))
+                              MessageFormat.format(
+                                  EDStatic.messages.metadataDownloadAr[language], "FGDC"))
                           + "\" >F</a>")
                   + "\n"
                   +
@@ -23276,7 +23475,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           + "title=\""
                           + XML.encodeAsHTMLAttribute(
                               MessageFormat.format(
-                                  EDStatic.metadataDownloadAr[language], "ISO 19115-2/19139"))
+                                  EDStatic.messages.metadataDownloadAr[language],
+                                  "ISO 19115-2/19139"))
                           + "\" >&nbsp;I&nbsp;</a>")
                   +
                   // dataset metadata
@@ -23289,7 +23489,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + "/index.html\" "
                   + // here, always .html
                   "title=\""
-                  + EDStatic.clickInfoAr[language]
+                  + EDStatic.messages.clickInfoAr[language]
                   + "\" >M</a>"
                   + "\n&nbsp;");
       backgroundCol.add(
@@ -23300,7 +23500,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + XML.encodeAsHTML(edd.infoUrl())
                   + "\" "
                   + "title=\""
-                  + EDStatic.clickBackgroundInfoAr[language]
+                  + EDStatic.messages.clickBackgroundInfoAr[language]
                   + "\" >background"
                   + (edd.infoUrl().startsWith(EDStatic.baseUrl) ? "" : externalLinkHtml)
                   + "</a>");
@@ -23380,14 +23580,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + EDStatic.errorJsonpNotAllowedAr[0],
-                  EDStatic.queryErrorAr[language] + EDStatic.errorJsonpNotAllowedAr[language]));
+                  EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpNotAllowedAr[0],
+                  EDStatic.messages.queryErrorAr[language]
+                      + EDStatic.messages.errorJsonpNotAllowedAr[language]));
         if (!String2.isJsonpNameSafe(jsonp))
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-                  EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+                  EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpFunctionNameAr[0],
+                  EDStatic.messages.queryErrorAr[language]
+                      + EDStatic.messages.errorJsonpFunctionNameAr[language]));
       }
     }
 
@@ -23515,11 +23717,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
-                      + MessageFormat.format(EDStatic.unsupportedFileTypeAr[0], fileTypeName),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.unsupportedFileTypeAr[language], fileTypeName)));
+                          EDStatic.messages.unsupportedFileTypeAr[0], fileTypeName),
+                  EDStatic.messages.queryErrorAr[language]
+                      + MessageFormat.format(
+                          EDStatic.messages.unsupportedFileTypeAr[language], fileTypeName)));
     }
 
     // essential

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/GenerateDatasetsXml.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/GenerateDatasetsXml.java
@@ -36,8 +36,8 @@ public class GenerateDatasetsXml {
   String outFileName = null;
 
   public GenerateDatasetsXml() {
-    logFileName = EDStatic.fullLogsDirectory + "GenerateDatasetsXml.log";
-    outFileName = EDStatic.fullLogsDirectory + "GenerateDatasetsXml.out";
+    logFileName = EDStatic.config.fullLogsDirectory + "GenerateDatasetsXml.log";
+    outFileName = EDStatic.config.fullLogsDirectory + "GenerateDatasetsXml.out";
   }
 
   private void printToBoth(String s) throws IOException {
@@ -113,8 +113,8 @@ public class GenerateDatasetsXml {
 
     try {
       // delete the old-system log files (pre 1.48 names)
-      File2.delete(EDStatic.fullLogsDirectory + "GenerateDatasetsXmlLog.txt");
-      File2.delete(EDStatic.fullLogsDirectory + "GenerateDatasetsXmlLog.txt.previous");
+      File2.delete(EDStatic.config.fullLogsDirectory + "GenerateDatasetsXmlLog.txt");
+      File2.delete(EDStatic.config.fullLogsDirectory + "GenerateDatasetsXmlLog.txt.previous");
 
       if (args == null) args = new String[0];
       String eddType = "EDDGridFromDap";
@@ -1243,7 +1243,10 @@ public class GenerateDatasetsXml {
       String datasetsXmlName = insert.substring(2, npo);
       if (datasetsXmlName.length() == 0) {
         datasetsXmlName =
-            EDStatic.contentDirectory + "datasets" + (EDStatic.developmentMode ? "2" : "") + ".xml";
+            EDStatic.config.contentDirectory
+                + "datasets"
+                + (EDStatic.config.developmentMode ? "2" : "")
+                + ".xml";
         String2.log("datasetsXmlName not specified, so using " + datasetsXmlName);
       }
       if (!File2.isFile(datasetsXmlName))

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -894,12 +894,13 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></commonStandardNames>":
             {
               String ts = xmlReader.content();
-              EDStatic.commonStandardNames =
+              EDStatic.messages.commonStandardNames =
                   String2.isSomething(ts)
                       ? String2.canonical(StringArray.arrayFromCSV(ts))
-                      : EDStatic.DEFAULT_commonStandardNames;
+                      : EDStatic.messages.DEFAULT_commonStandardNames;
               String2.log(
-                  "commonStandardNames=" + String2.toCSSVString(EDStatic.commonStandardNames));
+                  "commonStandardNames="
+                      + String2.toCSSVString(EDStatic.messages.commonStandardNames));
 
               break;
             }
@@ -1058,22 +1059,22 @@ public class LoadDatasets extends Thread {
             String tPalettes[] =
                 String2.isSomething(tContent)
                     ? String2.split(tContent, ',')
-                    : EDStatic.DEFAULT_palettes;
+                    : EDStatic.messages.DEFAULT_palettes;
             // ensure that all of the original palettes are present
             Set<String> newPaletteSet = String2.stringArrayToSet(tPalettes);
             // String2.log(">>> newPaletteSet=" + String2.toCSSVString(newPaletteSet));
             // String2.log(">>> defPaletteSet=" +
-            // String2.toCSSVString(EDStatic.DEFAULT_palettes_set));
+            // String2.toCSSVString(EDStatic.messages.DEFAULT_palettes_set));
 
-            if (!newPaletteSet.containsAll(EDStatic.DEFAULT_palettes_set))
+            if (!newPaletteSet.containsAll(EDStatic.messages.DEFAULT_palettes_set))
               throw new RuntimeException(
                   "The <palettes> tag MUST include all of the palettes listed in the <palettes> tag in messages.xml.");
             String tPalettes0[] = new String[tPalettes.length + 1];
             tPalettes0[0] = "";
             System.arraycopy(tPalettes, 0, tPalettes0, 1, tPalettes.length);
             // then copy into place
-            EDStatic.palettes = tPalettes;
-            EDStatic.palettes0 = tPalettes0;
+            EDStatic.messages.palettes = tPalettes;
+            EDStatic.messages.palettes0 = tPalettes0;
             String2.log("palettes=" + String2.toCSSVString(tPalettes));
 
             break;
@@ -1117,8 +1118,8 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardLicense>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardLicense =
-                  String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardLicense;
+              EDStatic.messages.standardLicense =
+                  String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardLicense;
               String2.log("standardLicense was set.");
 
               break;
@@ -1126,11 +1127,11 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardContact>":
             {
               String ts = xmlReader.content();
-              ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardContactAr[0];
+              ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardContactAr[0];
               ts =
                   String2.replaceAll(
                       ts, "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.adminEmail));
-              EDStatic.standardContactAr[0] = ts; // swap into place
+              EDStatic.messages.standardContactAr[0] = ts; // swap into place
 
               String2.log("standardContact was set.");
 
@@ -1139,8 +1140,10 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardDataLicenses>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardDataLicensesAr[0] =
-                  String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardDataLicensesAr[0];
+              EDStatic.messages.standardDataLicensesAr[0] =
+                  String2.isSomething(ts)
+                      ? ts
+                      : EDStatic.messages.DEFAULT_standardDataLicensesAr[0];
               String2.log("standardDataLicenses was set.");
 
               break;
@@ -1148,10 +1151,10 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardDisclaimerOfEndorsement>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardDisclaimerOfEndorsementAr[0] =
+              EDStatic.messages.standardDisclaimerOfEndorsementAr[0] =
                   String2.isSomething(ts)
                       ? ts
-                      : EDStatic.DEFAULT_standardDisclaimerOfEndorsementAr[0];
+                      : EDStatic.messages.DEFAULT_standardDisclaimerOfEndorsementAr[0];
               String2.log("standardDisclaimerOfEndorsement was set.");
 
               break;
@@ -1159,10 +1162,10 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardDisclaimerOfExternalLinks>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardDisclaimerOfExternalLinksAr[0] =
+              EDStatic.messages.standardDisclaimerOfExternalLinksAr[0] =
                   String2.isSomething(ts)
                       ? ts
-                      : EDStatic.DEFAULT_standardDisclaimerOfExternalLinksAr[0];
+                      : EDStatic.messages.DEFAULT_standardDisclaimerOfExternalLinksAr[0];
               String2.log("standardDisclaimerOfExternalLinks was set.");
 
               break;
@@ -1170,8 +1173,10 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardGeneralDisclaimer>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardGeneralDisclaimerAr[0] =
-                  String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardGeneralDisclaimerAr[0];
+              EDStatic.messages.standardGeneralDisclaimerAr[0] =
+                  String2.isSomething(ts)
+                      ? ts
+                      : EDStatic.messages.DEFAULT_standardGeneralDisclaimerAr[0];
               String2.log("standardGeneralDisclaimer was set.");
 
               break;
@@ -1179,8 +1184,10 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></standardPrivacyPolicy>":
             {
               String ts = xmlReader.content();
-              EDStatic.standardPrivacyPolicyAr[0] =
-                  String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardPrivacyPolicyAr[0];
+              EDStatic.messages.standardPrivacyPolicyAr[0] =
+                  String2.isSomething(ts)
+                      ? ts
+                      : EDStatic.messages.DEFAULT_standardPrivacyPolicyAr[0];
               String2.log("standardPrivacyPolicy was set.");
 
               break;
@@ -1188,14 +1195,14 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></startHeadHtml5>":
             {
               String ts = xmlReader.content();
-              ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_startHeadHtml;
+              ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_startHeadHtml;
               if (!ts.startsWith("<!DOCTYPE html>")) {
                 String2.log(
                     String2.ERROR
                         + " in datasets.xml: <startHeadHtml> must start with \"<!DOCTYPE html>\". Using default <startHeadHtml> instead.");
-                ts = EDStatic.DEFAULT_startHeadHtml;
+                ts = EDStatic.messages.DEFAULT_startHeadHtml;
               }
-              EDStatic.startHeadHtml = ts; // swap into place
+              EDStatic.messages.startHeadHtml = ts; // swap into place
 
               String2.log("startHeadHtml5 was set.");
 
@@ -1204,8 +1211,8 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></startBodyHtml5>":
             {
               String ts = xmlReader.content();
-              ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_startBodyHtmlAr[0];
-              EDStatic.startBodyHtmlAr[0] = ts; // swap into place
+              ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_startBodyHtmlAr[0];
+              EDStatic.messages.startBodyHtmlAr[0] = ts; // swap into place
 
               String2.log("startBodyHtml5 was set.");
 
@@ -1214,8 +1221,11 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></theShortDescriptionHtml>":
             {
               String ts = xmlReader.content();
-              ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_theShortDescriptionHtmlAr[0];
-              EDStatic.theShortDescriptionHtmlAr[0] = ts; // swap into place
+              ts =
+                  String2.isSomething(ts)
+                      ? ts
+                      : EDStatic.messages.DEFAULT_theShortDescriptionHtmlAr[0];
+              EDStatic.messages.theShortDescriptionHtmlAr[0] = ts; // swap into place
 
               String2.log("theShortDescriptionHtml was set.");
 
@@ -1224,9 +1234,9 @@ public class LoadDatasets extends Thread {
           case "<erddapDatasets></endBodyHtml5>":
             {
               String ts = xmlReader.content();
-              EDStatic.endBodyHtmlAr[0] =
+              EDStatic.messages.endBodyHtmlAr[0] =
                   String2.replaceAll(
-                      String2.isSomething(ts) ? ts : EDStatic.DEFAULT_endBodyHtmlAr[0],
+                      String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_endBodyHtmlAr[0],
                       "&erddapVersion;",
                       EDStatic.erddapVersion);
               String2.log("endBodyHtml5 was set.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/RunLoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/RunLoadDatasets.java
@@ -44,7 +44,7 @@ public class RunLoadDatasets extends Thread {
     this.erddap = erddap;
     setName("RunLoadDatasets");
 
-    if (EDStatic.useLuceneSearchEngine) {
+    if (EDStatic.config.useLuceneSearchEngine) {
       EDStatic.resetLuceneIndex();
     }
   }
@@ -75,30 +75,30 @@ public class RunLoadDatasets extends Thread {
         // delete old files in cache
         int nCacheFiles =
             File2.deleteIfOld(
-                EDStatic.fullCacheDirectory, // won't throw exception
-                System.currentTimeMillis() - EDStatic.cacheMillis,
+                EDStatic.config.fullCacheDirectory, // won't throw exception
+                System.currentTimeMillis() - EDStatic.config.cacheMillis,
                 true,
                 false); // false: important not to delete empty dirs
         int nPublicFiles =
             File2.deleteIfOld(
-                EDStatic.fullPublicDirectory,
-                System.currentTimeMillis() - EDStatic.cacheMillis,
+                EDStatic.config.fullPublicDirectory,
+                System.currentTimeMillis() - EDStatic.config.cacheMillis,
                 true,
                 false); // false: important not to delete empty dirs
         String2.log(
             nPublicFiles
                 + " files remain in "
-                + EDStatic.fullPublicDirectory
+                + EDStatic.config.fullPublicDirectory
                 + "\n"
                 + nCacheFiles
                 + " files remain in "
-                + EDStatic.fullCacheDirectory
+                + EDStatic.config.fullCacheDirectory
                 + " and subdirectories.");
 
         // start a new loadDatasets thread
         lastMajorLoadDatasetsStartTimeMillis = System.currentTimeMillis();
         EDStatic.lastMajorLoadDatasetsStartTimeMillis = lastMajorLoadDatasetsStartTimeMillis;
-        loadDatasets = new LoadDatasets(erddap, EDStatic.datasetsRegex, null, true);
+        loadDatasets = new LoadDatasets(erddap, EDStatic.config.datasetsRegex, null, true);
         // make a lower priority
         // [commented out: why lower priority?  It may be causing infrequent problems with a dataset
         // not available in a CWBrowser
@@ -118,7 +118,7 @@ public class RunLoadDatasets extends Thread {
                   + Calendar2.getCurrentISODateTimeStringLocalTZ();
           String content = MustBe.throwableToString(t);
           String2.log(subject + ": " + content);
-          EDStatic.email(EDStatic.emailEverythingToCsv, subject, content);
+          EDStatic.email(EDStatic.config.emailEverythingToCsv, subject, content);
         } catch (Throwable t2) {
           if (Thread.currentThread().isInterrupted() || t2 instanceof InterruptedException)
             break whileNotInterrupted;
@@ -129,7 +129,7 @@ public class RunLoadDatasets extends Thread {
       try {
         whileWait:
         while (System.currentTimeMillis() - lastMajorLoadDatasetsStartTimeMillis
-            < EDStatic.loadDatasetsMaxMillis * 3 / 4) {
+            < EDStatic.config.loadDatasetsMaxMillis * 3 / 4) {
 
           // isInterrupted?
           if (isInterrupted()) break whileNotInterrupted;
@@ -152,7 +152,7 @@ public class RunLoadDatasets extends Thread {
 
           if (loadDatasets == null) {
             if (System.currentTimeMillis() - lastMajorLoadDatasetsStartTimeMillis
-                > EDStatic.loadDatasetsMinMillis) {
+                > EDStatic.config.loadDatasetsMinMillis) {
               // this is a good time to jump out of whileWait loop
               break whileWait;
 
@@ -161,11 +161,11 @@ public class RunLoadDatasets extends Thread {
               // main load datasets finished early; we have free time;
               // so check hardFlag, flag, and badFilesFlag directories
               String fDir[] = {
-                EDStatic.fullHardFlagDirectory, // order is used below. see "hs =="
-                EDStatic
+                EDStatic.config.fullHardFlagDirectory, // order is used below. see "hs =="
+                EDStatic.config
                     .fullResetFlagDirectory, // so safer to add rather than insert new option before
                 // end of list
-                EDStatic.fullBadFilesFlagDirectory
+                EDStatic.config.fullBadFilesFlagDirectory
               };
               String fDirName[] = {"hardFlag", "flag", "badFilesFlag"};
 
@@ -228,7 +228,7 @@ public class RunLoadDatasets extends Thread {
                         EDD.deleteBadFilesFile(ttName); // the important difference
                       }
 
-                      if (ttName.matches(EDStatic.datasetsRegex)) {
+                      if (ttName.matches(EDStatic.config.datasetsRegex)) {
                         // name is okay
 
                         // if edd exists, setCreationTimeTo0 so loadDatasets will reload it
@@ -243,13 +243,13 @@ public class RunLoadDatasets extends Thread {
                         tFlagNames.set(i, ttName);
 
                       } else {
-                        // file name doesn't match EDStatic.datasetsRegex, so ignore it
+                        // file name doesn't match EDStatic.config.datasetsRegex, so ignore it
                         String2.log(
                             "RunloadDatasets is deleting "
                                 + ttName
                                 + " from "
                                 + fDirName[hs]
-                                + " directory because it doesn't match EDStatic.datasetsRegex.");
+                                + " directory because it doesn't match EDStatic.config.datasetsRegex.");
                         tFlagNames.remove(i);
                       }
 
@@ -311,7 +311,7 @@ public class RunLoadDatasets extends Thread {
                   + Calendar2.getCurrentISODateTimeStringLocalTZ();
           String content = MustBe.throwableToString(t);
           String2.log(subject + ": " + content);
-          EDStatic.email(EDStatic.emailEverythingToCsv, subject, content);
+          EDStatic.email(EDStatic.config.emailEverythingToCsv, subject, content);
         } catch (Throwable t2) {
           if (Thread.currentThread().isInterrupted() || t2 instanceof InterruptedException)
             break whileNotInterrupted;
@@ -328,7 +328,7 @@ public class RunLoadDatasets extends Thread {
         while (loadDatasets != null
             && loadDatasets.isAlive()
             && (System.currentTimeMillis() - lastMajorLoadDatasetsStartTimeMillis
-                < EDStatic.loadDatasetsMaxMillis * 3 / 4)) {
+                < EDStatic.config.loadDatasetsMaxMillis * 3 / 4)) {
 
           // isInterrupted?
           if (isInterrupted()) break whileNotInterrupted;
@@ -360,7 +360,7 @@ public class RunLoadDatasets extends Thread {
                   + Calendar2.elapsedTimeString(
                       System.currentTimeMillis() - lastMajorLoadDatasetsStartTimeMillis)
                   + " > 3/4 "
-                  + Calendar2.elapsedTimeString(EDStatic.loadDatasetsMaxMillis)
+                  + Calendar2.elapsedTimeString(EDStatic.config.loadDatasetsMaxMillis)
                   + ") at "
                   + Calendar2.getCurrentISODateTimeStringLocalTZ();
           String2.log("\n*** " + tError);
@@ -368,17 +368,17 @@ public class RunLoadDatasets extends Thread {
           // wait the final 1/4 loadDatasetsMax for !loadDatasets.isAlive
           if (EDStatic.stopThread(
               loadDatasets,
-              Math2.narrowToInt(EDStatic.loadDatasetsMaxMillis / 1000 / 4))) { // seconds
+              Math2.narrowToInt(EDStatic.config.loadDatasetsMaxMillis / 1000 / 4))) { // seconds
             tError =
                 "RunLoadDatasets stopped a stalled LoadDatasets thread ("
                     + Calendar2.elapsedTimeString(
                         System.currentTimeMillis() - lastMajorLoadDatasetsStartTimeMillis)
                     + " > "
-                    + Calendar2.elapsedTimeString(EDStatic.loadDatasetsMaxMillis)
+                    + Calendar2.elapsedTimeString(EDStatic.config.loadDatasetsMaxMillis)
                     + ") at "
                     + Calendar2.getCurrentISODateTimeStringLocalTZ();
             String2.log("\n*** " + tError);
-            EDStatic.email(EDStatic.emailEverythingToCsv, "RunLoadDatasets Stalled", tError);
+            EDStatic.email(EDStatic.config.emailEverythingToCsv, "RunLoadDatasets Stalled", tError);
           }
 
           loadDatasets = null;
@@ -399,7 +399,7 @@ public class RunLoadDatasets extends Thread {
                   + Calendar2.getCurrentISODateTimeStringLocalTZ();
           String content = MustBe.throwableToString(t);
           String2.log(subject + ": " + content);
-          EDStatic.email(EDStatic.emailEverythingToCsv, subject, content);
+          EDStatic.email(EDStatic.config.emailEverythingToCsv, subject, content);
         } catch (Throwable t2) {
           if (Thread.currentThread().isInterrupted() || t2 instanceof InterruptedException)
             break whileNotInterrupted;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/AxisDataAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/AxisDataAccessor.java
@@ -53,7 +53,7 @@ public class AxisDataAccessor {
    *
    * @param language the index of the selected language
    * @param tEDDGrid
-   * @param tRequestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param tRequestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param tUserDapQuery the part after the '?', still percentEncoded, may be null.
    * @param tConstraints
    * @throws Throwable if trouble
@@ -88,7 +88,7 @@ public class AxisDataAccessor {
     // fix up global attributes (always to a local COPY of global attributes)
     // remove acdd-style and google-style bounding box
     EDD.addToHistory(globalAttributes, eddGrid.publicSourceUrl());
-    EDD.addToHistory(globalAttributes, EDStatic.baseUrl + tRequestUrl + "?" + tUserDapQuery);
+    EDD.addToHistory(globalAttributes, EDStatic.config.baseUrl + tRequestUrl + "?" + tUserDapQuery);
     globalAttributes.remove("geospatial_lon_min");
     globalAttributes.remove("geospatial_lon_max");
     globalAttributes.remove("geospatial_lon_resolution");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -936,7 +936,7 @@ public abstract class EDD {
    *
    * Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    * Special case: for combinedGlobalAttributes name="license", any instance of "[standard]" will be
-   * converted to the EDStatic.standardLicense.
+   * converted to the EDStatic.messages.standardLicense.
    */
   public void setup(
       String tDatasetID,
@@ -954,7 +954,7 @@ public abstract class EDD {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     dataVariables = tDataVariables;
@@ -1003,7 +1003,8 @@ public abstract class EDD {
       if (String2.isSomething(ft)) combinedGlobalAttributes.set("cdm_data_type", ft);
     }
     String tLicense = combinedGlobalAttributes.getString("license");
-    if (tLicense == null) combinedGlobalAttributes.set("license", EDStatic.standardLicense);
+    if (tLicense == null)
+      combinedGlobalAttributes.set("license", EDStatic.messages.standardLicense);
     Test.ensureSomethingUnicode(cdmDataType(), errorInMethod + "cdm_data_type");
     Test.ensureSomethingUnicode(className(), errorInMethod + "className");
     if (defaultDataQuery == null || defaultDataQuery.length() == 0) {
@@ -1173,11 +1174,11 @@ public abstract class EDD {
   public String similar(EDD other) {
 
     try {
-      if (other == null) return "EDSimilar: " + EDStatic.EDDChangedWasnt;
+      if (other == null) return "EDSimilar: " + EDStatic.messages.EDDChangedWasnt;
 
       int nDv = dataVariables.length;
       if (nDv != other.dataVariables.length)
-        return EDStatic.EDDSimilarDifferentNVar
+        return EDStatic.messages.EDDSimilarDifferentNVar
             + " ("
             + nDv
             + " != "
@@ -1194,21 +1195,27 @@ public abstract class EDD {
         String msg2 = "#" + dv + "=" + s1;
         if (!s1.equals(s2))
           return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent, "destinationName", msg2, "(" + s1 + " != " + s2 + ")");
+              EDStatic.messages.EDDSimilarDifferent,
+              "destinationName",
+              msg2,
+              "(" + s1 + " != " + s2 + ")");
 
         // sourceDataType
         s1 = dv1.sourceDataType();
         s2 = dv2.sourceDataType();
         if (!s1.equals(s2))
           return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent, "sourceDataType", msg2, "(" + s1 + " != " + s2 + ")");
+              EDStatic.messages.EDDSimilarDifferent,
+              "sourceDataType",
+              msg2,
+              "(" + s1 + " != " + s2 + ")");
 
         // destinationDataType
         s1 = dv1.destinationDataType();
         s2 = dv2.destinationDataType();
         if (!s1.equals(s2))
           return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent,
+              EDStatic.messages.EDDSimilarDifferent,
               "destinationDataType",
               msg2,
               "(" + s1 + " != " + s2 + ")");
@@ -1218,14 +1225,14 @@ public abstract class EDD {
         s2 = dv2.units();
         if (!Test.equal(s1, s2)) // may be null
         return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent, "units", msg2, "(" + s1 + " != " + s2 + ")");
+              EDStatic.messages.EDDSimilarDifferent, "units", msg2, "(" + s1 + " != " + s2 + ")");
 
         // sourceMissingValue
         double d1 = dv1.sourceMissingValue();
         double d2 = dv2.sourceMissingValue();
         if (!Test.equal(d1, d2)) // says NaN==NaN is true
         return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent,
+              EDStatic.messages.EDDSimilarDifferent,
               "sourceMissingValue",
               msg2,
               "(" + d1 + " != " + d2 + ")");
@@ -1235,7 +1242,10 @@ public abstract class EDD {
         d2 = dv2.sourceFillValue();
         if (!Test.equal(d1, d2)) // says NaN==NaN is true
         return MessageFormat.format(
-              EDStatic.EDDSimilarDifferent, "sourceFillValue", msg2, "(" + d1 + " != " + d2 + ")");
+              EDStatic.messages.EDDSimilarDifferent,
+              "sourceFillValue",
+              msg2,
+              "(" + d1 + " != " + d2 + ")");
       }
 
       // they are similar
@@ -1278,7 +1288,7 @@ public abstract class EDD {
     // FUTURE: perhaps it would be nice if EDDTable changed showed new data.
     //  so it would appear in email subscription and rss.
     //  but for many datasets (e.g., ndbc met) there are huge number of buoys. so not practical.
-    if (oldSnapshot == null) return EDStatic.EDDChangedWasnt;
+    if (oldSnapshot == null) return EDStatic.messages.EDDChangedWasnt;
 
     Map<String, String> newSnapshot = snapshot();
     StringBuilder diff = new StringBuilder();
@@ -1286,7 +1296,9 @@ public abstract class EDD {
     if (!oldSnapshot.get("nDv").equals(newSnapshot.get("nDv"))) {
       diff.append(
           MessageFormat.format(
-              EDStatic.EDDChangedDifferentNVar, oldSnapshot.get("nDv"), newSnapshot.get("nDv")));
+              EDStatic.messages.EDDChangedDifferentNVar,
+              oldSnapshot.get("nDv"),
+              newSnapshot.get("nDv")));
       return diff.toString(); // because tests below assume nDv are same
     }
 
@@ -1299,7 +1311,7 @@ public abstract class EDD {
       if (!oldSnapshot.get(nameKey).equals(newSnapshot.get(nameKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChanged2Different,
+                    EDStatic.messages.EDDChanged2Different,
                     "destinationName",
                     msg2,
                     oldSnapshot.get(nameKey),
@@ -1309,7 +1321,7 @@ public abstract class EDD {
       if (!oldSnapshot.get(typeKey).equals(newSnapshot.get(typeKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChanged2Different,
+                    EDStatic.messages.EDDChanged2Different,
                     "destinationDataType",
                     msg2,
                     oldSnapshot.get(typeKey),
@@ -1319,7 +1331,8 @@ public abstract class EDD {
       String s = String2.differentLine(oldSnapshot.get(attrKey), newSnapshot.get(attrKey));
       if (s.length() > 0) {
         diff.append(
-            MessageFormat.format(EDStatic.EDDChanged1Different, "combinedAttribute", msg2, s)
+            MessageFormat.format(
+                    EDStatic.messages.EDDChanged1Different, "combinedAttribute", msg2, s)
                 + "\n");
       }
     }
@@ -1329,7 +1342,7 @@ public abstract class EDD {
         String2.differentLine(
             oldSnapshot.get("globalAttributes"), newSnapshot.get("globalAttributes"));
     if (s.length() > 0)
-      diff.append(MessageFormat.format(EDStatic.EDDChangedCGADifferent, s) + "\n");
+      diff.append(MessageFormat.format(EDStatic.messages.EDDChangedCGADifferent, s) + "\n");
 
     return diff.toString();
   }
@@ -1362,7 +1375,7 @@ public abstract class EDD {
     // FUTURE: perhaps it would be nice if EDDTable changed showed new data.
     //  so it would appear in email subscription and rss.
     //  but for many datasets (e.g., ndbc met) there are huge number of buoys. so not practical.
-    if (old == null) return EDStatic.EDDChangedWasnt;
+    if (old == null) return EDStatic.messages.EDDChangedWasnt;
 
     // check most important things first
     int nDv = dataVariables.length;
@@ -1370,7 +1383,7 @@ public abstract class EDD {
     String oldS = "" + old.dataVariables.length;
     String newS = "" + nDv;
     if (!oldS.equals(newS)) {
-      diff.append(MessageFormat.format(EDStatic.EDDChangedDifferentNVar, oldS, newS));
+      diff.append(MessageFormat.format(EDStatic.messages.EDDChangedDifferentNVar, oldS, newS));
       return diff.toString(); // because tests below assume nDv are same
     }
 
@@ -1384,7 +1397,8 @@ public abstract class EDD {
       newS = newName;
       if (!oldS.equals(newS))
         diff.append(
-            MessageFormat.format(EDStatic.EDDChanged2Different, "destinationName", msg2, oldS, newS)
+            MessageFormat.format(
+                    EDStatic.messages.EDDChanged2Different, "destinationName", msg2, oldS, newS)
                 + "\n");
 
       oldS = oldDV.destinationDataType();
@@ -1392,7 +1406,7 @@ public abstract class EDD {
       if (!oldS.equals(newS))
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChanged2Different, "destinationDataType", msg2, oldS, newS)
+                    EDStatic.messages.EDDChanged2Different, "destinationDataType", msg2, oldS, newS)
                 + "\n");
 
       String s =
@@ -1400,7 +1414,8 @@ public abstract class EDD {
               oldDV.combinedAttributes().toString(), newDV.combinedAttributes().toString());
       if (s.length() > 0)
         diff.append(
-            MessageFormat.format(EDStatic.EDDChanged1Different, "combinedAttribute", msg2, s)
+            MessageFormat.format(
+                    EDStatic.messages.EDDChanged1Different, "combinedAttribute", msg2, s)
                 + "\n");
     }
 
@@ -1409,7 +1424,7 @@ public abstract class EDD {
         String2.differentLine(
             old.combinedGlobalAttributes().toString(), combinedGlobalAttributes().toString());
     if (s.length() > 0)
-      diff.append(MessageFormat.format(EDStatic.EDDChangedCGADifferent, s) + "\n");
+      diff.append(MessageFormat.format(EDStatic.messages.EDDChangedCGADifferent, s) + "\n");
 
     return diff.toString();
   }
@@ -1506,19 +1521,19 @@ public abstract class EDD {
           "If you want to keep this dataset up-to-date, use a small reloadEveryNMinutes.";
       if (!tryToSubscribe) {
         String2.log(
-            EDStatic.warningAr[0]
+            EDStatic.messages.warningAr[0]
                 + " <tryToSubscribeToRemoteErddapDataset> is false. If that is permanent, then:\n"
                 + keepUpToDate);
       } else if (EDStatic.urlIsLocalhost(thisErddapUrl)) {
         String2.log(
-            EDStatic.warningAr[0]
+            EDStatic.messages.warningAr[0]
                 + " This ERDDAP won't try to subscribe to the dataset on the remote\n"
                 + "ERDDAP because this ERDDAP isn't publicly accessible.\n"
                 + keepUpToDate);
       } else if (!String2.isSomething(EDStatic.emailSubscriptionsFrom)) {
         // this erddap's subscription system isn't active
         String2.log(
-            EDStatic.warningAr[0]
+            EDStatic.messages.warningAr[0]
                 + " Subscribing to the remote ERDDAP dataset failed because\n"
                 + "emailEverythingTo wasn't specified in this ERDDAP's setup.xml.\n"
                 + keepUpToDate);
@@ -1770,7 +1785,7 @@ public abstract class EDD {
         + ".rss\" \n"
         + "  title=\"\"><img alt=\"RSS\"\n"
         + "    title=\""
-        + EDStatic.subscriptionRSSAr[language]
+        + EDStatic.messages.subscriptionRSSAr[language]
         + "\" \n"
         + "    src=\""
         + EDStatic.imageDirUrl(loggedInAs, language)
@@ -1796,7 +1811,7 @@ public abstract class EDD {
           + "&amp;showErrors=false&amp;email=\" \n"
           + "  title=\"\"><img alt=\"Subscribe\"\n"
           + "    title=\""
-          + XML.encodeAsHTMLAttribute(EDStatic.subscriptionEmailAr[language])
+          + XML.encodeAsHTMLAttribute(EDStatic.messages.subscriptionEmailAr[language])
           + "\" \n"
           + "    src=\""
           + EDStatic.imageDirUrl(loggedInAs, language)
@@ -2261,17 +2276,18 @@ public abstract class EDD {
             } else {
               // file doesn't exist
               throw new SimpleException(
-                  EDStatic.resourceNotFoundAr[0] + "the <fgdcFile> specified in datasets.xml.");
+                  EDStatic.messages.resourceNotFoundAr[0]
+                      + "the <fgdcFile> specified in datasets.xml.");
             }
 
           } else {
-            accessibleViaFGDC = MessageFormat.format(EDStatic.noXxxAr[0], "FGDC");
+            accessibleViaFGDC = MessageFormat.format(EDStatic.messages.noXxxAr[0], "FGDC");
           }
 
         } catch (Throwable t) {
           String2.log(
               MessageFormat.format(
-                  EDStatic.noXxxBecause2Ar[0],
+                  EDStatic.messages.noXxxBecause2Ar[0],
                   "FGDC",
                   (t instanceof SimpleException
                       ? MustBe.getShortErrorMessage(t)
@@ -2285,9 +2301,9 @@ public abstract class EDD {
         accessibleViaFGDC =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[0],
+                    EDStatic.messages.noXxxBecause2Ar[0],
                     "FGDC",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "FGDC")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "FGDC")));
       }
     }
     return accessibleViaFGDC;
@@ -2332,17 +2348,19 @@ public abstract class EDD {
             } else {
               // file doesn't exist
               throw new SimpleException(
-                  EDStatic.resourceNotFoundAr[0] + "the <iso19115File> specified in datasets.xml.");
+                  EDStatic.messages.resourceNotFoundAr[0]
+                      + "the <iso19115File> specified in datasets.xml.");
             }
 
           } else {
-            accessibleViaISO19115 = MessageFormat.format(EDStatic.noXxxAr[0], "ISO 19115-2/19139");
+            accessibleViaISO19115 =
+                MessageFormat.format(EDStatic.messages.noXxxAr[0], "ISO 19115-2/19139");
           }
 
         } catch (Throwable t) {
           String2.log(
               MessageFormat.format(
-                  EDStatic.noXxxBecause2Ar[0],
+                  EDStatic.messages.noXxxBecause2Ar[0],
                   "ISO 19115-2/19139",
                   (t instanceof SimpleException
                       ? MustBe.getShortErrorMessage(t)
@@ -2356,9 +2374,10 @@ public abstract class EDD {
         accessibleViaISO19115 =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[0],
+                    EDStatic.messages.noXxxBecause2Ar[0],
                     "ISO 19115-2/19139",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "ISO 19115-2/19139")));
+                    MessageFormat.format(
+                        EDStatic.messages.noXxxNotActiveAr[0], "ISO 19115-2/19139")));
       }
     }
     return accessibleViaISO19115;
@@ -2760,7 +2779,7 @@ public abstract class EDD {
     if (which < 0)
       throw new SimpleException(
           MessageFormat.format(
-              EDStatic.errorNotFoundAr[0],
+              EDStatic.messages.errorNotFoundAr[0],
               "sourceVariableName=" + tSourceName + " in datasetID=" + datasetID));
     return dataVariables[which];
   }
@@ -2780,7 +2799,7 @@ public abstract class EDD {
     if (which < 0)
       throw new SimpleException(
           MessageFormat.format(
-              EDStatic.errorNotFoundInAr[0],
+              EDStatic.messages.errorNotFoundInAr[0],
               "destinationVariableName=" + tDestinationName,
               "datasetID=" + datasetID));
     return dataVariables[which];
@@ -3294,10 +3313,11 @@ public abstract class EDD {
     throw new SimpleException(
         EDStatic.bilingual(
             language,
-            EDStatic.queryErrorAr[0]
-                + MessageFormat.format(EDStatic.queryErrorFileTypeAr[0], fileTypeName),
-            EDStatic.queryErrorAr[language]
-                + MessageFormat.format(EDStatic.queryErrorFileTypeAr[language], fileTypeName)));
+            EDStatic.messages.queryErrorAr[0]
+                + MessageFormat.format(EDStatic.messages.queryErrorFileTypeAr[0], fileTypeName),
+            EDStatic.messages.queryErrorAr[language]
+                + MessageFormat.format(
+                    EDStatic.messages.queryErrorFileTypeAr[language], fileTypeName)));
   }
 
   /**
@@ -3725,20 +3745,20 @@ public abstract class EDD {
       dafLink =
           "     | <a rel=\"alternate\" "
               + "title=\""
-              + EDStatic.clickAccessAr[language]
+              + EDStatic.messages.clickAccessAr[language]
               + "\" \n"
               + "         href=\""
               + dapUrl
               + ".html"
               + tQuery
               + "\">"
-              + EDStatic.dafAr[language]
+              + EDStatic.messages.dafAr[language]
               + "</a>\n";
     if (isAccessible && showSubsetLink && accessibleViaSubset().length() == 0)
       subsetLink =
           "     | <a rel=\"alternate\" "
               + "title=\""
-              + EDStatic.dtSubsetAr[language]
+              + EDStatic.messages.dtSubsetAr[language]
               + "\" \n"
               + "         href=\""
               + dapUrl
@@ -3748,40 +3768,41 @@ public abstract class EDD {
                   ? ""
                   : XML.encodeAsHTMLAttribute(EDDTable.DEFAULT_SUBSET_VIEWS))
               + "\">"
-              + EDStatic.subsetAr[language]
+              + EDStatic.messages.subsetAr[language]
               + "</a>\n";
     if (isAccessible && showFilesLink && accessibleViaFiles) // > because it has sourceDir
     filesLink =
           "     | <a rel=\"alternate\" "
               + "title=\""
               + XML.encodeAsHTMLAttribute(
-                  EDStatic.filesDescriptionAr[language]
+                  EDStatic.messages.filesDescriptionAr[language]
                       + (this instanceof EDDTableFromFileNames
                           ? ""
                           : "\n"
-                              + EDStatic.warningAr[language]
+                              + EDStatic.messages.warningAr[language]
                               + " "
-                              + String2.replaceAll(EDStatic.filesWarningAr[language], "<br>", "")))
+                              + String2.replaceAll(
+                                  EDStatic.messages.filesWarningAr[language], "<br>", "")))
               + "\" \n"
               + "         href=\""
               + tErddapUrl
               + "/files/"
               + datasetID
               + "/\">"
-              + EDStatic.EDDFilesAr[language]
+              + EDStatic.messages.EDDFilesAr[language]
               + "</a>\n";
     if (graphsAccessible && showGraphLink && accessibleViaMAG().length() == 0)
       graphLink =
           "     | <a rel=\"alternate\" "
               + "title=\""
-              + EDStatic.dtMAGAr[language]
+              + EDStatic.messages.dtMAGAr[language]
               + "\" \n"
               + "         href=\""
               + dapUrl
               + ".graph"
               + tQuery
               + "\">"
-              + EDStatic.EDDMakeAGraphAr[language]
+              + EDStatic.messages.EDDMakeAGraphAr[language]
               + "</a>\n";
     String encTitle = XML.encodeAsHTML(String2.noLongLines(title(), 80, ""));
     encTitle = String2.replaceAll(encTitle, "\n", "<br>");
@@ -3790,7 +3811,7 @@ public abstract class EDD {
         "<table class=\"compact nowrap\">\n"
             + "  <tr>\n"
             + "    <td>"
-            + EDStatic.EDDDatasetTitleAr[language]
+            + EDStatic.messages.EDDDatasetTitleAr[language]
             + ":&nbsp;</td>\n"
             + "    <td style=\"vertical-align:middle\"><span class=\"standoutColor\" style=\"font-size:130%; line-height:130%;\"><strong>"
             + encTitle
@@ -3808,13 +3829,13 @@ public abstract class EDD {
             + "  </tr>\n"
             + "  <tr>\n"
             + "    <td>"
-            + EDStatic.EDDInstitutionAr[language]
+            + EDStatic.messages.EDDInstitutionAr[language]
             + ":&nbsp;</td>\n"
             + "    <td>"
             + XML.encodeAsHTML(institution())
             + "&nbsp;&nbsp;\n"
             + "    ("
-            + EDStatic.EDDDatasetIDAr[language]
+            + EDStatic.messages.EDDDatasetIDAr[language]
             + ": "
             + XML.encodeAsHTML(datasetID)
             + ")</td>\n"
@@ -3823,7 +3844,7 @@ public abstract class EDD {
             + "\n"
             + "  <tr>\n"
             + "    <td>"
-            + EDStatic.EDDInformationAr[language]
+            + EDStatic.messages.EDDInformationAr[language]
             + ":&nbsp;</td>\n"
             + "    <td>"
             + getDisplayInfo(language, loggedInAs)
@@ -3831,46 +3852,46 @@ public abstract class EDD {
                 ? ""
                 : "     | <a rel=\"alternate\" \n"
                     + "          title=\""
-                    + EDStatic.EDDFgdcMetadataAr[language]
+                    + EDStatic.messages.EDDFgdcMetadataAr[language]
                     + "\" \n"
                     + "          href=\""
                     + dapUrl
                     + ".fgdc\">"
-                    + EDStatic.EDDFgdc
+                    + EDStatic.messages.EDDFgdc
                     + "</a>\n")
             + (accessibleViaISO19115().length() > 0
                 ? ""
                 : "     | <a rel=\"alternate\" \n"
                     + "          title=\""
-                    + EDStatic.EDDIso19115MetadataAr[language]
+                    + EDStatic.messages.EDDIso19115MetadataAr[language]
                     + "\" \n"
                     + "          href=\""
                     + dapUrl
                     + ".iso19115\">"
-                    + EDStatic.EDDIso19115
+                    + EDStatic.messages.EDDIso19115
                     + "</a>\n")
             + "     | <a rel=\"alternate\" \n"
             + "          title=\""
-            + EDStatic.clickInfoAr[language]
+            + EDStatic.messages.clickInfoAr[language]
             + "\" \n"
             + "          href=\""
             + tErddapUrl
             + "/info/"
             + datasetID
             + "/index.html\">"
-            + EDStatic.EDDMetadataAr[language]
+            + EDStatic.messages.EDDMetadataAr[language]
             + "</a>\n"
             + "     | <a rel=\"bookmark\" \n"
             + "          title=\""
-            + EDStatic.clickBackgroundInfoAr[language]
+            + EDStatic.messages.clickBackgroundInfoAr[language]
             + "\" \n"
             + "          href=\""
             + XML.encodeAsHTMLAttribute(infoUrl())
             + "\">"
-            + EDStatic.EDDBackgroundAr[language]
+            + EDStatic.messages.EDDBackgroundAr[language]
             + (infoUrl().startsWith(EDStatic.baseUrl)
                 ? ""
-                : EDStatic.externalLinkHtml(language, tErddapUrl))
+                : EDStatic.messages.externalLinkHtml(language, tErddapUrl))
             + "</a>\n"
             + subsetLink
             + "\n"
@@ -3907,11 +3928,11 @@ public abstract class EDD {
       // Handle "summary"
       if ("summary".equals(attribute)) {
         attVal = extendedSummary();
-        displayInfo = EDStatic.EDDSummaryAr[language];
+        displayInfo = EDStatic.messages.EDDSummaryAr[language];
       }
       if ("license".equals(attribute)) {
-        warningColor = attVal != null && !attVal.equals(EDStatic.standardLicense);
-        displayInfo = EDStatic.licenseAr[language];
+        warningColor = attVal != null && !attVal.equals(EDStatic.messages.standardLicense);
+        displayInfo = EDStatic.messages.licenseAr[language];
       }
       if (warningColor) {
         displayInfo = "<span class=\"warningColor\">" + displayInfo + "</span>";
@@ -14139,7 +14160,8 @@ public abstract class EDD {
   public static String sparqlP01toP02(String p01) {
     // FUTURE: move this to messages.txt and EDStatic and make it setable in setup.xml
 
-    String urlString = EDStatic.sparqlP01toP02pre + p01 + EDStatic.sparqlP01toP02post;
+    String urlString =
+        EDStatic.messages.sparqlP01toP02pre + p01 + EDStatic.messages.sparqlP01toP02post;
     try {
       Table table = new Table();
       table.readASCII(

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -727,7 +727,7 @@ public abstract class EDDGrid extends EDD {
   public String accessibleViaSOS() {
     if (accessibleViaSOS == null) {
 
-      if (!EDStatic.sosActive)
+      if (!EDStatic.config.sosActive)
         accessibleViaSOS =
             String2.canonical(
                 MessageFormat.format(
@@ -750,7 +750,7 @@ public abstract class EDDGrid extends EDD {
   public String accessibleViaGeoServicesRest() {
     if (accessibleViaGeoServicesRest == null) {
 
-      if (!EDStatic.geoServicesRestActive) {
+      if (!EDStatic.config.geoServicesRestActive) {
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
@@ -835,7 +835,7 @@ public abstract class EDDGrid extends EDD {
   public String accessibleViaWCS() {
     if (accessibleViaWCS == null) {
 
-      if (!EDStatic.wcsActive)
+      if (!EDStatic.config.wcsActive)
         accessibleViaWCS =
             String2.canonical(
                 MessageFormat.format(
@@ -896,7 +896,7 @@ public abstract class EDDGrid extends EDD {
   public String accessibleViaWMS() {
     if (accessibleViaWMS == null) {
 
-      if (!EDStatic.wmsActive)
+      if (!EDStatic.config.wmsActive)
         accessibleViaWMS =
             String2.canonical(
                 MessageFormat.format(
@@ -2601,7 +2601,7 @@ public abstract class EDDGrid extends EDD {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.
@@ -2958,7 +2958,7 @@ public abstract class EDDGrid extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but in unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded
    *     (shouldn't be null).
    * @param outputStreamSource the source of an outputStream that receives the results, usually
@@ -3362,10 +3362,10 @@ public abstract class EDDGrid extends EDD {
 
         } else if (fileTypeName.equals(".nc4") || fileTypeName.equals(".nc4Header")) {
 
-          if (EDStatic.accessibleViaNC4.length() > 0)
+          if (EDStatic.config.accessibleViaNC4.length() > 0)
             throw new SimpleException(
                 EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
-                    + EDStatic.accessibleViaNC4);
+                    + EDStatic.config.accessibleViaNC4);
 
           // if .nc4Header, make sure the .nc4 file exists (and it is the better file to cache)
           saveAsNc(
@@ -3433,7 +3433,8 @@ public abstract class EDDGrid extends EDD {
           File2.rename(cacheFullName + random, cacheFullName);
           if (!ok) // make eligible to be removed from cache in 5 minutes
           File2.touch(
-                cacheFullName, Math.max(0, EDStatic.cacheMillis - 5 * Calendar2.MILLIS_PER_MINUTE));
+                cacheFullName,
+                Math.max(0, EDStatic.config.cacheMillis - 5 * Calendar2.MILLIS_PER_MINUTE));
 
           File2.isFile(
               cacheFullName,
@@ -3475,7 +3476,7 @@ public abstract class EDDGrid extends EDD {
       }
 
       // copy file to ...
-      if (EDStatic.awsS3OutputBucketUrl == null) {
+      if (EDStatic.config.awsS3OutputBucketUrl == null) {
 
         // copy file to outputStream
         // (I delayed getting actual outputStream as long as possible.)
@@ -3501,9 +3502,10 @@ public abstract class EDDGrid extends EDD {
         String contentType =
             OutputStreamFromHttpResponse.getFileContentType(
                 request, fileTypeName, fileTypeExtension);
-        String fullAwsUrl = EDStatic.awsS3OutputBucketUrl + File2.getNameAndExtension(fullName);
+        String fullAwsUrl =
+            EDStatic.config.awsS3OutputBucketUrl + File2.getNameAndExtension(fullName);
         SSR.uploadFileToAwsS3(
-            EDStatic.awsS3OutputTransferManager, fullName, fullAwsUrl, contentType);
+            EDStatic.config.awsS3OutputTransferManager, fullName, fullAwsUrl, contentType);
         response.sendRedirect(fullAwsUrl);
       }
 
@@ -3521,7 +3523,7 @@ public abstract class EDDGrid extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery from the user (may be "" or null), still percentEncoded (shouldn't be
    *     null). If the query has missing or invalid parameters, defaults will be used. If the query
    *     has irrelevant parameters, they will be ignored.
@@ -4799,7 +4801,7 @@ public abstract class EDDGrid extends EDD {
       }
 
       // bgColor
-      Color bgColor = EDStatic.graphBackgroundColor;
+      Color bgColor = EDStatic.config.graphBackgroundColor;
       String tBGColor = String2.stringStartsWith(queryParts, partName = ".bgColor=");
       if (tBGColor != null) {
         String tBGColorAr[] = String2.split(tBGColor.substring(partName.length()), '|');
@@ -6099,7 +6101,7 @@ public abstract class EDDGrid extends EDD {
    * THREDDs doesn't even object if userDapQuery is invalid.) See writeDAS().
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded
    *     (shouldn't be null).
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -6150,7 +6152,7 @@ public abstract class EDDGrid extends EDD {
    * }
    * </pre>
    *
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded
    *     (shouldn't be null). (Affects history only.)
    * @param writer a Writer. At the end of this method the Writer is flushed, not closed.
@@ -6185,7 +6187,7 @@ public abstract class EDDGrid extends EDD {
     EDD.addToHistory(gAtts, publicSourceUrl());
     EDD.addToHistory(
         gAtts,
-        EDStatic.baseUrl
+        EDStatic.config.baseUrl
             + requestUrl
             + (userDapQuery == null || userDapQuery.length() == 0 ? "" : "?" + userDapQuery));
 
@@ -6221,7 +6223,7 @@ public abstract class EDDGrid extends EDD {
    * </pre>
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param writer an 8859-1 writer, usually already buffered, to receive the results. At the end of
@@ -6362,7 +6364,7 @@ public abstract class EDDGrid extends EDD {
    *
    * @param language the index of the selected language
    * @param loggedInAs
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
    *     the results. At the end of this method the outputStream is flushed, not closed.
    * @throws Throwable if trouble.
@@ -6481,7 +6483,7 @@ public abstract class EDDGrid extends EDD {
    * DODS DataDDS format (OPeNDAP 2.0, 7.2.3).
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -6668,7 +6670,7 @@ public abstract class EDDGrid extends EDD {
    * more extensive fixup].
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -7229,7 +7231,7 @@ public abstract class EDDGrid extends EDD {
    * (but presumably that is what it will request).
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param dir the directory (on this computer's hard drive) to use for temporary/cache files
@@ -7363,7 +7365,7 @@ public abstract class EDDGrid extends EDD {
       int markerSize = GraphDataLayer.MARKER_SIZE_SMALL;
       double fontScale = 1, vectorStandard = Double.NaN;
       String currentDrawLandMask = null; // null = not yet set
-      Color bgColor = EDStatic.graphBackgroundColor;
+      Color bgColor = EDStatic.config.graphBackgroundColor;
       for (String ampPart : ampParts) {
         // .bgColor
         if (ampPart.startsWith(".bgColor=")) {
@@ -8311,14 +8313,14 @@ public abstract class EDDGrid extends EDD {
           if (scale.length() == 0) scale = "Linear";
           cptFullName =
               CompoundColorMap.makeCPT(
-                  EDStatic.fullPaletteDirectory,
+                  EDStatic.config.fullPaletteDirectory,
                   palette,
                   scale,
                   paletteMin,
                   paletteMax,
                   nSections,
                   continuous,
-                  EDStatic.fullCptCacheDirectory);
+                  EDStatic.config.fullCptCacheDirectory);
 
           // make a graphDataLayer with coloredSurface setup
           graphDataLayer =
@@ -8486,25 +8488,25 @@ public abstract class EDDGrid extends EDD {
               if (vars[2] instanceof EDVTimeStamp)
                 colorMap =
                     new CompoundColorMap(
-                        EDStatic.fullPaletteDirectory,
+                        EDStatic.config.fullPaletteDirectory,
                         palette,
                         false, // false= data is seconds
                         paletteMin,
                         paletteMax,
                         nSections,
                         continuous,
-                        EDStatic.fullCptCacheDirectory);
+                        EDStatic.config.fullCptCacheDirectory);
               else
                 colorMap =
                     new CompoundColorMap(
-                        EDStatic.fullPaletteDirectory,
+                        EDStatic.config.fullPaletteDirectory,
                         palette,
                         scale,
                         paletteMin,
                         paletteMax,
                         nSections,
                         continuous,
-                        EDStatic.fullCptCacheDirectory);
+                        EDStatic.config.fullCptCacheDirectory);
             }
           }
 
@@ -8552,7 +8554,7 @@ public abstract class EDDGrid extends EDD {
       // transparentPng will revise this below
       if (pdf) {
         fontScale *= 1.4 * fontScale; // SgtMap.PDF_FONTSCALE=1.5 is too big
-        logoImageFile = EDStatic.highResLogoImageFile;
+        logoImageFile = EDStatic.config.highResLogoImageFile;
         pdfInfo =
             SgtUtil.createPdf(
                 SgtUtil.PDF_PORTRAIT,
@@ -8563,7 +8565,9 @@ public abstract class EDDGrid extends EDD {
       } else {
         fontScale *= imageWidth < 500 ? 1 : 1.25;
         logoImageFile =
-            sizeIndex <= 1 ? EDStatic.lowResLogoImageFile : EDStatic.highResLogoImageFile;
+            sizeIndex <= 1
+                ? EDStatic.config.lowResLogoImageFile
+                : EDStatic.config.highResLogoImageFile;
 
         // transparentPng supports returning requests outside of data
         // range to enable tiles that partially contain data. This
@@ -8685,7 +8689,7 @@ public abstract class EDDGrid extends EDD {
                   SgtUtil.LEGEND_BELOW,
                   EDStatic.messages.legendTitle1,
                   EDStatic.messages.legendTitle2,
-                  EDStatic.imageDir,
+                  EDStatic.config.imageDir,
                   logoImageFile,
                   minX,
                   maxX,
@@ -8750,7 +8754,7 @@ public abstract class EDDGrid extends EDD {
                     SgtUtil.LEGEND_BELOW,
                     EDStatic.messages.legendTitle1,
                     EDStatic.messages.legendTitle2,
-                    EDStatic.imageDir,
+                    EDStatic.config.imageDir,
                     logoImageFile,
                     minX,
                     maxX,
@@ -8799,7 +8803,7 @@ public abstract class EDDGrid extends EDD {
                     SgtUtil.LEGEND_BELOW,
                     EDStatic.messages.legendTitle1,
                     EDStatic.messages.legendTitle2,
-                    EDStatic.imageDir,
+                    EDStatic.config.imageDir,
                     logoImageFile,
                     minX,
                     maxX,
@@ -8819,7 +8823,7 @@ public abstract class EDDGrid extends EDD {
                     imageHeight,
                     Double.NaN, // graph imageWidth/imageHeight
                     drawSurface
-                        ? (!bgColor.equals(EDStatic.graphBackgroundColor)
+                        ? (!bgColor.equals(EDStatic.config.graphBackgroundColor)
                             ? bgColor
                             : palette.equals("BlackWhite") || palette.equals("WhiteBlack")
                                 ? new Color(0xccccff)
@@ -8888,7 +8892,7 @@ public abstract class EDDGrid extends EDD {
             msg = String2.noLongLines(msg, (imageWidth * 10 / 6) / tHeight, "    ");
             String lines[] = msg.split("\\n"); // not String2.split which trims
             g2.setColor(Color.black);
-            g2.setFont(new Font(EDStatic.fontFamily, Font.PLAIN, tHeight));
+            g2.setFont(new Font(EDStatic.config.fontFamily, Font.PLAIN, tHeight));
             int ty = tHeight * 2;
             for (String line : lines) {
               g2.drawString(line, tHeight, ty);
@@ -9282,7 +9286,7 @@ public abstract class EDDGrid extends EDD {
    * format. If no exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]. This method extracts the jsonp
    *     text to be prepended to the results (or null if none). See
@@ -9354,7 +9358,7 @@ public abstract class EDDGrid extends EDD {
    * successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160].
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -9454,7 +9458,7 @@ public abstract class EDDGrid extends EDD {
    * KVP format. If no exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]. This method extracts the jsonp
    *     text to be prepended to the results (or null if none). See
@@ -9539,7 +9543,7 @@ public abstract class EDDGrid extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160].
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -10036,7 +10040,7 @@ public abstract class EDDGrid extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160].
    * @param fullOutName is dir + UniqueName + ".wav"
@@ -10136,7 +10140,7 @@ public abstract class EDDGrid extends EDD {
    * The file extension should be .itx
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -10335,7 +10339,7 @@ public abstract class EDDGrid extends EDD {
    * thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percent-encoded (shouldn't be
    *     null), e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -10618,7 +10622,7 @@ public abstract class EDDGrid extends EDD {
    *
    * @param language the index of the selected language
    * @param ncVersion either NetcdfFileFormat.NETCDF3 or NETCDF4.
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param fullFileName the name for the file (including directory and extension)
@@ -10941,7 +10945,7 @@ public abstract class EDDGrid extends EDD {
    *
    * @param language the index of the selected language
    * @param ncVersion either NetcdfFileFormat.NETCDF3 or NETCDF4.
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @throws Throwable
@@ -11287,7 +11291,7 @@ public abstract class EDDGrid extends EDD {
    * exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -11322,7 +11326,7 @@ public abstract class EDDGrid extends EDD {
    * exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -11357,7 +11361,7 @@ public abstract class EDDGrid extends EDD {
    * exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -11429,7 +11433,7 @@ public abstract class EDDGrid extends EDD {
    * Format .txt file. If no exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -11490,7 +11494,7 @@ public abstract class EDDGrid extends EDD {
    * .parquet file. If no exception is thrown, the data was successfully written.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param outputStreamSource the source of an outputStream (usually already buffered) to receive
@@ -11542,7 +11546,7 @@ public abstract class EDDGrid extends EDD {
    * xhtml table. See TableWriterHtml for details.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). for a axis data, e.g., time[40:45], or for a grid data, e.g.,
    *     ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
@@ -13237,7 +13241,7 @@ public abstract class EDDGrid extends EDD {
             + "</a>\n"
             + "     (e.g., 2002-08-03T12:30:00Z, but some variables include milliseconds, e.g.,\n"
             + "     2002-08-03T12:30:00.123Z).\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "     <br>ERDDAP has a utility to\n"
                     + "       <a rel=\"bookmark\" href=\""
                     + tErddapUrl
@@ -13283,7 +13287,7 @@ public abstract class EDDGrid extends EDD {
             + "     And this is consistent with some other places in ERDDAP that try to repair\n"
             + "     invalid input when the intention is clear, instead of just returning an error\n"
             + "     message.)\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "     ERDDAP has a utility to\n"
                     + "       <a rel=\"bookmark\" href=\""
                     + tErddapUrl
@@ -13350,7 +13354,7 @@ public abstract class EDDGrid extends EDD {
             + "       For example, a fully opaque (ff) greenish-blue color with red=22, green=88, blue=ee\n"
             + "       would be 0xff2288ee. Opaque white is 0xffffffff. Opaque light blue is 0xffccccff.\n"
             + "       The default on this ERDDAP is "
-            + String2.to0xHexString(EDStatic.graphBackgroundColor.getRGB(), 8)
+            + String2.to0xHexString(EDStatic.config.graphBackgroundColor.getRGB(), 8)
             + ".\n"
             + "     <li><kbd>&amp;.colorBar=<i>palette</i>|<i>continuous</i>|<i>scale</i>|<i>min</i>|<i>max</i>|<i>nSections</i></kbd> \n"
             + "       <br>This specifies the settings for a color bar.  The sub-values are:\n"
@@ -13993,38 +13997,38 @@ public abstract class EDDGrid extends EDD {
           "    </keywords>\n"
               + "    <responsibleParty>\n"
               + "      <individualName>"
-              + XML.encodeAsXML(EDStatic.adminIndividualName)
+              + XML.encodeAsXML(EDStatic.config.adminIndividualName)
               + "</individualName>\n"
               + "      <organisationName>"
-              + XML.encodeAsXML(EDStatic.adminInstitution)
+              + XML.encodeAsXML(EDStatic.config.adminInstitution)
               + "</organisationName>\n"
               + "      <positionName>"
-              + XML.encodeAsXML(EDStatic.adminPosition)
+              + XML.encodeAsXML(EDStatic.config.adminPosition)
               + "</positionName>\n"
               + "      <contactInfo>\n"
               + "        <phone>\n"
               + "          <voice>"
-              + XML.encodeAsXML(EDStatic.adminPhone)
+              + XML.encodeAsXML(EDStatic.config.adminPhone)
               + "</voice>\n"
               + "        </phone>\n"
               + "        <address>\n"
               + "          <deliveryPoint>"
-              + XML.encodeAsXML(EDStatic.adminAddress)
+              + XML.encodeAsXML(EDStatic.config.adminAddress)
               + "</deliveryPoint>\n"
               + "          <city>"
-              + XML.encodeAsXML(EDStatic.adminCity)
+              + XML.encodeAsXML(EDStatic.config.adminCity)
               + "</city>\n"
               + "          <administrativeArea>"
-              + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+              + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
               + "</administrativeArea>\n"
               + "          <postalCode>"
-              + XML.encodeAsXML(EDStatic.adminPostalCode)
+              + XML.encodeAsXML(EDStatic.config.adminPostalCode)
               + "</postalCode>\n"
               + "          <country>"
-              + XML.encodeAsXML(EDStatic.adminCountry)
+              + XML.encodeAsXML(EDStatic.config.adminCountry)
               + "</country>\n"
               + "          <electronicMailAddress>"
-              + XML.encodeAsXML(EDStatic.adminEmail)
+              + XML.encodeAsXML(EDStatic.config.adminEmail)
               + "</electronicMailAddress>\n"
               + "        </address>\n"
               + "        <onlineResource xlink:href=\""
@@ -14158,22 +14162,22 @@ public abstract class EDDGrid extends EDD {
       "    <ows:AccessConstraints>" + XML.encodeAsXML(accessConstraints()) + "</ows:AccessConstraints>\n" +
       "  </ows:ServiceIdentification>\n" +
       "  <ows:ServiceProvider>\n" +
-      "    <ows:ProviderName>" + XML.encodeAsXML(EDStatic.adminInstitution) + "</ows:ProviderName>\n" +
+      "    <ows:ProviderName>" + XML.encodeAsXML(EDStatic.config.adminInstitution) + "</ows:ProviderName>\n" +
       "    <ows:ProviderSite xlink:href=\"" + XML.encodeAsXML(EDStatic.erddapUrl) + "\">\n" +
       "    <ows:ServiceContact>\n" +
-      "      <ows:IndividualName>" + XML.encodeAsXML(EDStatic.adminIndividualName) + "</ows:IndividualName>\n" +
-      "      <ows:PositionName>" + XML.encodeAsXML(EDStatic.adminPosition) + "</ows:PositionName>\n" +
+      "      <ows:IndividualName>" + XML.encodeAsXML(EDStatic.config.adminIndividualName) + "</ows:IndividualName>\n" +
+      "      <ows:PositionName>" + XML.encodeAsXML(EDStatic.config.adminPosition) + "</ows:PositionName>\n" +
       "      <ows:ContactInfo>\n" +
       "        <ows:Phone>\n" +
-      "          <ows:Voice>" + XML.encodeAsXML(EDStatic.adminPhone) + "</ows:Voice>\n" +
+      "          <ows:Voice>" + XML.encodeAsXML(EDStatic.config.adminPhone) + "</ows:Voice>\n" +
       "        </ows:Phone>\n" +
       "        <ows:Address>\n" +
-      "          <ows:DeliveryPoint>" + XML.encodeAsXML(EDStatic.adminAddress) + "</ows:DeliveryPoint>\n" +
-      "          <ows:City>" + XML.encodeAsXML(EDStatic.adminCity) + "</ows:City>\n" +
-      "          <ows:AdministrativeArea>" + XML.encodeAsXML(EDStatic.adminStateOrProvince) + "</ows:AdministrativeArea>\n" +
-      "          <ows:PostalCode>" + XML.encodeAsXML(EDStatic.adminPostalCode) + "</ows:PostalCode>\n" +
-      "          <ows:Country>" + XML.encodeAsXML(EDStatic.adminCountry) + "</ows:Country>\n" +
-      "          <ows:ElectronicMailAddress>" + XML.encodeAsXML(EDStatic.adminEmail) + "</ows:ElectronicMailAddress>\n" +
+      "          <ows:DeliveryPoint>" + XML.encodeAsXML(EDStatic.config.adminAddress) + "</ows:DeliveryPoint>\n" +
+      "          <ows:City>" + XML.encodeAsXML(EDStatic.config.adminCity) + "</ows:City>\n" +
+      "          <ows:AdministrativeArea>" + XML.encodeAsXML(EDStatic.config.adminStateOrProvince) + "</ows:AdministrativeArea>\n" +
+      "          <ows:PostalCode>" + XML.encodeAsXML(EDStatic.config.adminPostalCode) + "</ows:PostalCode>\n" +
+      "          <ows:Country>" + XML.encodeAsXML(EDStatic.config.adminCountry) + "</ows:Country>\n" +
+      "          <ows:ElectronicMailAddress>" + XML.encodeAsXML(EDStatic.config.adminEmail) + "</ows:ElectronicMailAddress>\n" +
       "        </ows:Address>\n" +
       "      </ows:ContactInfo>\n" +
       "      <ows:Role>ERDDAP/WCS Administrator</ows:Role>\n" +
@@ -15452,7 +15456,7 @@ public abstract class EDDGrid extends EDD {
             + "      <br>In ERDDAP, this parameter is optional and the default is always the last time available.\n"
             + "      <br>The WCS standard allows <i>time=beginTime,endTime,timeRes</i>.  ERDDAP doesn't allow this.\n"
             + "      <br>The WCS standard allows <i>time=time1,time2,...</i>  ERDDAP doesn't allow this.</td>\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "      <br>ERDDAP has a utility to\n"
                     + "        <a rel=\"bookmark\" href=\""
                     + tErddapUrl
@@ -15596,7 +15600,7 @@ public abstract class EDDGrid extends EDD {
     String datasetUrl = tErddapUrl + "/" + dapProtocol + "/" + datasetID();
     String wcsUrl = tErddapUrl + "/wcs/" + datasetID() + "/" + wcsServer; // "?" at end?
     String wmsUrl = tErddapUrl + "/wms/" + datasetID() + "/" + WMS_SERVER; // "?" at end?
-    String domain = EDStatic.baseUrl;
+    String domain = EDStatic.config.baseUrl;
     if (domain.startsWith("http://")) domain = domain.substring(7);
     else if (domain.startsWith("https://")) domain = domain.substring(8);
     String eddCreationDate =
@@ -15632,7 +15636,7 @@ public abstract class EDDGrid extends EDD {
     String keywords = combinedGlobalAttributes.getString("keywords");
     String keywordsVocabulary = combinedGlobalAttributes.getString("keywords_vocabulary");
     if (keywords == null) { // use the crude, ERDDAP keywords
-      keywords = EDStatic.keywords;
+      keywords = EDStatic.config.keywords;
       keywordsVocabulary = null;
     }
     String license = combinedGlobalAttributes.getString("license");
@@ -15645,18 +15649,24 @@ public abstract class EDDGrid extends EDD {
     String standardNameVocabulary = combinedGlobalAttributes.getString("standard_name_vocabulary");
 
     String adminInstitution =
-        EDStatic.adminInstitution == null ? unknown : EDStatic.adminInstitution;
+        EDStatic.config.adminInstitution == null ? unknown : EDStatic.config.adminInstitution;
     String adminIndividualName =
-        EDStatic.adminIndividualName == null ? unknown : EDStatic.adminIndividualName;
-    String adminPosition = EDStatic.adminPosition == null ? unknown : EDStatic.adminPosition;
-    String adminPhone = EDStatic.adminPhone == null ? unknown : EDStatic.adminPhone;
-    String adminAddress = EDStatic.adminAddress == null ? unknown : EDStatic.adminAddress;
-    String adminCity = EDStatic.adminCity == null ? unknown : EDStatic.adminCity;
+        EDStatic.config.adminIndividualName == null ? unknown : EDStatic.config.adminIndividualName;
+    String adminPosition =
+        EDStatic.config.adminPosition == null ? unknown : EDStatic.config.adminPosition;
+    String adminPhone = EDStatic.config.adminPhone == null ? unknown : EDStatic.config.adminPhone;
+    String adminAddress =
+        EDStatic.config.adminAddress == null ? unknown : EDStatic.config.adminAddress;
+    String adminCity = EDStatic.config.adminCity == null ? unknown : EDStatic.config.adminCity;
     String adminStateOrProvince =
-        EDStatic.adminStateOrProvince == null ? unknown : EDStatic.adminStateOrProvince;
-    String adminPostalCode = EDStatic.adminPostalCode == null ? unknown : EDStatic.adminPostalCode;
-    String adminCountry = EDStatic.adminCountry == null ? unknown : EDStatic.adminCountry;
-    String adminEmail = EDStatic.adminEmail == null ? unknown : EDStatic.adminEmail;
+        EDStatic.config.adminStateOrProvince == null
+            ? unknown
+            : EDStatic.config.adminStateOrProvince;
+    String adminPostalCode =
+        EDStatic.config.adminPostalCode == null ? unknown : EDStatic.config.adminPostalCode;
+    String adminCountry =
+        EDStatic.config.adminCountry == null ? unknown : EDStatic.config.adminCountry;
+    String adminEmail = EDStatic.config.adminEmail == null ? unknown : EDStatic.config.adminEmail;
 
     // testMinimalMetadata is useful for Bob doing tests of validity of FGDC results
     //  when a dataset has minimal metadata
@@ -16677,7 +16687,7 @@ public abstract class EDDGrid extends EDD {
     String datasetUrl = tErddapUrl + "/griddap/" + datasetID;
     // String wcsUrl     = tErddapUrl + "/wcs/"     + datasetID() + "/" + wcsServer;  // "?" at end?
     String wmsUrl = tErddapUrl + "/wms/" + datasetID() + "/" + WMS_SERVER; // "?" at end?
-    String domain = EDStatic.baseUrl;
+    String domain = EDStatic.config.baseUrl;
     if (domain.startsWith("http://")) domain = domain.substring(7);
     else if (domain.startsWith("https://")) domain = domain.substring(8);
     String eddCreationDate = Calendar2.millisToIsoDateString(creationTimeMillis());
@@ -16712,7 +16722,7 @@ public abstract class EDDGrid extends EDD {
     String institution = combinedGlobalAttributes.getString("institution");
     String keywords = combinedGlobalAttributes.getString("keywords");
     if (keywords == null) { // use the crude, ERDDAP keywords
-      keywords = EDStatic.keywords;
+      keywords = EDStatic.config.keywords;
     }
     String license = combinedGlobalAttributes.getString("license");
     String project = combinedGlobalAttributes.getString("project");
@@ -16859,12 +16869,12 @@ public abstract class EDDGrid extends EDD {
             + "    <gmd:CI_ResponsibleParty>\n"
             + "      <gmd:individualName>\n"
             + "        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminIndividualName)
+            + XML.encodeAsXML(EDStatic.config.adminIndividualName)
             + "</gco:CharacterString>\n"
             + "      </gmd:individualName>\n"
             + "      <gmd:organisationName>\n"
             + "        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminInstitution)
+            + XML.encodeAsXML(EDStatic.config.adminInstitution)
             + "</gco:CharacterString>\n"
             + "      </gmd:organisationName>\n"
             + "      <gmd:contactInfo>\n"
@@ -16873,7 +16883,7 @@ public abstract class EDDGrid extends EDD {
             + "            <gmd:CI_Telephone>\n"
             + "              <gmd:voice>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPhone)
+            + XML.encodeAsXML(EDStatic.config.adminPhone)
             + "</gco:CharacterString>\n"
             + "              </gmd:voice>\n"
             + "            </gmd:CI_Telephone>\n"
@@ -16882,32 +16892,32 @@ public abstract class EDDGrid extends EDD {
             + "            <gmd:CI_Address>\n"
             + "              <gmd:deliveryPoint>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminAddress)
+            + XML.encodeAsXML(EDStatic.config.adminAddress)
             + "</gco:CharacterString>\n"
             + "              </gmd:deliveryPoint>\n"
             + "              <gmd:city>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCity)
+            + XML.encodeAsXML(EDStatic.config.adminCity)
             + "</gco:CharacterString>\n"
             + "              </gmd:city>\n"
             + "              <gmd:administrativeArea>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+            + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
             + "</gco:CharacterString>\n"
             + "              </gmd:administrativeArea>\n"
             + "              <gmd:postalCode>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPostalCode)
+            + XML.encodeAsXML(EDStatic.config.adminPostalCode)
             + "</gco:CharacterString>\n"
             + "              </gmd:postalCode>\n"
             + "              <gmd:country>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCountry)
+            + XML.encodeAsXML(EDStatic.config.adminCountry)
             + "</gco:CharacterString>\n"
             + "              </gmd:country>\n"
             + "              <gmd:electronicMailAddress>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminEmail)
+            + XML.encodeAsXML(EDStatic.config.adminEmail)
             + "</gco:CharacterString>\n"
             + "              </gmd:electronicMailAddress>\n"
             + "            </gmd:CI_Address>\n"
@@ -17989,12 +17999,12 @@ public abstract class EDDGrid extends EDD {
             "            <gmd:CI_ResponsibleParty>\n"
             + "              <gmd:individualName>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminIndividualName)
+            + XML.encodeAsXML(EDStatic.config.adminIndividualName)
             + "</gco:CharacterString>\n"
             + "              </gmd:individualName>\n"
             + "              <gmd:organisationName>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminInstitution)
+            + XML.encodeAsXML(EDStatic.config.adminInstitution)
             + "</gco:CharacterString>\n"
             + "              </gmd:organisationName>\n"
             + "              <gmd:contactInfo>\n"
@@ -18003,7 +18013,7 @@ public abstract class EDDGrid extends EDD {
             + "                    <gmd:CI_Telephone>\n"
             + "                      <gmd:voice>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPhone)
+            + XML.encodeAsXML(EDStatic.config.adminPhone)
             + "</gco:CharacterString>\n"
             + "                      </gmd:voice>\n"
             + "                    </gmd:CI_Telephone>\n"
@@ -18012,32 +18022,32 @@ public abstract class EDDGrid extends EDD {
             + "                    <gmd:CI_Address>\n"
             + "                      <gmd:deliveryPoint>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminAddress)
+            + XML.encodeAsXML(EDStatic.config.adminAddress)
             + "</gco:CharacterString>\n"
             + "                      </gmd:deliveryPoint>\n"
             + "                      <gmd:city>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCity)
+            + XML.encodeAsXML(EDStatic.config.adminCity)
             + "</gco:CharacterString>\n"
             + "                      </gmd:city>\n"
             + "                      <gmd:administrativeArea>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+            + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
             + "</gco:CharacterString>\n"
             + "                      </gmd:administrativeArea>\n"
             + "                      <gmd:postalCode>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPostalCode)
+            + XML.encodeAsXML(EDStatic.config.adminPostalCode)
             + "</gco:CharacterString>\n"
             + "                      </gmd:postalCode>\n"
             + "                      <gmd:country>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCountry)
+            + XML.encodeAsXML(EDStatic.config.adminCountry)
             + "</gco:CharacterString>\n"
             + "                      </gmd:country>\n"
             + "                      <gmd:electronicMailAddress>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminEmail)
+            + XML.encodeAsXML(EDStatic.config.adminEmail)
             + "</gco:CharacterString>\n"
             + "                      </gmd:electronicMailAddress>\n"
             + "                    </gmd:CI_Address>\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -289,64 +289,64 @@ public abstract class EDDGrid extends EDD {
     int nDFTN = dataFileTypeNames.size();
     int nIFTN = imageFileTypeNames.size();
 
-    dataFileTypeDescriptionsAr = new String[EDStatic.nLanguages][nDFTN];
-    imageFileTypeDescriptionsAr = new String[EDStatic.nLanguages][nIFTN];
+    dataFileTypeDescriptionsAr = new String[EDStatic.messages.nLanguages][nDFTN];
+    imageFileTypeDescriptionsAr = new String[EDStatic.messages.nLanguages][nIFTN];
 
-    for (int tl = 0; tl < EDStatic.nLanguages; tl++) {
+    for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++) {
       dataFileTypeDescriptionsAr[tl] =
           new String[] {
-            EDStatic.fileHelp_ascAr[tl],
-            EDStatic.fileHelp_csvAr[tl],
-            EDStatic.fileHelp_csvpAr[tl],
-            EDStatic.fileHelp_csv0Ar[tl],
-            EDStatic.fileHelp_dasAr[tl],
-            EDStatic.fileHelp_ddsAr[tl],
-            EDStatic.fileHelp_dodsAr[tl],
-            EDStatic.fileHelpGrid_esriAsciiAr[tl],
+            EDStatic.messages.fileHelp_ascAr[tl],
+            EDStatic.messages.fileHelp_csvAr[tl],
+            EDStatic.messages.fileHelp_csvpAr[tl],
+            EDStatic.messages.fileHelp_csv0Ar[tl],
+            EDStatic.messages.fileHelp_dasAr[tl],
+            EDStatic.messages.fileHelp_ddsAr[tl],
+            EDStatic.messages.fileHelp_dodsAr[tl],
+            EDStatic.messages.fileHelpGrid_esriAsciiAr[tl],
             // "Download a GMT-style NetCDF .grd file (for lat lon data only).",
             // "Download a Hierarchal Data Format Version 4 SDS file (for lat lon data only).",
-            EDStatic.fileHelp_fgdcAr[tl],
-            EDStatic.fileHelp_graphAr[tl],
-            EDStatic.fileHelpGrid_helpAr[tl],
-            EDStatic.fileHelp_htmlAr[tl],
-            EDStatic.fileHelp_htmlTableAr[tl],
-            EDStatic.fileHelp_iso19115Ar[tl],
-            EDStatic.fileHelp_itxGridAr[tl],
-            EDStatic.fileHelp_jsonAr[tl],
-            EDStatic.fileHelp_jsonlCSV1Ar[tl],
-            EDStatic.fileHelp_jsonlCSVAr[tl],
-            EDStatic.fileHelp_jsonlKVPAr[tl],
-            EDStatic.fileHelp_matAr[tl],
-            EDStatic.fileHelpGrid_nc3Ar[tl],
-            EDStatic.fileHelp_nc3HeaderAr[tl],
-            EDStatic.fileHelp_ncmlAr[tl],
-            //        EDStatic.fileHelpGrid_nc4Ar[tl],
-            //        EDStatic.fileHelp_nc4HeaderAr[tl],
-            EDStatic.fileHelp_nccsvAr[tl],
-            EDStatic.fileHelp_nccsvMetadataAr[tl],
-            EDStatic.fileHelp_ncoJsonAr[tl],
-            EDStatic.fileHelpGrid_odvTxtAr[tl],
-            EDStatic.fileHelp_parquetAr[tl],
-            EDStatic.fileHelp_parquet_with_metaAr[tl],
-            EDStatic.fileHelp_timeGapsAr[tl],
-            EDStatic.fileHelp_tsvAr[tl],
-            EDStatic.fileHelp_tsvpAr[tl],
-            EDStatic.fileHelp_tsv0Ar[tl],
-            EDStatic.fileHelp_wavAr[tl],
-            EDStatic.fileHelp_xhtmlAr[tl]
+            EDStatic.messages.fileHelp_fgdcAr[tl],
+            EDStatic.messages.fileHelp_graphAr[tl],
+            EDStatic.messages.fileHelpGrid_helpAr[tl],
+            EDStatic.messages.fileHelp_htmlAr[tl],
+            EDStatic.messages.fileHelp_htmlTableAr[tl],
+            EDStatic.messages.fileHelp_iso19115Ar[tl],
+            EDStatic.messages.fileHelp_itxGridAr[tl],
+            EDStatic.messages.fileHelp_jsonAr[tl],
+            EDStatic.messages.fileHelp_jsonlCSV1Ar[tl],
+            EDStatic.messages.fileHelp_jsonlCSVAr[tl],
+            EDStatic.messages.fileHelp_jsonlKVPAr[tl],
+            EDStatic.messages.fileHelp_matAr[tl],
+            EDStatic.messages.fileHelpGrid_nc3Ar[tl],
+            EDStatic.messages.fileHelp_nc3HeaderAr[tl],
+            EDStatic.messages.fileHelp_ncmlAr[tl],
+            //        EDStatic.messages.fileHelpGrid_nc4Ar[tl],
+            //        EDStatic.messages.fileHelp_nc4HeaderAr[tl],
+            EDStatic.messages.fileHelp_nccsvAr[tl],
+            EDStatic.messages.fileHelp_nccsvMetadataAr[tl],
+            EDStatic.messages.fileHelp_ncoJsonAr[tl],
+            EDStatic.messages.fileHelpGrid_odvTxtAr[tl],
+            EDStatic.messages.fileHelp_parquetAr[tl],
+            EDStatic.messages.fileHelp_parquet_with_metaAr[tl],
+            EDStatic.messages.fileHelp_timeGapsAr[tl],
+            EDStatic.messages.fileHelp_tsvAr[tl],
+            EDStatic.messages.fileHelp_tsvpAr[tl],
+            EDStatic.messages.fileHelp_tsv0Ar[tl],
+            EDStatic.messages.fileHelp_wavAr[tl],
+            EDStatic.messages.fileHelp_xhtmlAr[tl]
           };
 
       imageFileTypeDescriptionsAr[tl] =
           new String[] {
-            EDStatic.fileHelp_geotifAr[tl],
-            EDStatic.fileHelpGrid_kmlAr[tl],
-            EDStatic.fileHelp_smallPdfAr[tl],
-            EDStatic.fileHelp_pdfAr[tl],
-            EDStatic.fileHelp_largePdfAr[tl],
-            EDStatic.fileHelp_smallPngAr[tl],
-            EDStatic.fileHelp_pngAr[tl],
-            EDStatic.fileHelp_largePngAr[tl],
-            EDStatic.fileHelp_transparentPngAr[tl]
+            EDStatic.messages.fileHelp_geotifAr[tl],
+            EDStatic.messages.fileHelpGrid_kmlAr[tl],
+            EDStatic.messages.fileHelp_smallPdfAr[tl],
+            EDStatic.messages.fileHelp_pdfAr[tl],
+            EDStatic.messages.fileHelp_largePdfAr[tl],
+            EDStatic.messages.fileHelp_smallPngAr[tl],
+            EDStatic.messages.fileHelp_pngAr[tl],
+            EDStatic.messages.fileHelp_largePngAr[tl],
+            EDStatic.messages.fileHelp_transparentPngAr[tl]
           }; // .transparentPng: if lon and lat are evenly spaced, .png size will be 1:1; otherwise,
       // 1:1 but morphed a little
     }
@@ -387,16 +387,16 @@ public abstract class EDDGrid extends EDD {
     publicGraphFileTypeNames[5] = ".iso19115";
 
     // construct allFileTypeOptions
-    allFileTypeOptionsAr = new String[EDStatic.nLanguages][nDFTN + nIFTN];
+    allFileTypeOptionsAr = new String[EDStatic.messages.nLanguages][nDFTN + nIFTN];
     allFileTypeNames = new String[nDFTN + nIFTN];
     for (int i = 0; i < nDFTN; i++) {
-      for (int tl = 0; tl < EDStatic.nLanguages; tl++)
+      for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++)
         allFileTypeOptionsAr[tl][i] =
             dataFileTypeNames.get(i) + " - " + dataFileTypeDescriptionsAr[tl][i];
       allFileTypeNames[i] = dataFileTypeNames.get(i);
     }
     for (int i = 0; i < nIFTN; i++) {
-      for (int tl = 0; tl < EDStatic.nLanguages; tl++)
+      for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++)
         allFileTypeOptionsAr[tl][nDFTN + i] =
             imageFileTypeNames.get(i) + " - " + imageFileTypeDescriptionsAr[tl][i];
       allFileTypeNames[nDFTN + i] = imageFileTypeNames.get(i);
@@ -683,7 +683,9 @@ public abstract class EDDGrid extends EDD {
         accessibleViaMAG =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[0], EDStatic.magAr[0], EDStatic.noXxxNoAxis1Ar[0]));
+                    EDStatic.messages.noXxxBecause2Ar[0],
+                    EDStatic.messages.magAr[0],
+                    EDStatic.messages.noXxxNoAxis1Ar[0]));
       } else {
 
         // find the numeric dataVariables
@@ -699,9 +701,9 @@ public abstract class EDDGrid extends EDD {
           accessibleViaMAG =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[0],
-                      EDStatic.magAr[0],
-                      EDStatic.noXxxNoNonStringAr[0]));
+                      EDStatic.messages.noXxxBecause2Ar[0],
+                      EDStatic.messages.magAr[0],
+                      EDStatic.messages.noXxxNoNonStringAr[0]));
       }
     }
     return accessibleViaMAG;
@@ -714,9 +716,9 @@ public abstract class EDDGrid extends EDD {
       accessibleViaSubset =
           String2.canonical(
               MessageFormat.format(
-                  EDStatic.noXxxBecause2Ar[0],
-                  EDStatic.subsetAr[0],
-                  EDStatic.noXxxItsGriddedAr[0]));
+                  EDStatic.messages.noXxxBecause2Ar[0],
+                  EDStatic.messages.subsetAr[0],
+                  EDStatic.messages.noXxxItsGriddedAr[0]));
     return accessibleViaSubset;
   }
 
@@ -729,14 +731,16 @@ public abstract class EDDGrid extends EDD {
         accessibleViaSOS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "SOS",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "SOS")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "SOS")));
       else
         accessibleViaSOS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0], "SOS", EDStatic.noXxxItsGriddedAr[0]));
+                    EDStatic.messages.noXxxBecauseAr[0],
+                    "SOS",
+                    EDStatic.messages.noXxxItsGriddedAr[0]));
     }
     return accessibleViaSOS;
   }
@@ -750,15 +754,18 @@ public abstract class EDDGrid extends EDD {
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "GeoServicesRest",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "GeoServicesRest")));
+                    MessageFormat.format(
+                        EDStatic.messages.noXxxNotActiveAr[0], "GeoServicesRest")));
       } else if (lonIndex < 0 || latIndex < 0) {
         // must have lat and lon axes
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0], "GeoServicesRest", EDStatic.noXxxNoLLAr[0]));
+                    EDStatic.messages.noXxxBecauseAr[0],
+                    "GeoServicesRest",
+                    EDStatic.messages.noXxxNoLLAr[0]));
       } else {
         // must have more than one value for lat and lon axes
         EDVGridAxis lonVar = axisVariables[lonIndex];
@@ -769,25 +776,27 @@ public abstract class EDDGrid extends EDD {
           accessibleViaGeoServicesRest =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "GeoServicesRest", EDStatic.noXxxNoLLGt1Ar[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "GeoServicesRest",
+                      EDStatic.messages.noXxxNoLLGt1Ar[0]));
         else if (lonVar.destinationMinDouble() >= 360
             || // unlikely
             lonVar.destinationMaxDouble() <= -180) // unlikely
         accessibleViaGeoServicesRest =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0],
+                      EDStatic.messages.noXxxBecauseAr[0],
                       "GeoServicesRest",
-                      EDStatic.noXxxNoLonIn180Ar[0]));
+                      EDStatic.messages.noXxxNoLonIn180Ar[0]));
         else if (!lonVar.isEvenlySpaced()
             || // ???Future: not necessary? draw map as appropriate.
             !latVar.isEvenlySpaced())
           accessibleViaGeoServicesRest =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0],
+                      EDStatic.messages.noXxxBecauseAr[0],
                       "GeoServicesRest",
-                      EDStatic.noXxxNoLLEvenlySpacedAr[0]));
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[0]));
 
         // else {  //NO. other axes are allowed.
 
@@ -806,9 +815,9 @@ public abstract class EDDGrid extends EDD {
           accessibleViaGeoServicesRest =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0],
+                      EDStatic.messages.noXxxBecauseAr[0],
                       "GeoServicesRest",
-                      EDStatic.noXxxNoColorBarAr[0]));
+                      EDStatic.messages.noXxxNoColorBarAr[0]));
       }
 
       // okay!
@@ -830,14 +839,15 @@ public abstract class EDDGrid extends EDD {
         accessibleViaWCS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "WCS",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "WCS")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "WCS")));
       else if (lonIndex < 0 || latIndex < 0)
         // must have lat and lon axes
         accessibleViaWCS =
             String2.canonical(
-                MessageFormat.format(EDStatic.noXxxBecauseAr[0], "WCS", EDStatic.noXxxNoLLAr[0]));
+                MessageFormat.format(
+                    EDStatic.messages.noXxxBecauseAr[0], "WCS", EDStatic.messages.noXxxNoLLAr[0]));
       else {
         // must have more than one value for lat and lon axes
         EDVGridAxis lonVar = axisVariables[lonIndex];
@@ -848,21 +858,27 @@ public abstract class EDDGrid extends EDD {
           accessibleViaWCS =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "WCS", EDStatic.noXxxNoLLGt1Ar[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "WCS",
+                      EDStatic.messages.noXxxNoLLGt1Ar[0]));
         else if (lonVar.destinationMinDouble() >= 360
             || // unlikely
             lonVar.destinationMaxDouble() <= -180) // unlikely
         accessibleViaWCS =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "WCS", EDStatic.noXxxNoLonIn180Ar[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "WCS",
+                      EDStatic.messages.noXxxNoLonIn180Ar[0]));
         else if (!lonVar.isEvenlySpaced()
             || // ???Future: not necessary? draw map as appropriate.
             !latVar.isEvenlySpaced())
           accessibleViaWCS =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "WCS", EDStatic.noXxxNoLLEvenlySpacedAr[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "WCS",
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[0]));
 
         // else {  //NO. other axes are allowed.
 
@@ -884,13 +900,14 @@ public abstract class EDDGrid extends EDD {
         accessibleViaWMS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "WMS",
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "WMS")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "WMS")));
       else if (lonIndex < 0 || latIndex < 0)
         accessibleViaWMS =
             String2.canonical(
-                MessageFormat.format(EDStatic.noXxxBecauseAr[0], "WMS", EDStatic.noXxxNoLLAr[0]));
+                MessageFormat.format(
+                    EDStatic.messages.noXxxBecauseAr[0], "WMS", EDStatic.messages.noXxxNoLLAr[0]));
       else {
         EDVGridAxis lonVar = axisVariables[lonIndex];
         EDVGridAxis latVar = axisVariables[latIndex];
@@ -900,14 +917,18 @@ public abstract class EDDGrid extends EDD {
           accessibleViaWMS =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "WMS", EDStatic.noXxxNoLLGt1Ar[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "WMS",
+                      EDStatic.messages.noXxxNoLLGt1Ar[0]));
         else if (lonVar.destinationMinDouble() >= 360
             || // unlikely
             lonVar.destinationMaxDouble() <= -180) // unlikely
         accessibleViaWMS =
               String2.canonical(
                   MessageFormat.format(
-                      EDStatic.noXxxBecauseAr[0], "WMS", EDStatic.noXxxNoLonIn180Ar[0]));
+                      EDStatic.messages.noXxxBecauseAr[0],
+                      "WMS",
+                      EDStatic.messages.noXxxNoLonIn180Ar[0]));
         // else if (!lonVar.isEvenlySpaced() ||  //not necessary. map is drawn as appropriate.
         //    !latVar.isEvenlySpaced())
         //   accessibleViaWMS = String2.canonical(start + "???";
@@ -915,7 +936,9 @@ public abstract class EDDGrid extends EDD {
         else {
           String ta =
               MessageFormat.format(
-                  EDStatic.noXxxBecauseAr[0], "WMS", EDStatic.noXxxNoColorBarAr[0]);
+                  EDStatic.messages.noXxxBecauseAr[0],
+                  "WMS",
+                  EDStatic.messages.noXxxNoColorBarAr[0]);
           for (EDV dataVariable : dataVariables) {
             if (dataVariable.hasColorBarMinMax()) {
               ta = ""; // set back to OK
@@ -964,7 +987,7 @@ public abstract class EDDGrid extends EDD {
    */
   @Override
   public String dapDescription(int language) {
-    return EDStatic.EDDGridDapDescriptionAr[language];
+    return EDStatic.messages.EDDGridDapDescriptionAr[language];
   }
 
   /**
@@ -975,7 +998,7 @@ public abstract class EDDGrid extends EDD {
    */
   public static String longDapDescription(int language, String tErddapUrl) {
     return String2.replaceAll(
-        EDStatic.EDDGridDapLongDescriptionAr[language], "&erddapUrl;", tErddapUrl);
+        EDStatic.messages.EDDGridDapLongDescriptionAr[language], "&erddapUrl;", tErddapUrl);
   }
 
   /**
@@ -1293,11 +1316,11 @@ public abstract class EDDGrid extends EDD {
           EDStatic.bilingual(
               language,
               MessageFormat.format(
-                  EDStatic.errorNotFoundInAr[0],
+                  EDStatic.messages.errorNotFoundInAr[0],
                   "sourceAxisVariableName=" + tSourceName,
                   "datasetID=" + datasetID),
               MessageFormat.format(
-                  EDStatic.errorNotFoundInAr[language],
+                  EDStatic.messages.errorNotFoundInAr[language],
                   "sourceAxisVariableName=" + tSourceName,
                   "datasetID=" + datasetID)));
     return axisVariables[which];
@@ -1318,11 +1341,11 @@ public abstract class EDDGrid extends EDD {
           EDStatic.bilingual(
               language,
               MessageFormat.format(
-                  EDStatic.errorNotFoundInAr[0],
+                  EDStatic.messages.errorNotFoundInAr[0],
                   "variableName=" + tDestinationName,
                   "datasetID=" + datasetID),
               MessageFormat.format(
-                  EDStatic.errorNotFoundInAr[language],
+                  EDStatic.messages.errorNotFoundInAr[language],
                   "variableName=" + tDestinationName,
                   "datasetID=" + datasetID)));
     return axisVariables[which];
@@ -1493,8 +1516,9 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0] + EDStatic.queryErrorGridAmpAr[0],
-                EDStatic.queryErrorAr[language] + EDStatic.queryErrorGridAmpAr[language]));
+                EDStatic.messages.queryErrorAr[0] + EDStatic.messages.queryErrorGridAmpAr[0],
+                EDStatic.messages.queryErrorAr[language]
+                    + EDStatic.messages.queryErrorGridAmpAr[language]));
     }
     String query = ampParts[0]; // it has been percentDecoded
 
@@ -1534,11 +1558,12 @@ public abstract class EDDGrid extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
-                          + MessageFormat.format(EDStatic.queryErrorGridNoAxisVarAr[0], destName),
-                      EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorGridNoAxisVarAr[language], destName)));
+                              EDStatic.messages.queryErrorGridNoAxisVarAr[0], destName),
+                      EDStatic.messages.queryErrorAr[language]
+                          + MessageFormat.format(
+                              EDStatic.messages.queryErrorGridNoAxisVarAr[language], destName)));
             findDataVariableByDestinationName(destName); // throws Throwable if trouble
           }
         }
@@ -1548,7 +1573,7 @@ public abstract class EDDGrid extends EDD {
         if (tdi >= 0) {
           if (!repair)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "Variable name='"
                     + destName
                     + "' occurs twice.");
@@ -1570,15 +1595,15 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryErrorExpectedAtAr[0],
+                            EDStatic.messages.queryErrorExpectedAtAr[0],
                             ",\" or \"[end of query]",
                             "" + po,
                             "\"" + query.charAt(po) + "\""),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryErrorExpectedAtAr[language],
+                            EDStatic.messages.queryErrorExpectedAtAr[language],
                             ",\" or \"[end of query]",
                             "" + po,
                             "\"" + query.charAt(po) + "\"")));
@@ -1595,12 +1620,15 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorExpectedAtAr[0], "[", "" + po, "[end of query]"),
-                  EDStatic.queryErrorAr[language]
+                          EDStatic.messages.queryErrorExpectedAtAr[0],
+                          "[",
+                          "" + po,
+                          "[end of query]"),
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorExpectedAtAr[language],
+                          EDStatic.messages.queryErrorExpectedAtAr[language],
                           "[",
                           "" + po,
                           "[end of query]")));
@@ -1632,11 +1660,12 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
-                      + MessageFormat.format(EDStatic.queryErrorOccursTwiceAr[0], destinationName),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorOccursTwiceAr[language], destinationName)));
+                          EDStatic.messages.queryErrorOccursTwiceAr[0], destinationName),
+                  EDStatic.messages.queryErrorAr[language]
+                      + MessageFormat.format(
+                          EDStatic.messages.queryErrorOccursTwiceAr[language], destinationName)));
       } else {
         destinationNames.add(destinationName);
       }
@@ -1667,9 +1696,9 @@ public abstract class EDDGrid extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorGridNotIdenticalAr[0],
+                              EDStatic.messages.queryErrorGridNotIdenticalAr[0],
                               axisVariableDestinationNames()[axis]
                                   + "["
                                   + startI
@@ -1688,9 +1717,9 @@ public abstract class EDDGrid extends EDD {
                                   + constraints.get(axis * 3 + 2)
                                   + "]"
                                   + destinationNames.get(0)),
-                      EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorAr[language]
                           + MessageFormat.format(
-                              EDStatic.queryErrorGridNotIdenticalAr[language],
+                              EDStatic.messages.queryErrorGridNotIdenticalAr[language],
                               axisVariableDestinationNames()[axis]
                                   + "["
                                   + startI
@@ -1761,13 +1790,15 @@ public abstract class EDDGrid extends EDD {
     // ensure not nothing (which is a data request)
     if (ampParts[0].length() == 0)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorGrid1AxisAr));
+          EDStatic.bilingual(
+              language, EDStatic.messages.queryErrorAr, EDStatic.messages.queryErrorGrid1AxisAr));
 
     // ignore any &.cmd constraints
     for (int ap = 1; ap < ampParts.length; ap++)
       if (!repair && !ampParts[ap].startsWith("."))
         throw new SimpleException(
-            EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorGridAmpAr));
+            EDStatic.bilingual(
+                language, EDStatic.messages.queryErrorAr, EDStatic.messages.queryErrorGridAmpAr));
     userDapQuery = ampParts[0];
 
     // get the destinationNames
@@ -1791,13 +1822,13 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorUnknownVariableAr[0],
+                          EDStatic.messages.queryErrorUnknownVariableAr[0],
                           destinationName.substring(0, period)),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorUnknownVariableAr[language],
+                          EDStatic.messages.queryErrorUnknownVariableAr[language],
                           destinationName.substring(0, period))));
         destinationName = destinationName.substring(period + 1);
       }
@@ -1812,12 +1843,13 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridNoDataVarAr[0], destinationName),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.queryErrorGridNoDataVarAr[0], destinationName),
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridNoDataVarAr[language], destinationName)));
+                            EDStatic.messages.queryErrorGridNoDataVarAr[language],
+                            destinationName)));
           findAxisVariableByDestinationName(
               language, destinationName); // throws Throwable if trouble
         }
@@ -1831,11 +1863,12 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
-                      + MessageFormat.format(EDStatic.queryErrorOccursTwiceAr[0], destinationName),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorOccursTwiceAr[language], destinationName)));
+                          EDStatic.messages.queryErrorOccursTwiceAr[0], destinationName),
+                  EDStatic.messages.queryErrorAr[language]
+                      + MessageFormat.format(
+                          EDStatic.messages.queryErrorOccursTwiceAr[language], destinationName)));
       } else {
         destinationNames.add(destinationName);
       }
@@ -1853,14 +1886,14 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorNotExpectedAtAr[0],
+                          EDStatic.messages.queryErrorNotExpectedAtAr[0],
                           userDapQuery.charAt(po),
                           "" + (po + 1)),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorNotExpectedAtAr[language],
+                          EDStatic.messages.queryErrorNotExpectedAtAr[language],
                           userDapQuery.charAt(po),
                           "" + (po + 1))));
         // if (reallyVerbose) String2.log("      axis=" + axis +
@@ -1913,13 +1946,13 @@ public abstract class EDDGrid extends EDD {
             : av.destinationDataPAType() == PAType.DOUBLE ? 9 : 5;
     String diagnostic0 =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[0],
+            EDStatic.messages.queryErrorGridDiagnosticAr[0],
             destinationName,
             "" + axis,
             av.destinationName());
     String diagnosticl =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[language],
+            EDStatic.messages.queryErrorGridDiagnosticAr[language],
             destinationName,
             "" + axis,
             av.destinationName());
@@ -1938,21 +1971,21 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + diagnostic0
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorExpectedAtAr[0],
+                        EDStatic.messages.queryErrorExpectedAtAr[0],
                         "[",
                         "" + po,
                         po >= deQuery.length()
                             ? "[end of query]"
                             : "\"" + deQuery.charAt(po) + "\""),
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + diagnosticl
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorExpectedAtAr[language],
+                        EDStatic.messages.queryErrorExpectedAtAr[language],
                         "[",
                         "" + po,
                         po >= deQuery.length()
@@ -1969,22 +2002,27 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + diagnostic0
                     + ": "
-                    + MessageFormat.format(EDStatic.queryErrorNotFoundAfterAr[0], "]", "" + leftPo),
-                EDStatic.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryErrorNotFoundAfterAr[0], "]", "" + leftPo),
+                EDStatic.messages.queryErrorAr[language]
                     + diagnosticl
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorNotFoundAfterAr[language], "]", "" + leftPo)));
+                        EDStatic.messages.queryErrorNotFoundAfterAr[language], "]", "" + leftPo)));
     }
     defaults[3] = rightPo;
     diagnostic0 +=
-        " " + EDStatic.EDDConstraintAr[0] + "=\"" + deQuery.substring(leftPo, rightPo + 1) + "\"";
+        " "
+            + EDStatic.messages.EDDConstraintAr[0]
+            + "=\""
+            + deQuery.substring(leftPo, rightPo + 1)
+            + "\"";
     diagnosticl +=
         " "
-            + EDStatic.EDDConstraintAr[language]
+            + EDStatic.messages.EDDConstraintAr[language]
             + "=\""
             + deQuery.substring(leftPo, rightPo + 1)
             + "\"";
@@ -2009,16 +2047,18 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorNotFoundAfterAr[0], ")", "" + leftPo),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.queryErrorNotFoundAfterAr[0], ")", "" + leftPo),
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorNotFoundAfterAr[language], ")", "" + leftPo)));
+                            EDStatic.messages.queryErrorNotFoundAfterAr[language],
+                            ")",
+                            "" + leftPo)));
         }
         colon1++;
       } else {
@@ -2042,16 +2082,18 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorNotFoundAfterAr[0], ")", "" + (colon2 + 2)),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.queryErrorNotFoundAfterAr[0], ")", "" + (colon2 + 2)),
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorNotFoundAfterAr[language], ")", "" + (colon2 + 2))));
+                            EDStatic.messages.queryErrorNotFoundAfterAr[language],
+                            ")",
+                            "" + (colon2 + 2))));
         } else {
           // next char must be ']' or ':'
           colon2++;
@@ -2065,19 +2107,19 @@ public abstract class EDDGrid extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + diagnostic0
                           + ": "
                           + MessageFormat.format(
-                              EDStatic.queryErrorExpectedAtAr[0],
+                              EDStatic.messages.queryErrorExpectedAtAr[0],
                               "]\" or \":",
                               "" + colon2,
                               "\"" + deQuery.charAt(colon2) + "\""),
-                      EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorAr[language]
                           + diagnosticl
                           + ": "
                           + MessageFormat.format(
-                              EDStatic.queryErrorExpectedAtAr[language],
+                              EDStatic.messages.queryErrorExpectedAtAr[language],
                               "]\" or \":",
                               "" + colon2,
                               "\"" + deQuery.charAt(colon2) + "\"")));
@@ -2114,18 +2156,18 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorInvalidAr[0],
-                            EDStatic.EDDGridStrideAr[0] + "=" + strideS),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.queryErrorInvalidAr[0],
+                            EDStatic.messages.EDDGridStrideAr[0] + "=" + strideS),
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorInvalidAr[language],
-                            EDStatic.EDDGridStrideAr[language] + "=" + strideS)));
+                            EDStatic.messages.queryErrorInvalidAr[language],
+                            EDStatic.messages.EDDGridStrideAr[language] + "=" + strideS)));
         }
       }
       startS = startS.trim();
@@ -2136,7 +2178,7 @@ public abstract class EDDGrid extends EDD {
       //    startI = av.sourceValues().size() - 1;
       // } else
       if (startS.startsWith("last") || startS.startsWith("(last"))
-        startS = convertLast(language, av, EDStatic.EDDGridStartAr, startS);
+        startS = convertLast(language, av, EDStatic.messages.EDDGridStartAr, startS);
 
       if (startS.startsWith("(")) {
         // convert paren startS
@@ -2145,17 +2187,18 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + diagnostic0
                       + ": "
                       + MessageFormat.format(
-                          EDStatic.queryErrorGridMissingAr[0], EDStatic.EDDGridStartAr[0]),
-                  EDStatic.queryErrorAr[language]
+                          EDStatic.messages.queryErrorGridMissingAr[0],
+                          EDStatic.messages.EDDGridStartAr[0]),
+                  EDStatic.messages.queryErrorAr[language]
                       + diagnosticl
                       + ": "
                       + MessageFormat.format(
-                          EDStatic.queryErrorGridMissingAr[language],
-                          EDStatic.EDDGridStartAr[language])));
+                          EDStatic.messages.queryErrorGridMissingAr[language],
+                          EDStatic.messages.EDDGridStartAr[language])));
         double startDestD =
             av.destinationToDouble(startS); // ISO 8601 times -> to epochSeconds w/millis precision
         // String2.log("\n! startS=" + startS + " startDestD=" + startDestD + "\n");
@@ -2167,18 +2210,19 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.notAllowedAr[0],
-                            EDStatic.EDDGridStartAr[0] + "=NaN (invalid format?)"),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.notAllowedAr[0],
+                            EDStatic.messages.EDDGridStartAr[0] + "=NaN (invalid format?)"),
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.notAllowedAr[language],
-                            EDStatic.EDDGridStartAr[language] + "=NaN (invalid format?)")));
+                            EDStatic.messages.notAllowedAr[language],
+                            EDStatic.messages.EDDGridStartAr[language]
+                                + "=NaN (invalid format?)")));
         }
 
         startDestD =
@@ -2188,7 +2232,7 @@ public abstract class EDDGrid extends EDD {
                 startS,
                 av,
                 repair,
-                EDStatic.EDDGridStartAr,
+                EDStatic.messages.EDDGridStartAr,
                 language,
                 diagnostic0,
                 diagnosticl);
@@ -2199,7 +2243,7 @@ public abstract class EDDGrid extends EDD {
                 startS,
                 av,
                 repair,
-                EDStatic.EDDGridStartAr,
+                EDStatic.messages.EDDGridStartAr,
                 language,
                 diagnostic0,
                 diagnosticl);
@@ -2216,20 +2260,20 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[0],
-                            EDStatic.EDDGridStartAr[0],
+                            EDStatic.messages.queryErrorGridBetweenAr[0],
+                            EDStatic.messages.EDDGridStartAr[0],
                             startS,
                             "" + (nAvSourceValues - 1)),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[language],
-                            EDStatic.EDDGridStartAr[language],
+                            EDStatic.messages.queryErrorGridBetweenAr[language],
+                            EDStatic.messages.EDDGridStartAr[language],
                             startS,
                             "" + (nAvSourceValues - 1))));
         }
@@ -2242,20 +2286,20 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[0],
-                            EDStatic.EDDGridStartAr[0],
+                            EDStatic.messages.queryErrorGridBetweenAr[0],
+                            EDStatic.messages.EDDGridStartAr[0],
                             startS,
                             "" + (nAvSourceValues - 1)),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[language],
-                            EDStatic.EDDGridStartAr[language],
+                            EDStatic.messages.queryErrorGridBetweenAr[language],
+                            EDStatic.messages.EDDGridStartAr[language],
                             startS,
                             "" + (nAvSourceValues - 1))));
         }
@@ -2266,7 +2310,7 @@ public abstract class EDDGrid extends EDD {
       //    stopI = av.sourceValues().size() - 1;
       // } else
       if (stopS.startsWith("last") || stopS.startsWith("(last"))
-        stopS = convertLast(language, av, EDStatic.EDDGridStopAr, stopS);
+        stopS = convertLast(language, av, EDStatic.messages.EDDGridStopAr, stopS);
 
       if (stopS.startsWith("(")) {
         // convert paren stopS
@@ -2275,17 +2319,18 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + diagnostic0
                       + ": "
                       + MessageFormat.format(
-                          EDStatic.queryErrorGridMissingAr[0], EDStatic.EDDGridStopAr[0]),
-                  EDStatic.queryErrorAr[language]
+                          EDStatic.messages.queryErrorGridMissingAr[0],
+                          EDStatic.messages.EDDGridStopAr[0]),
+                  EDStatic.messages.queryErrorAr[language]
                       + diagnosticl
                       + ": "
                       + MessageFormat.format(
-                          EDStatic.queryErrorGridMissingAr[language],
-                          EDStatic.EDDGridStopAr[language])));
+                          EDStatic.messages.queryErrorGridMissingAr[language],
+                          EDStatic.messages.EDDGridStopAr[language])));
         double stopDestD =
             av.destinationToDouble(stopS); // ISO 8601 times -> to epochSeconds w/millis precision
         // String2.log("\n! stopS=" + stopS + " stopDestD=" + stopDestD + "\n");
@@ -2297,18 +2342,18 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.notAllowedAr[0],
-                            EDStatic.EDDGridStopAr[0] + "=NaN (invalid format?)"),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.notAllowedAr[0],
+                            EDStatic.messages.EDDGridStopAr[0] + "=NaN (invalid format?)"),
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.notAllowedAr[language],
-                            EDStatic.EDDGridStopAr[language] + "=NaN (invalid format?)")));
+                            EDStatic.messages.notAllowedAr[language],
+                            EDStatic.messages.EDDGridStopAr[language] + "=NaN (invalid format?)")));
         }
 
         stopDestD =
@@ -2318,7 +2363,7 @@ public abstract class EDDGrid extends EDD {
                 stopS,
                 av,
                 repair,
-                EDStatic.EDDGridStopAr,
+                EDStatic.messages.EDDGridStopAr,
                 language,
                 diagnostic0,
                 diagnosticl);
@@ -2329,7 +2374,7 @@ public abstract class EDDGrid extends EDD {
                 stopS,
                 av,
                 repair,
-                EDStatic.EDDGridStopAr,
+                EDStatic.messages.EDDGridStopAr,
                 language,
                 diagnostic0,
                 diagnosticl);
@@ -2347,20 +2392,20 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[0],
-                            EDStatic.EDDGridStopAr[0],
+                            EDStatic.messages.queryErrorGridBetweenAr[0],
+                            EDStatic.messages.EDDGridStopAr[0],
                             stopS,
                             "" + (nAvSourceValues - 1)),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[language],
-                            EDStatic.EDDGridStopAr[language],
+                            EDStatic.messages.queryErrorGridBetweenAr[language],
+                            EDStatic.messages.EDDGridStopAr[language],
                             stopS,
                             "" + (nAvSourceValues - 1))));
         }
@@ -2371,20 +2416,20 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + diagnostic0
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[0],
-                            EDStatic.EDDGridStopAr[0],
+                            EDStatic.messages.queryErrorGridBetweenAr[0],
+                            EDStatic.messages.EDDGridStopAr[0],
                             stopS,
                             "" + (nAvSourceValues - 1)),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + diagnosticl
                         + ": "
                         + MessageFormat.format(
-                            EDStatic.queryErrorGridBetweenAr[language],
-                            EDStatic.EDDGridStopAr[language],
+                            EDStatic.messages.queryErrorGridBetweenAr[language],
+                            EDStatic.messages.EDDGridStopAr[language],
                             stopS,
                             "" + (nAvSourceValues - 1))));
         }
@@ -2413,7 +2458,8 @@ public abstract class EDDGrid extends EDD {
    *
    * @param language the index of the selected language
    * @param av an EDVGridAxis variable
-   * @param name EDStatic.EDDGridStartAr ("Start") or EDStatic.EDDGridStopAr ("Stop")
+   * @param name EDStatic.messages.EDDGridStartAr ("Start") or EDStatic.messages.EDDGridStopAr
+   *     ("Stop")
    * @param ssValue the start or stop value
    * @return ssValue converted to "index" or a "(value)"
    * @throws Throwable if invalid format or n is too large
@@ -2429,12 +2475,12 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastEndPAr[0], nameAr[0] + "=" + ossValue),
-                EDStatic.queryErrorAr[language]
+                        EDStatic.messages.queryErrorLastEndPAr[0], nameAr[0] + "=" + ossValue),
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastEndPAr[language],
+                        EDStatic.messages.queryErrorLastEndPAr[language],
                         nameAr[language] + "=" + ossValue)));
     }
 
@@ -2444,12 +2490,12 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.queryErrorLastExpectedAr[0], nameAr[0] + "=" + ossValue),
-              EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorLastExpectedAr[0], nameAr[0] + "=" + ossValue),
+              EDStatic.messages.queryErrorAr[language]
                   + MessageFormat.format(
-                      EDStatic.queryErrorLastExpectedAr[language],
+                      EDStatic.messages.queryErrorLastExpectedAr[language],
                       nameAr[language] + "=" + ossValue)));
 
     // done?
@@ -2463,12 +2509,12 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.queryErrorLastUnexpectedAr[0], nameAr[0] + "=" + ossValue),
-              EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorLastUnexpectedAr[0], nameAr[0] + "=" + ossValue),
+              EDStatic.messages.queryErrorAr[language]
                   + MessageFormat.format(
-                      EDStatic.queryErrorLastUnexpectedAr[language],
+                      EDStatic.messages.queryErrorLastUnexpectedAr[language],
                       nameAr[language] + "=" + ossValue)));
     ssValue = ssValue.substring(1).trim();
 
@@ -2479,12 +2525,12 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastPMInvalidAr[0], nameAr[0] + "=" + ossValue),
-                EDStatic.queryErrorAr[language]
+                        EDStatic.messages.queryErrorLastPMInvalidAr[0], nameAr[0] + "=" + ossValue),
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastPMInvalidAr[language],
+                        EDStatic.messages.queryErrorLastPMInvalidAr[language],
                         nameAr[language] + "=" + ossValue)));
       return "(" + (av.lastDestinationValue() + pm * td) + ")";
     } else {
@@ -2495,12 +2541,12 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastPMIntegerAr[0], nameAr[0] + "=" + ossValue),
-                EDStatic.queryErrorAr[language]
+                        EDStatic.messages.queryErrorLastPMIntegerAr[0], nameAr[0] + "=" + ossValue),
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorLastPMIntegerAr[language],
+                        EDStatic.messages.queryErrorLastPMIntegerAr[language],
                         nameAr[language] + "=" + ossValue)),
             t);
       }
@@ -2640,7 +2686,7 @@ public abstract class EDDGrid extends EDD {
     if (!oldSnapshot.get("nAv").equals(newSnapshot.get("nAv"))) {
       diff.append(
           MessageFormat.format(
-              EDStatic.EDDChangedAxesDifferentNVar,
+              EDStatic.messages.EDDChangedAxesDifferentNVar,
               oldSnapshot.get("nAv"),
               newSnapshot.get("nAv")));
       return diff.toString(); // because tests below assume nAv are same
@@ -2658,7 +2704,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldSnapshot.get(nameKey).equals(newSnapshot.get(nameKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "destinationName",
                     msg2,
                     oldSnapshot.get(nameKey),
@@ -2668,7 +2714,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldSnapshot.get(typeKey).equals(newSnapshot.get(typeKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "destinationDataType",
                     msg2,
                     oldSnapshot.get(typeKey),
@@ -2678,7 +2724,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldSnapshot.get(sourceSizeKey).equals(newSnapshot.get(sourceSizeKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "numberOfValues",
                     msg2,
                     oldSnapshot.get(sourceSizeKey),
@@ -2688,7 +2734,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldSnapshot.get(minKey).equals(newSnapshot.get(minKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "minValue",
                     msg2,
                     oldSnapshot.get(minKey),
@@ -2698,7 +2744,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldSnapshot.get(maxKey).equals(newSnapshot.get(maxKey))) {
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "maxValue",
                     msg2,
                     oldSnapshot.get(maxKey),
@@ -2708,7 +2754,8 @@ public abstract class EDDGrid extends EDD {
       String s = String2.differentLine(oldSnapshot.get(attrKey), newSnapshot.get(attrKey));
       if (s.length() > 0) {
         diff.append(
-            MessageFormat.format(EDStatic.EDDChangedAxes1Different, "combinedAttribute", msg2, s)
+            MessageFormat.format(
+                    EDStatic.messages.EDDChangedAxes1Different, "combinedAttribute", msg2, s)
                 + "\n");
       }
     }
@@ -2733,7 +2780,7 @@ public abstract class EDDGrid extends EDD {
   public String changed(EDD old) {
     if (old == null) return super.changed(old); // so message is consistent
 
-    if (!(old instanceof EDDGrid)) return EDStatic.EDDChangedTableToGrid + "\n";
+    if (!(old instanceof EDDGrid)) return EDStatic.messages.EDDChangedTableToGrid + "\n";
 
     EDDGrid oldG = (EDDGrid) old;
 
@@ -2743,7 +2790,8 @@ public abstract class EDDGrid extends EDD {
     String oldS = "" + oldG.axisVariables().length;
     String newS = "" + nAv;
     if (!oldS.equals(newS)) {
-      diff.append(MessageFormat.format(EDStatic.EDDChangedAxesDifferentNVar, oldS, newS) + "\n");
+      diff.append(
+          MessageFormat.format(EDStatic.messages.EDDChangedAxesDifferentNVar, oldS, newS) + "\n");
       return diff.toString(); // because tests below assume nAv are same
     }
 
@@ -2758,7 +2806,7 @@ public abstract class EDDGrid extends EDD {
       if (!oldS.equals(newS))
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different, "destinationName", msg2, oldS, newS)
+                    EDStatic.messages.EDDChangedAxes2Different, "destinationName", msg2, oldS, newS)
                 + "\n");
 
       oldS = oldAV.destinationDataType();
@@ -2766,7 +2814,11 @@ public abstract class EDDGrid extends EDD {
       if (!oldS.equals(newS))
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different, "destinationDataType", msg2, oldS, newS)
+                    EDStatic.messages.EDDChangedAxes2Different,
+                    "destinationDataType",
+                    msg2,
+                    oldS,
+                    newS)
                 + "\n");
 
       // most import case: new time value will be displayed as an iso time
@@ -2775,28 +2827,28 @@ public abstract class EDDGrid extends EDD {
       if (!oldS.equals(newS))
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different, "numberOfValues", msg2, oldS, newS)
+                    EDStatic.messages.EDDChangedAxes2Different, "numberOfValues", msg2, oldS, newS)
                 + "\n");
 
       int diffIndex = newAV.sourceValues().diffIndex(oldAV.sourceValues());
       if (diffIndex >= 0)
         diff.append(
             MessageFormat.format(
-                    EDStatic.EDDChangedAxes2Different,
+                    EDStatic.messages.EDDChangedAxes2Different,
                     "destinationValues",
                     msg2,
                     "index #"
                         + diffIndex
                         + "="
                         + (diffIndex >= oldAV.sourceValues().size()
-                            ? EDStatic.EDDChangedNoValue
+                            ? EDStatic.messages.EDDChangedNoValue
                             : oldAV.destinationToString(
                                 oldAV.destinationValue(diffIndex).getDouble(0))),
                     "index #"
                         + diffIndex
                         + "="
                         + (diffIndex >= newAV.sourceValues().size()
-                            ? EDStatic.EDDChangedNoValue
+                            ? EDStatic.messages.EDDChangedNoValue
                             : newAV.destinationToString(
                                 newAV.destinationValue(diffIndex).getDouble(0))))
                 + "\n");
@@ -2806,7 +2858,8 @@ public abstract class EDDGrid extends EDD {
               oldAV.combinedAttributes().toString(), newAV.combinedAttributes().toString());
       if (s.length() > 0)
         diff.append(
-            MessageFormat.format(EDStatic.EDDChangedAxes1Different, "combinedAttribute", msg2, s)
+            MessageFormat.format(
+                    EDStatic.messages.EDDChangedAxes1Different, "combinedAttribute", msg2, s)
                 + "\n");
     }
 
@@ -2986,7 +3039,8 @@ public abstract class EDDGrid extends EDD {
 
           } else {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaFGDC);
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                    + accessibleViaFGDC);
           }
           return;
         }
@@ -3014,7 +3068,7 @@ public abstract class EDDGrid extends EDD {
           try {
             writer.write(
                 EDStatic.startHeadHtml(
-                    language, tErddapUrl, title() + " - " + EDStatic.dafAr[language]));
+                    language, tErddapUrl, title() + " - " + EDStatic.messages.dafAr[language]));
             writer.write("\n" + rssHeadLink());
             writer.write("\n</head>\n");
             writer.write(
@@ -3038,13 +3092,13 @@ public abstract class EDDGrid extends EDD {
                     language,
                     loggedInAs,
                     dapProtocol,
-                    EDStatic.dafAr[language],
+                    EDStatic.messages.dafAr[language],
                     "<div class=\"standard_max_width\">"
-                        + EDStatic.dafGridTooltipAr[language]
+                        + EDStatic.messages.dafGridTooltipAr[language]
                         + "<p>"
-                        + EDStatic.EDDGridDownloadDataTooltipAr[language]
+                        + EDStatic.messages.EDDGridDownloadDataTooltipAr[language]
                         + "</ol>\n"
-                        + EDStatic.dafGridBypassTooltipAr[language]
+                        + EDStatic.messages.dafGridBypassTooltipAr[language]
                         + "</div>"));
             writeHtmlDatasetInfo(
                 language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
@@ -3059,7 +3113,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 "<hr>\n"
                     + "<h2><a class=\"selfLink\" id=\"DAS\" href=\"#DAS\" rel=\"bookmark\">"
-                    + EDStatic.dasTitleAr[language]
+                    + EDStatic.messages.dasTitleAr[language]
                     + "</a></h2>\n"
                     + "<pre style=\"white-space:pre-wrap;\">\n");
             writeDAS(
@@ -3114,7 +3168,8 @@ public abstract class EDDGrid extends EDD {
             // downloads of e.g., erddap2.css don't work right if not closed. (just if gzip'd?)
           } else {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaISO19115);
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                    + accessibleViaISO19115);
           }
           return;
         }
@@ -3188,8 +3243,9 @@ public abstract class EDDGrid extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + EDStatic.errorFileNotFoundImageAr[0],
-                  EDStatic.queryErrorAr[language] + EDStatic.errorFileNotFoundImageAr[language]));
+                  EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorFileNotFoundImageAr[0],
+                  EDStatic.messages.queryErrorAr[language]
+                      + EDStatic.messages.errorFileNotFoundImageAr[language]));
 
         // ok, copy it  (and don't close the outputStream)
         try (OutputStream out = outputStreamSource.outputStream(File2.UTF_8)) {
@@ -3308,7 +3364,7 @@ public abstract class EDDGrid extends EDD {
 
           if (EDStatic.accessibleViaNC4.length() > 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + EDStatic.accessibleViaNC4);
 
           // if .nc4Header, make sure the .nc4 file exists (and it is the better file to cache)
@@ -3364,11 +3420,12 @@ public abstract class EDDGrid extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
-                          + MessageFormat.format(EDStatic.queryErrorFileTypeAr[0], fileTypeName),
-                      EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorFileTypeAr[language], fileTypeName)));
+                              EDStatic.messages.queryErrorFileTypeAr[0], fileTypeName),
+                      EDStatic.messages.queryErrorAr[language]
+                          + MessageFormat.format(
+                              EDStatic.messages.queryErrorFileTypeAr[language], fileTypeName)));
             }
           } finally {
             fos.close();
@@ -3493,7 +3550,7 @@ public abstract class EDDGrid extends EDD {
     if (reallyVerbose) String2.log("*** respondToGraphQuery");
     if (accessibleViaMAG().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaMAG());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaMAG());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
     String formName = "f1"; // change JavaScript below if this changes
@@ -3504,7 +3561,8 @@ public abstract class EDDGrid extends EDD {
 
       // write the header
       writer.write(
-          EDStatic.startHeadHtml(language, tErddapUrl, title() + " - " + EDStatic.magAr[language]));
+          EDStatic.startHeadHtml(
+              language, tErddapUrl, title() + " - " + EDStatic.messages.magAr[language]));
       writer.write("\n" + rssHeadLink());
       writer.write("\n</head>\n");
       writer.write(
@@ -3527,9 +3585,9 @@ public abstract class EDDGrid extends EDD {
               language,
               loggedInAs,
               "griddap",
-              EDStatic.magAr[language],
+              EDStatic.messages.magAr[language],
               "<div class=\"standard_max_width\">"
-                  + EDStatic.magGridTooltipAr[language]
+                  + EDStatic.messages.magGridTooltipAr[language]
                   + "</div>"));
       writeHtmlDatasetInfo(language, loggedInAs, writer, true, true, true, false, userDapQuery, "");
       if (userDapQuery.length() == 0)
@@ -3655,10 +3713,14 @@ public abstract class EDDGrid extends EDD {
       if (drawLines) {
         nVars = 2;
         varLabel =
-            new String[] {EDStatic.magAxisXAr[language] + ":", EDStatic.magAxisYAr[language] + ":"};
+            new String[] {
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":"
+            };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language], EDStatic.magAxisHelpGraphYAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+              EDStatic.messages.magAxisHelpGraphYAr[language]
             };
         varOptions = new String[][] {avNames, dvNames};
         varName[0] =
@@ -3673,15 +3735,15 @@ public abstract class EDDGrid extends EDD {
         nVars = 3;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisYAr[language] + ":",
-              EDStatic.magAxisColorAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":",
+              EDStatic.messages.magAxisColorAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language],
-              EDStatic.magAxisHelpGraphYAr[language],
-              EDStatic.magAxisHelpMarkerColorAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+              EDStatic.messages.magAxisHelpGraphYAr[language],
+              EDStatic.messages.magAxisHelpMarkerColorAr[language]
             };
         varOptions = new String[][] {avNames, dvNames, dvNames0};
         varName[0] =
@@ -3701,14 +3763,16 @@ public abstract class EDDGrid extends EDD {
         nVars = 3;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisStickXAr[language] + ":",
-              EDStatic.magAxisStickYAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisStickXAr[language] + ":",
+              EDStatic.messages.magAxisStickYAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language], EDStatic.magAxisHelpGraphYAr[language],
-              EDStatic.magAxisHelpStickXAr[language], EDStatic.magAxisHelpStickYAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+                  EDStatic.messages.magAxisHelpGraphYAr[language],
+              EDStatic.messages.magAxisHelpStickXAr[language],
+                  EDStatic.messages.magAxisHelpStickYAr[language]
             };
         varOptions = new String[][] {avNames, dvNames, dvNames};
         varName[0] =
@@ -3728,15 +3792,15 @@ public abstract class EDDGrid extends EDD {
         nVars = 3;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisYAr[language] + ":",
-              EDStatic.magAxisColorAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":",
+              EDStatic.messages.magAxisColorAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpMapXAr[language],
-              EDStatic.magAxisHelpMapYAr[language],
-              EDStatic.magAxisHelpSurfaceColorAr[language]
+              EDStatic.messages.magAxisHelpMapXAr[language],
+              EDStatic.messages.magAxisHelpMapYAr[language],
+              EDStatic.messages.magAxisHelpSurfaceColorAr[language]
             };
         varOptions = new String[][] {avNames, avNames, dvNames};
         varName[0] =
@@ -3759,17 +3823,17 @@ public abstract class EDDGrid extends EDD {
         nVars = 4;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisYAr[language] + ":",
-              EDStatic.magAxisVectorXAr[language] + ":",
-              EDStatic.magAxisVectorYAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":",
+              EDStatic.messages.magAxisVectorXAr[language] + ":",
+              EDStatic.messages.magAxisVectorYAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpMapXAr[language],
-              EDStatic.magAxisHelpMapYAr[language],
-              EDStatic.magAxisHelpVectorXAr[language],
-              EDStatic.magAxisHelpVectorYAr[language]
+              EDStatic.messages.magAxisHelpMapXAr[language],
+              EDStatic.messages.magAxisHelpMapYAr[language],
+              EDStatic.messages.magAxisHelpVectorXAr[language],
+              EDStatic.messages.magAxisHelpVectorYAr[language]
             };
         varOptions =
             new String[][] {
@@ -3788,7 +3852,8 @@ public abstract class EDDGrid extends EDD {
         }
         // ??? ensure same units???
       } else
-        throw new SimpleException(EDStatic.errorInternalAr[0] + "'draw' wasn't set correctly.");
+        throw new SimpleException(
+            EDStatic.messages.errorInternalAr[0] + "'draw' wasn't set correctly.");
       // if (debugMode) String2.log("respondToGraphQuery 4");
 
       // avoid lat lon reversed (which sgtMap will reverse)
@@ -4098,7 +4163,7 @@ public abstract class EDDGrid extends EDD {
       writer.write(
           "<tr>\n"
               + "  <td><strong>"
-              + EDStatic.magGraphTypeAr[language]
+              + EDStatic.messages.magGraphTypeAr[language]
               + ":&nbsp;</strong>"
               + "  </td>\n"
               + "  <td>\n");
@@ -4124,7 +4189,7 @@ public abstract class EDDGrid extends EDD {
                   language,
                   loggedInAs,
                   "<div class=\"standard_max_width\">"
-                      + EDStatic.magGraphTypeTooltipGridAr[language]
+                      + EDStatic.messages.magGraphTypeTooltipGridAr[language]
                       + "</div>")
               + "  </td>\n"
               + "</tr>\n");
@@ -4143,7 +4208,8 @@ public abstract class EDDGrid extends EDD {
             varName[v] = tvNames[0];
             vi = 0;
           } else {
-            throw new SimpleException(EDStatic.errorInternalAr[0] + "No varOptions for v=" + v);
+            throw new SimpleException(
+                EDStatic.messages.errorInternalAr[0] + "No varOptions for v=" + v);
           }
         }
         // avoid duplicate with previous var
@@ -4168,8 +4234,8 @@ public abstract class EDDGrid extends EDD {
                 EDStatic.htmlTooltipImage(
                     language,
                     loggedInAs,
-                    MessageFormat.format(EDStatic.magAxisVarHelpAr[language], varHelp[v])
-                        + EDStatic.magAxisVarHelpGridAr[language]));
+                    MessageFormat.format(EDStatic.messages.magAxisVarHelpAr[language], varHelp[v])
+                        + EDStatic.messages.magAxisVarHelpGridAr[language]));
         writer.write("""
                   </td>
                 </tr>
@@ -4185,40 +4251,40 @@ public abstract class EDDGrid extends EDD {
       writer.write(
           "<tr>\n"
               + "  <th class=\"L\">"
-              + EDStatic.EDDGridDimensionRangesAr[language]
+              + EDStatic.messages.EDDGridDimensionRangesAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
-                  EDStatic.EDDGridDimensionTooltipAr[0]
+                  EDStatic.messages.EDDGridDimensionTooltipAr[0]
                       + "<br>"
-                      + EDStatic.EDDGridVarHasDimTooltipAr[language])
+                      + EDStatic.messages.EDDGridVarHasDimTooltipAr[language])
               + "</th>\n"
               + "  <th style=\"text-align:center;\">"
               + gap
-              + EDStatic.EDDGridStartAr[language]
+              + EDStatic.messages.EDDGridStartAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
-                  EDStatic.EDDGridDimensionTooltipAr[language]
+                  EDStatic.messages.EDDGridDimensionTooltipAr[language]
                       + "<br>"
-                      + EDStatic.EDDGridStartStopTooltipAr[language]
+                      + EDStatic.messages.EDDGridStartStopTooltipAr[language]
                       + "<br>"
-                      + EDStatic.EDDGridStartTooltipAr[language])
+                      + EDStatic.messages.EDDGridStartTooltipAr[language])
               + "</th>\n"
               + "  <th style=\"text-align:center;\">"
               + gap
-              + EDStatic.EDDGridStopAr[0]
+              + EDStatic.messages.EDDGridStopAr[0]
               + " "
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
-                  EDStatic.EDDGridDimensionTooltipAr[0]
+                  EDStatic.messages.EDDGridDimensionTooltipAr[0]
                       + "<br>"
-                      + EDStatic.EDDGridStartStopTooltipAr[language]
+                      + EDStatic.messages.EDDGridStartStopTooltipAr[language]
                       + "<br>"
-                      + EDStatic.EDDGridStopTooltipAr[language])
+                      + EDStatic.messages.EDDGridStopTooltipAr[language])
               + "</th>\n"
               + "</tr>\n");
 
@@ -4258,7 +4324,7 @@ public abstract class EDDGrid extends EDD {
                       + HtmlWidgets.htmlTooltipImage(
                           EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
                           "|<",
-                          EDStatic.magItemFirstAr[language],
+                          EDStatic.messages.magItemFirstAr[language],
                           "class=\"B\" "
                               + // vertical-align: 'b'ottom
                               "onMouseUp='f1."
@@ -4283,7 +4349,7 @@ public abstract class EDDGrid extends EDD {
                       + HtmlWidgets.htmlTooltipImage(
                           EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
                           "-",
-                          EDStatic.magItemPreviousAr[language],
+                          EDStatic.messages.magItemPreviousAr[language],
                           "class=\"B\" "
                               + // vertical-align: 'b'ottom
                               "onMouseUp='f1."
@@ -4304,7 +4370,7 @@ public abstract class EDDGrid extends EDD {
                       + HtmlWidgets.htmlTooltipImage(
                           EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
                           "+",
-                          EDStatic.magItemNextAr[language],
+                          EDStatic.messages.magItemNextAr[language],
                           "class=\"B\" "
                               + // vertical-align: 'b'ottom
                               "onMouseUp='f1."
@@ -4322,7 +4388,7 @@ public abstract class EDDGrid extends EDD {
                       + HtmlWidgets.htmlTooltipImage(
                           EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
                           ">|",
-                          EDStatic.magItemLastAr[language],
+                          EDStatic.messages.magItemLastAr[language],
                           // the word "last" works for all datasets
                           // and works better than tLast for updateEveryNMillis datasets
                           "class=\"B\" "
@@ -4353,7 +4419,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 gap
                     + "<span class=\"subduedColor\">&nbsp;"
-                    + EDStatic.magJust1ValueAr[language]
+                    + EDStatic.messages.magJust1ValueAr[language]
                     + "</span>\n");
             writer.write(widgets.hidden(paramName, "SeeStop"));
           }
@@ -4440,7 +4506,9 @@ public abstract class EDDGrid extends EDD {
       writer.write("&nbsp;\n"); // necessary for the blank line before start of table (not <p>)
       writer.write(widgets.beginTable("class=\"compact nowrap\""));
       writer.write(
-          "  <tr><th class=\"L\" colspan=\"6\">" + EDStatic.magGSAr[language] + "</th></tr>\n");
+          "  <tr><th class=\"L\" colspan=\"6\">"
+              + EDStatic.messages.magGSAr[language]
+              + "</th></tr>\n");
       if (drawLinesAndMarkers || drawMarkers) {
         // get Marker settings
         int mType = -1, mSize = -1;
@@ -4462,7 +4530,7 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSMarkerTypeAr[language]
+                + EDStatic.messages.magGSMarkerTypeAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(widgets.select(paramName, "", 1, GraphDataLayer.MARKER_TYPES, mType, ""));
@@ -4477,7 +4545,10 @@ public abstract class EDDGrid extends EDD {
             String2.indexOf(mSizes, "" + mSize); // convert from literal 3.. to index in mSizes[0..]
         if (mSize < 0) mSize = String2.indexOf(mSizes, "" + GraphDataLayer.MARKER_SIZE_SMALL);
         writer.write(
-            "    <td>&nbsp;" + EDStatic.magGSSizeAr[language] + ":&nbsp;</td>" + "    <td>");
+            "    <td>&nbsp;"
+                + EDStatic.messages.magGSSizeAr[language]
+                + ":&nbsp;</td>"
+                + "    <td>");
         writer.write(widgets.select(paramName, "", 1, mSizes, mSize, ""));
         writer.write(
             """
@@ -4503,7 +4574,7 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSColorAr[language]
+                + EDStatic.messages.magGSColorAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td colspan=\"5\">");
         writer.write(widgets.color17("", paramName, "", colori, ""));
@@ -4532,19 +4603,19 @@ public abstract class EDDGrid extends EDD {
             Math.max(
                 0,
                 String2.indexOf(
-                    EDStatic.palettes0, pParts.length > 0 ? pParts[0] : defaultPalette));
+                    EDStatic.messages.palettes0, pParts.length > 0 ? pParts[0] : defaultPalette));
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSColorBarAr[language]
+                + EDStatic.messages.magGSColorBarAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.select(
                 paramName,
-                EDStatic.magGSColorBarTooltipAr[language],
+                EDStatic.messages.magGSColorBarTooltipAr[language],
                 1,
-                EDStatic.palettes0,
+                EDStatic.messages.palettes0,
                 palette,
                 ""));
         writer.write("</td>\n");
@@ -4555,12 +4626,17 @@ public abstract class EDDGrid extends EDD {
             pParts.length > 1 ? (pParts[1].equals("D") ? 2 : pParts[1].equals("C") ? 1 : 0) : 0;
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSContinuityAr[language]
+                + EDStatic.messages.magGSContinuityAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.select(
-                paramName, EDStatic.magGSContinuityTooltipAr[language], 1, conDis, continuous, ""));
+                paramName,
+                EDStatic.messages.magGSContinuityTooltipAr[language],
+                1,
+                conDis,
+                continuous,
+                ""));
         writer.write("</td>\n");
 
         paramName = "ps";
@@ -4568,11 +4644,14 @@ public abstract class EDDGrid extends EDD {
         int scale =
             Math.max(0, EDV.VALID_SCALES0.indexOf(pParts.length > 2 ? pParts[2] : defaultScale));
         writer.write(
-            "    <td>&nbsp;" + EDStatic.magGSScaleAr[language] + ":&nbsp;</td>\n" + "    <td>");
+            "    <td>&nbsp;"
+                + EDStatic.messages.magGSScaleAr[language]
+                + ":&nbsp;</td>\n"
+                + "    <td>");
         writer.write(
             widgets.select(
                 paramName,
-                EDStatic.magGSScaleTooltipAr[language],
+                EDStatic.messages.magGSScaleTooltipAr[language],
                 1,
                 EDV.VALID_SCALES0,
                 scale,
@@ -4590,31 +4669,39 @@ public abstract class EDDGrid extends EDD {
             "  <tr>\n"
                 + "    <td>"
                 + gap
-                + EDStatic.magGSMinAr[language]
+                + EDStatic.messages.magGSMinAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
-            widgets.textField(paramName, EDStatic.magGSMinTooltipAr[language], 10, 60, palMin, ""));
+            widgets.textField(
+                paramName, EDStatic.messages.magGSMinTooltipAr[language], 10, 60, palMin, ""));
         writer.write("</td>\n");
 
         paramName = "pMax";
         String defaultMax = "";
         String palMax = pParts.length > 4 ? pParts[4] : defaultMax;
         writer.write(
-            "    <td>&nbsp;" + EDStatic.magGSMaxAr[language] + ":&nbsp;</td>\n" + "    <td>");
+            "    <td>&nbsp;"
+                + EDStatic.messages.magGSMaxAr[language]
+                + ":&nbsp;</td>\n"
+                + "    <td>");
         writer.write(
-            widgets.textField(paramName, EDStatic.magGSMaxTooltipAr[language], 10, 60, palMax, ""));
+            widgets.textField(
+                paramName, EDStatic.messages.magGSMaxTooltipAr[language], 10, 60, palMax, ""));
         writer.write("</td>\n");
 
         paramName = "pSec";
         int pSections =
             Math.max(0, EDStatic.paletteSections.indexOf(pParts.length > 5 ? pParts[5] : ""));
         writer.write(
-            "    <td>&nbsp;" + EDStatic.magGSNSectionsAr[language] + ":&nbsp;</td>\n" + "    <td>");
+            "    <td>&nbsp;"
+                + EDStatic.messages.magGSNSectionsAr[language]
+                + ":&nbsp;</td>\n"
+                + "    <td>");
         writer.write(
             widgets.select(
                 paramName,
-                EDStatic.magGSNSectionsTooltipAr[language],
+                EDStatic.messages.magGSNSectionsTooltipAr[language],
                 1,
                 EDStatic.paletteSections,
                 pSections,
@@ -4628,7 +4715,7 @@ public abstract class EDDGrid extends EDD {
         graphQuery.append(
             "&.colorBar="
                 + SSR.minimalPercentEncode(
-                    EDStatic.palettes0[palette]
+                    EDStatic.messages.palettes0[palette]
                         + "|"
                         + (conDis[continuous].length() == 0 ? "" : conDis[continuous].charAt(0))
                         + "|"
@@ -4650,12 +4737,17 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSVectorStandardAr[language]
+                + EDStatic.messages.magGSVectorStandardAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.textField(
-                paramName, EDStatic.magGSVectorStandardTooltipAr[language], 10, 30, vec, ""));
+                paramName,
+                EDStatic.messages.magGSVectorStandardTooltipAr[language],
+                10,
+                30,
+                vec,
+                ""));
         writer.write(
             """
                         </td>
@@ -4681,13 +4773,13 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSLandMaskAr[language]
+                + EDStatic.messages.magGSLandMaskAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.select(
                 "land",
-                EDStatic.magGSLandMaskTooltipGridAr[language],
+                EDStatic.messages.magGSLandMaskTooltipGridAr[language],
                 1,
                 String2.immutableListToArray(SgtMap.drawLandMask_OPTIONS),
                 tLand,
@@ -4745,15 +4837,15 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSYAxisMinAr[language]
+                + EDStatic.messages.magGSYAxisMinAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.textField(
                 "yRangeMin",
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.magGSYRangeMinTooltipAr[language]
-                    + EDStatic.magGSYRangeTooltipAr[language]
+                    + EDStatic.messages.magGSYRangeMinTooltipAr[language]
+                    + EDStatic.messages.magGSYRangeTooltipAr[language]
                     + "</div>",
                 10,
                 30,
@@ -4762,15 +4854,15 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             "</td>\n"
                 + "    <td>&nbsp;"
-                + EDStatic.magGSYAxisMaxAr[language]
+                + EDStatic.messages.magGSYAxisMaxAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>");
         writer.write(
             widgets.textField(
                 "yRangeMax",
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.magGSYRangeMaxTooltipAr[language]
-                    + EDStatic.magGSYRangeTooltipAr[language]
+                    + EDStatic.messages.magGSYRangeMaxTooltipAr[language]
+                    + EDStatic.messages.magGSYRangeTooltipAr[language]
                     + "</div>",
                 10,
                 30,
@@ -4780,7 +4872,7 @@ public abstract class EDDGrid extends EDD {
         writer.write(
             widgets.select(
                 "yRangeAscending",
-                EDStatic.magGSYAscendingTooltipAr[language],
+                EDStatic.messages.magGSYAscendingTooltipAr[language],
                 1,
                 new String[] {"Ascending", "Descending"},
                 yAscending ? 0 : 1,
@@ -4790,7 +4882,7 @@ public abstract class EDDGrid extends EDD {
                 + "    <td>"
                 + widgets.select(
                     "yScale",
-                    EDStatic.magGSYScaleTooltipAr[language],
+                    EDStatic.messages.magGSYScaleTooltipAr[language],
                     1,
                     new String[] {"", "Linear", "Log"},
                     yAxisScale.equals("Linear") ? 1 : yAxisScale.equals("Log") ? 2 : 0,
@@ -4954,27 +5046,27 @@ public abstract class EDDGrid extends EDD {
               "button",
               "",
               "",
-              EDStatic.magRedrawTooltipAr[language],
+              EDStatic.messages.magRedrawTooltipAr[language],
               "<span style=\"font-size:large;\"><strong>"
-                  + EDStatic.magRedrawAr[language]
+                  + EDStatic.messages.magRedrawAr[language]
                   + "</strong></span>",
               "onMouseUp='mySubmit(true);'"));
-      writer.write(" " + EDStatic.patientDataAr[language] + "\n" + "</td></tr>\n");
+      writer.write(" " + EDStatic.messages.patientDataAr[language] + "\n" + "</td></tr>\n");
 
       // Download the Data
       writer.write(
           "<tr><td>&nbsp;<br>"
-              + EDStatic.optionalAr[language]
+              + EDStatic.messages.optionalAr[language]
               + ":"
               + "<br>"
-              + EDStatic.magFileTypeAr[language]
+              + EDStatic.messages.magFileTypeAr[language]
               + ":\n");
       paramName = "fType";
       boolean tAccessibleTo = isAccessibleTo(EDStatic.getRoles(loggedInAs));
       writer.write(
           widgets.select(
               paramName,
-              EDStatic.EDDSelectFileTypeAr[language],
+              EDStatic.messages.EDDSelectFileTypeAr[language],
               1,
               tAccessibleTo ? allFileTypeNames : publicGraphFileTypeNames,
               tAccessibleTo ? defaultFileTypeOption : defaultPublicGraphFileTypeOption,
@@ -4990,7 +5082,7 @@ public abstract class EDDGrid extends EDD {
           " (<a rel=\"help\" href=\""
               + tErddapUrl
               + "/griddap/documentation.html#fileType\">"
-              + EDStatic.EDDFileTypeInformationAr[language]
+              + EDStatic.messages.EDDFileTypeInformationAr[language]
               + "</a>)\n");
 
       writer.write("<br>and\n");
@@ -4998,8 +5090,10 @@ public abstract class EDDGrid extends EDD {
           widgets.button(
               "button",
               "",
-              EDStatic.magDownloadTooltipAr[language] + "<br>" + EDStatic.patientDataAr[language],
-              EDStatic.magDownloadAr[language],
+              EDStatic.messages.magDownloadTooltipAr[language]
+                  + "<br>"
+                  + EDStatic.messages.patientDataAr[language],
+              EDStatic.messages.magDownloadAr[language],
               // "class=\"skinny\" " + //only IE needs it but only IE ignores it
               "onMouseUp='window.location=\""
                   + tErddapUrl
@@ -5018,11 +5112,11 @@ public abstract class EDDGrid extends EDD {
       String genViewHtml =
           String2.replaceAll(
               "<div class=\"standard_max_width\">"
-                  + EDStatic.justGenerateAndViewGraphUrlTooltipAr[language]
+                  + EDStatic.messages.justGenerateAndViewGraphUrlTooltipAr[language]
                   + "</div>",
               "&protocolName;",
               dapProtocol);
-      writer.write("<tr><td>" + EDStatic.magViewUrlAr[language] + ":\n");
+      writer.write("<tr><td>" + EDStatic.messages.magViewUrlAr[language] + ":\n");
       writer.write(
           widgets.textField(
               "tUrl",
@@ -5043,7 +5137,7 @@ public abstract class EDDGrid extends EDD {
               + tErddapUrl
               + "/griddap/documentation.html\" "
               + "title=\"griddap documentation\">"
-              + EDStatic.magDocumentationAr[language]
+              + EDStatic.messages.magDocumentationAr[language]
               + "</a>\n"
               + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml)
               + ")\n");
@@ -5071,12 +5165,12 @@ public abstract class EDDGrid extends EDD {
       // *** zoomLatLon stuff
       if (zoomLatLon) {
         writer.write(
-            EDStatic.magZoomCenterAr[language]
+            EDStatic.messages.magZoomCenterAr[language]
                 + "\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.magZoomCenterTooltipAr[language])
+                    language, loggedInAs, EDStatic.messages.magZoomCenterTooltipAr[language])
                 + "<br><strong>"
-                + EDStatic.magZoomAr[language]
+                + EDStatic.messages.magZoomAr[language]
                 + ":</strong>\n");
 
         double cRadius =
@@ -5102,8 +5196,9 @@ public abstract class EDDGrid extends EDD {
                 "button",
                 "",
                 MessageFormat.format(
-                    EDStatic.magZoomOutTooltipAr[language], EDStatic.magZoomOutDataAr[language]),
-                EDStatic.magZoomDataAr[language],
+                    EDStatic.messages.magZoomOutTooltipAr[language],
+                    EDStatic.messages.magZoomOutDataAr[language]),
+                EDStatic.messages.magZoomDataAr[language],
                 "class=\"skinny\" "
                     + (disableZoomOut
                         ? "disabled"
@@ -5139,8 +5234,8 @@ public abstract class EDDGrid extends EDD {
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomOutTooltipAr[language], "8x"),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutTooltipAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "8x"),
                 "class=\"skinny\" "
                     + (disableZoomOut
                         ? "disabled"
@@ -5175,8 +5270,8 @@ public abstract class EDDGrid extends EDD {
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomOutTooltipAr[language], "2x"),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutTooltipAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "2x"),
                 "class=\"skinny\" "
                     + (disableZoomOut
                         ? "disabled"
@@ -5212,8 +5307,9 @@ public abstract class EDDGrid extends EDD {
                 "button",
                 "",
                 MessageFormat.format(
-                    EDStatic.magZoomOutTooltipAr[language], EDStatic.magZoomALittleAr[language]),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "").trim(),
+                    EDStatic.messages.magZoomOutTooltipAr[language],
+                    EDStatic.messages.magZoomALittleAr[language]),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "").trim(),
                 "class=\"skinny\" "
                     + (disableZoomOut
                         ? "disabled"
@@ -5245,8 +5341,9 @@ public abstract class EDDGrid extends EDD {
                     "button",
                     "",
                     MessageFormat.format(
-                        EDStatic.magZoomInTooltipAr[language], EDStatic.magZoomALittleAr[language]),
-                    MessageFormat.format(EDStatic.magZoomInAr[language], "").trim(),
+                        EDStatic.messages.magZoomInTooltipAr[language],
+                        EDStatic.messages.magZoomALittleAr[language]),
+                    MessageFormat.format(EDStatic.messages.magZoomInAr[language], "").trim(),
                     "class=\"skinny\" "
                         + "onMouseUp='f1.start"
                         + lonIndex
@@ -5272,8 +5369,8 @@ public abstract class EDDGrid extends EDD {
                 + widgets.button(
                     "button",
                     "",
-                    MessageFormat.format(EDStatic.magZoomInTooltipAr[language], "2x"),
-                    MessageFormat.format(EDStatic.magZoomInAr[language], "2x"),
+                    MessageFormat.format(EDStatic.messages.magZoomInTooltipAr[language], "2x"),
+                    MessageFormat.format(EDStatic.messages.magZoomInAr[language], "2x"),
                     "class=\"skinny\" "
                         + "onMouseUp='f1.start"
                         + lonIndex
@@ -5299,8 +5396,8 @@ public abstract class EDDGrid extends EDD {
                 + widgets.button(
                     "button",
                     "",
-                    MessageFormat.format(EDStatic.magZoomInTooltipAr[language], "8x"),
-                    MessageFormat.format(EDStatic.magZoomInAr[language], "8x"),
+                    MessageFormat.format(EDStatic.messages.magZoomInTooltipAr[language], "8x"),
+                    MessageFormat.format(EDStatic.messages.magZoomInAr[language], "8x"),
                     "class=\"skinny\" "
                         + "onMouseUp='f1.start"
                         + lonIndex
@@ -5345,13 +5442,14 @@ public abstract class EDDGrid extends EDD {
                   + "   stop="
                   + Calendar2.epochSecondsToLimitedIsoStringT(time_precision, timeStop, ""));
 
-        writer.write("<strong>" + EDStatic.magTimeRangeAr[language] + "</strong>\n");
+        writer.write("<strong>" + EDStatic.messages.magTimeRangeAr[language] + "</strong>\n");
 
         String timeRangeString =
             idealTimeN + " " + Calendar2.IDEAL_UNITS_OPTIONS.get(idealTimeUnits);
-        String timesVary = "<br>(" + EDStatic.magTimesVaryAr[language] + ")";
+        String timesVary = "<br>(" + EDStatic.messages.magTimesVaryAr[language] + ")";
         String timeRangeTip =
-            EDStatic.magTimeRangeTooltipAr[language] + EDStatic.magTimeRangeTooltip2Ar[language];
+            EDStatic.messages.magTimeRangeTooltipAr[language]
+                + EDStatic.messages.magTimeRangeTooltip2Ar[language];
         String timeGap = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;\n";
 
         // n = 1..100
@@ -5410,7 +5508,7 @@ public abstract class EDDGrid extends EDD {
                         EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
                         "|<",
                         MessageFormat.format(
-                                EDStatic.magTimeRangeFirstAr[language], timeRangeString)
+                                EDStatic.messages.magTimeRangeFirstAr[language], timeRangeString)
                             + timesVary,
                         "class=\"B\" "
                             + // vertical-align: 'b'ottom
@@ -5439,7 +5537,8 @@ public abstract class EDDGrid extends EDD {
                     + HtmlWidgets.htmlTooltipImage(
                         EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
                         "-",
-                        MessageFormat.format(EDStatic.magTimeRangeBackAr[language], timeRangeString)
+                        MessageFormat.format(
+                                EDStatic.messages.magTimeRangeBackAr[language], timeRangeString)
                             + timesVary,
                         "class=\"B\" "
                             + // vertical-align: 'b'ottom
@@ -5476,7 +5575,7 @@ public abstract class EDDGrid extends EDD {
                         EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
                         "+",
                         MessageFormat.format(
-                                EDStatic.magTimeRangeForwardAr[language], timeRangeString)
+                                EDStatic.messages.magTimeRangeForwardAr[language], timeRangeString)
                             + timesVary,
                         "class=\"B\" "
                             + // vertical-align: 'b'ottom
@@ -5518,7 +5617,8 @@ public abstract class EDDGrid extends EDD {
                     + HtmlWidgets.htmlTooltipImage(
                         EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
                         ">|",
-                        MessageFormat.format(EDStatic.magTimeRangeLastAr[language], timeRangeString)
+                        MessageFormat.format(
+                                EDStatic.messages.magTimeRangeLastAr[language], timeRangeString)
                             + timesVary,
                         "class=\"B\" "
                             + // vertical-align: 'b'ottom
@@ -5567,8 +5667,8 @@ public abstract class EDDGrid extends EDD {
                       "button",
                       "zoomXzoomIn",
                       "", // value
-                      EDStatic.zoomInAr[language],
-                      EDStatic.zoomInAr[language], // tooltip, labelHtml
+                      EDStatic.messages.zoomInAr[language],
+                      EDStatic.messages.zoomInAr[language], // tooltip, labelHtml
                       "onMouseUp='f1.start"
                           + axisVarX
                           + ".value=\""
@@ -5603,8 +5703,8 @@ public abstract class EDDGrid extends EDD {
                       "button",
                       "zoomXzoomOut",
                       "", // value
-                      EDStatic.zoomOutAr[language],
-                      EDStatic.zoomOutAr[language], // tooltip, labelHtml
+                      EDStatic.messages.zoomOutAr[language],
+                      EDStatic.messages.zoomOutAr[language], // tooltip, labelHtml
                       "onMouseUp='f1.start"
                           + axisVarX
                           + ".value=\""
@@ -5625,7 +5725,7 @@ public abstract class EDDGrid extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
                       "|<",
-                      EDStatic.shiftXAllTheWayLeftAr[language],
+                      EDStatic.messages.shiftXAllTheWayLeftAr[language],
                       "class=\"B\" "
                           + // vertical-align: 'b'ottom
                           "onMouseUp='f1.start"
@@ -5647,7 +5747,7 @@ public abstract class EDDGrid extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
                       "-",
-                      EDStatic.shiftXLeftAr[language],
+                      EDStatic.messages.shiftXLeftAr[language],
                       "class=\"B\" "
                           + // vertical-align: 'b'ottom
                           "onMouseUp='f1.start"
@@ -5673,7 +5773,7 @@ public abstract class EDDGrid extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
                       "+",
-                      EDStatic.shiftXRightAr[0],
+                      EDStatic.messages.shiftXRightAr[0],
                       "class=\"B\" "
                           + // vertical-align: 'b'ottom
                           "onMouseUp='f1.start"
@@ -5694,7 +5794,7 @@ public abstract class EDDGrid extends EDD {
               HtmlWidgets.htmlTooltipImage(
                   EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
                   ">|",
-                  EDStatic.shiftXAllTheWayRightAr[language],
+                  EDStatic.messages.shiftXAllTheWayRightAr[language],
                   "class=\"B\" "
                       + // vertical-align: 'b'ottom
                       "onMouseUp='f1.start"
@@ -5733,12 +5833,12 @@ public abstract class EDDGrid extends EDD {
           "<img "
               + (zoomLatLon ? "ismap " : "")
               + "width=\""
-              + EDStatic.imageWidths[1]
+              + EDStatic.messages.imageWidths[1]
               + "\" height=\""
-              + EDStatic.imageHeights[1]
+              + EDStatic.messages.imageHeights[1]
               + "\" "
               + "alt=\""
-              + EDStatic.patientYourGraphAr[language]
+              + EDStatic.messages.patientYourGraphAr[language]
               + "\" "
               + "src=\""
               + XML.encodeAsHTMLAttribute(tErddapUrl + "/griddap/" + datasetID + ".png?" + aQuery)
@@ -5760,7 +5860,7 @@ public abstract class EDDGrid extends EDD {
       // *** Things you can do with graphs
       writer.write(
           String2.replaceAll(
-              MessageFormat.format(EDStatic.doWithGraphsAr[language], tErddapUrl),
+              MessageFormat.format(EDStatic.messages.doWithGraphsAr[language], tErddapUrl),
               "&erddapUrl;",
               tErddapUrl));
       writer.write("\n\n");
@@ -5769,7 +5869,7 @@ public abstract class EDDGrid extends EDD {
       writer.write(
           "<hr>\n"
               + "<h2><a class=\"selfLink\" id=\"DAS\" href=\"#DAS\" rel=\"bookmark\">"
-              + EDStatic.dasTitleAr[language]
+              + EDStatic.messages.dasTitleAr[language]
               + "</a></h2>\n"
               + "<pre style=\"white-space:pre-wrap;\">\n");
       writeDAS(
@@ -6529,7 +6629,7 @@ public abstract class EDDGrid extends EDD {
               while (partialGda.incrementChunk()) pas[0].externalizeForDODS(dos);
             } else {
               throw new RuntimeException(
-                  EDStatic.errorInternalAr[0] + "unsupported source data type=" + type);
+                  EDStatic.messages.errorInternalAr[0] + "unsupported source data type=" + type);
             } /* */
 
             for (int av = 0; av < nAxisVariables; av++)
@@ -6587,39 +6687,42 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[0], ".esriAscii", EDStatic.noXxxNoLLAr[0]),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[language],
+                      EDStatic.messages.noXxxBecause2Ar[0],
                       ".esriAscii",
-                      EDStatic.noXxxNoLLAr[language])));
+                      EDStatic.messages.noXxxNoLLAr[0]),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.noXxxBecause2Ar[language],
+                      ".esriAscii",
+                      EDStatic.messages.noXxxNoLLAr[language])));
 
     if (!axisVariables[latIndex].isEvenlySpaced() || !axisVariables[lonIndex].isEvenlySpaced())
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[0],
+                      EDStatic.messages.noXxxBecause2Ar[0],
                       ".esriAscii",
-                      EDStatic.noXxxNoLLEvenlySpacedAr[0]),
-              EDStatic.queryErrorAr[language]
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[0]),
+              EDStatic.messages.queryErrorAr[language]
                   + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[language],
+                      EDStatic.messages.noXxxBecause2Ar[language],
                       ".esriAscii",
-                      EDStatic.noXxxNoLLEvenlySpacedAr[language])));
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[language])));
 
     // can't handle axis request
     if (isAxisDapQuery(userDapQuery))
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
-                  + MessageFormat.format(EDStatic.queryErrorNotAxisAr[0], ".esriAscii"),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(EDStatic.queryErrorNotAxisAr[language], ".esriAscii")));
+              EDStatic.messages.queryErrorAr[0]
+                  + MessageFormat.format(EDStatic.messages.queryErrorNotAxisAr[0], ".esriAscii"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.queryErrorNotAxisAr[language], ".esriAscii")));
 
     // parse the userDapQuery and get the GridDataAccessor
     // this also tests for error when parsing query
@@ -6630,10 +6733,11 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryError1VarAr[0], ".esriAscii"),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryError1VarAr[language], ".esriAscii")));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryError1VarAr[0], ".esriAscii"),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryError1VarAr[language], ".esriAscii")));
       EDV edv = gridDataAccessor.dataVariables()[0];
       PAType edvPAType = edv.destinationDataPAType();
       PAOne edvPAOne = new PAOne(edvPAType);
@@ -6651,14 +6755,14 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryError1ValueAr[0],
+                            EDStatic.messages.queryError1ValueAr[0],
                             ".esriAscii",
                             axisVariables[av].destinationName()),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryError1ValueAr[language],
+                            EDStatic.messages.queryError1ValueAr[language],
                             ".esriAscii",
                             axisVariables[av].destinationName())));
         }
@@ -6692,10 +6796,11 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryErrorLLGt1Ar[0], ".esriAscii"),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryErrorLLGt1Ar[language], ".esriAscii")));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryErrorLLGt1Ar[0], ".esriAscii"),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryErrorLLGt1Ar[language], ".esriAscii")));
 
       // for almostEqual(3, lonSpacing, latSpacing) DON'T GO BELOW 3!!!
       // For example: PHssta has 4096 lon points so spacing is ~.0878
@@ -6706,15 +6811,15 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorEqualSpacingAr[0],
+                        EDStatic.messages.queryErrorEqualSpacingAr[0],
                         ".esriAscii",
                         "" + lonSpacing,
                         "" + latSpacing),
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorEqualSpacingAr[language],
+                        EDStatic.messages.queryErrorEqualSpacingAr[language],
                         ".esriAscii",
                         "" + lonSpacing,
                         "" + latSpacing)));
@@ -6722,24 +6827,25 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryError180Ar[0], ".esriAscii"),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryError180Ar[language], ".esriAscii")));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryError180Ar[0], ".esriAscii"),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryError180Ar[language], ".esriAscii")));
       double lonAdjust = lonPa.getDouble(0) >= 180 ? -360 : 0;
       if (minX + lonAdjust < -180 || maxX + lonAdjust > 180)
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorAdjustedAr[0],
+                        EDStatic.messages.queryErrorAdjustedAr[0],
                         ".esriAscii",
                         "" + (minX + lonAdjust),
                         "" + (maxX + lonAdjust)),
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorAdjustedAr[language],
+                        EDStatic.messages.queryErrorAdjustedAr[language],
                         ".esriAscii",
                         "" + (minX + lonAdjust),
                         "" + (maxX + lonAdjust))));
@@ -6854,14 +6960,16 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[0], ".geotif", EDStatic.noXxxNoLLAr[0]),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[language],
+                      EDStatic.messages.noXxxBecause2Ar[0],
                       ".geotif",
-                      EDStatic.noXxxNoLLAr[language])));
+                      EDStatic.messages.noXxxNoLLAr[0]),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.noXxxBecause2Ar[language],
+                      ".geotif",
+                      EDStatic.messages.noXxxNoLLAr[language])));
 
     // Lon and Lat are evenly spaced?
     // See 2nd test in EDDGridFromDap.testDescendingAxisGeotif()
@@ -6869,14 +6977,16 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[0], ".geotif", EDStatic.noXxxNoLLEvenlySpacedAr[0]),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(
-                      EDStatic.noXxxBecause2Ar[language],
+                      EDStatic.messages.noXxxBecause2Ar[0],
                       ".geotif",
-                      EDStatic.noXxxNoLLEvenlySpacedAr[language])));
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[0]),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.noXxxBecause2Ar[language],
+                      ".geotif",
+                      EDStatic.messages.noXxxNoLLEvenlySpacedAr[language])));
 
     // 2013-10-21 NO LONGER A LIMITATION: lon and lat are ascending?
     //  GeotiffWriter now deals with descending.
@@ -6884,9 +6994,11 @@ public abstract class EDDGrid extends EDD {
     // if (axisVariables[latIndex].averageSpacing() <= 0 ||
     //    axisVariables[lonIndex].averageSpacing() <= 0)
     //    throw new SimpleException(EDStatic.bilingual(language,
-    //    EDStatic.queryErrorAr[0]        + MessageFormat.format(EDStatic.queryErrorAscending,
+    //    EDStatic.messages.queryErrorAr[0]        +
+    // MessageFormat.format(EDStatic.messages.queryErrorAscending,
     // ".geotif"),
-    //    EDStatic.queryErrorAr[language] + MessageFormat.format(EDStatic.queryErrorAscending,
+    //    EDStatic.messages.queryErrorAr[language] +
+    // MessageFormat.format(EDStatic.messages.queryErrorAscending,
     // ".geotif")));
 
     // can't handle axis request
@@ -6894,10 +7006,11 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
-                  + MessageFormat.format(EDStatic.queryErrorNotAxisAr[0], ".geotif"),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(EDStatic.queryErrorNotAxisAr[language], ".geotif")));
+              EDStatic.messages.queryErrorAr[0]
+                  + MessageFormat.format(EDStatic.messages.queryErrorNotAxisAr[0], ".geotif"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(
+                      EDStatic.messages.queryErrorNotAxisAr[language], ".geotif")));
 
     // parse the userDapQuery and get the GridDataAccessor
     // this also tests for error when parsing query
@@ -6909,10 +7022,11 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryError1VarAr[0], ".geotif"),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryError1VarAr[language], ".geotif")));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryError1VarAr[0], ".geotif"),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryError1VarAr[language], ".geotif")));
 
       PrimitiveArray lonPa = null, latPa = null;
       double minX = Double.NaN, maxX = Double.NaN, minY = Double.NaN, maxY = Double.NaN;
@@ -6931,10 +7045,11 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
-                        + MessageFormat.format(EDStatic.queryError180Ar[0], ".geotif"),
-                    EDStatic.queryErrorAr[language]
-                        + MessageFormat.format(EDStatic.queryError180Ar[language], ".geotif")));
+                    EDStatic.messages.queryErrorAr[0]
+                        + MessageFormat.format(EDStatic.messages.queryError180Ar[0], ".geotif"),
+                    EDStatic.messages.queryErrorAr[language]
+                        + MessageFormat.format(
+                            EDStatic.messages.queryError180Ar[language], ".geotif")));
           if (minX >= 180) lonAdjust = -360;
           minX += lonAdjust;
           maxX += lonAdjust;
@@ -6942,12 +7057,15 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryErrorAdjustedAr[0], ".geotif", "" + minX, "" + maxX),
-                    EDStatic.queryErrorAr[language]
+                            EDStatic.messages.queryErrorAdjustedAr[0],
+                            ".geotif",
+                            "" + minX,
+                            "" + maxX),
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryErrorAdjustedAr[language],
+                            EDStatic.messages.queryErrorAdjustedAr[language],
                             ".geotif",
                             "" + minX,
                             "" + maxX)));
@@ -6965,14 +7083,14 @@ public abstract class EDDGrid extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryError1ValueAr[0],
+                            EDStatic.messages.queryError1ValueAr[0],
                             ".geotif",
                             axisVariables[av].destinationName()),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + MessageFormat.format(
-                            EDStatic.queryError1ValueAr[language],
+                            EDStatic.messages.queryError1ValueAr[language],
                             ".geotif",
                             axisVariables[av].destinationName())));
         }
@@ -7146,19 +7264,19 @@ public abstract class EDDGrid extends EDD {
     boolean transparentPng = fileTypeName.equals(".transparentPng");
     if (!pdf && !png)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "Unexpected image type="
               + fileTypeName);
     int imageWidth, imageHeight;
     if (pdf) {
-      imageWidth = EDStatic.pdfWidths[sizeIndex];
-      imageHeight = EDStatic.pdfHeights[sizeIndex];
+      imageWidth = EDStatic.messages.pdfWidths[sizeIndex];
+      imageHeight = EDStatic.messages.pdfHeights[sizeIndex];
     } else if (transparentPng) {
-      imageWidth = EDStatic.imageWidths[sizeIndex];
+      imageWidth = EDStatic.messages.imageWidths[sizeIndex];
       imageHeight = imageWidth;
     } else {
-      imageWidth = EDStatic.imageWidths[sizeIndex];
-      imageHeight = EDStatic.imageHeights[sizeIndex];
+      imageWidth = EDStatic.messages.imageWidths[sizeIndex];
+      imageHeight = EDStatic.messages.imageHeights[sizeIndex];
     }
     if (reallyVerbose)
       String2.log(
@@ -7185,10 +7303,11 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryErrorNotAxisAr[0], fileTypeName),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryErrorNotAxisAr[language], fileTypeName)));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryErrorNotAxisAr[0], fileTypeName),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryErrorNotAxisAr[language], fileTypeName)));
 
       // modify the query to get no more data than needed
       StringArray reqDataNames = new StringArray();
@@ -7383,12 +7502,13 @@ public abstract class EDDGrid extends EDD {
                 throw new SimpleException(
                     EDStatic.bilingual(
                         language,
-                        EDStatic.queryErrorAr[0]
+                        EDStatic.messages.queryErrorAr[0]
                             + MessageFormat.format(
-                                EDStatic.queryErrorUnknownVariableAr[0], pParts[p]),
-                        EDStatic.queryErrorAr[language]
+                                EDStatic.messages.queryErrorUnknownVariableAr[0], pParts[p]),
+                        EDStatic.messages.queryErrorAr[language]
                             + MessageFormat.format(
-                                EDStatic.queryErrorUnknownVariableAr[language], pParts[p])));
+                                EDStatic.messages.queryErrorUnknownVariableAr[language],
+                                pParts[p])));
               }
             }
           }
@@ -7463,7 +7583,7 @@ public abstract class EDDGrid extends EDD {
       int nAAv = activeAxes.size();
       if (nAAv < 1 || nAAv > 2)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "To draw a graph, either 1 or 2 axes must be active and have 2 or more values.");
 
       // figure out / validate graph set up
@@ -7477,18 +7597,18 @@ public abstract class EDDGrid extends EDD {
             else if (nDv > cDataI) vars[v] = reqDataVars[cDataI++];
             else
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "Too few active axes and/or data variables for .draw=lines.");
           }
         } else {
           // vars 0,1 must be valid (any type)
           if (vars[0] == null)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=lines, .var #0 is required.");
           if (vars[1] == null)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=lines, .var #1 is required.");
         }
         vars[2] = null;
@@ -7502,7 +7622,7 @@ public abstract class EDDGrid extends EDD {
             else if (nDv > cDataI) vars[v] = reqDataVars[cDataI++];
             else if (v < 2)
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "Too few active axes and/or data variables for .draw="
                       + what
                       + ".");
@@ -7511,13 +7631,13 @@ public abstract class EDDGrid extends EDD {
           // vars 0,1 must be valid (any type)
           if (vars[0] == null)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw="
                     + what
                     + ", .var #0 is required.");
           if (vars[1] == null)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw="
                     + what
                     + ", .var #1 is required.");
@@ -7530,29 +7650,29 @@ public abstract class EDDGrid extends EDD {
           if (nAAv > 0) vars[0] = axisVariables[activeAxes.get(cAxisI++)];
           else
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".draw=sticks requires an active axis variable.");
           // var 1,2 must be data
           for (int v = 1; v <= 2; v++) {
             if (nDv > cDataI) vars[v] = reqDataVars[cDataI++];
             else
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "Too few data variables to .draw=sticks.");
           }
         } else {
           // vars 0 must be axis, 1,2 must be data
           if (axisVarI[0] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=sticks, .var #0 must be an axis variable.");
           if (dataVarI[1] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=sticks, .var #1 must be a data variable.");
           if (dataVarI[2] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=sticks, .var #2 must be a data variable.");
         }
         vars[3] = null;
@@ -7565,7 +7685,7 @@ public abstract class EDDGrid extends EDD {
             vars[1] = axisVariables[latIndex];
           } else if (nAAv < 2) {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".draw=surface requires 2 axes with >1 value.");
           } else {
             // prefer last 2 axes (e.g., if [time][altitude][y][x]
@@ -7578,15 +7698,15 @@ public abstract class EDDGrid extends EDD {
           // vars 0,1 must be axis, 2 must be data
           if (axisVarI[0] < 0 || axisVarI[1] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=surface, .var #0 and #1 must be axis variables.");
           if (axisVarI[0] == axisVarI[1])
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=surface, .var #0 and #1 must be different axis variables.");
           if (dataVarI[2] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=surface, .var #2 must be a data variable.");
         }
         vars[3] = null;
@@ -7599,7 +7719,7 @@ public abstract class EDDGrid extends EDD {
             vars[1] = axisVariables[activeAxes.get(1)];
           } else
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".draw=vectors requires 2 active axis variables.");
           // var2,3 must be data
           if (nDv == 2) {
@@ -7607,25 +7727,25 @@ public abstract class EDDGrid extends EDD {
             vars[3] = reqDataVars[1];
           } else
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".draw=vectors requires 2 data variables.");
         } else {
           // vars 0,1 must be axes, 2,3 must be data
           if (axisVarI[0] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=vectors, .var #0 must be an axis variable.");
           if (axisVarI[1] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=vectors, .var #1 must be an axis variable.");
           if (dataVarI[2] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=vectors, .var #2 must be a data variable.");
           if (dataVarI[3] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For .draw=vectors, .var #3 must be a data variable.");
         }
 
@@ -7635,7 +7755,7 @@ public abstract class EDDGrid extends EDD {
         vars = new EDV[nVars];
         if (nAAv == 0) {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "At least 1 axis variable must be active and have a range of values.");
         } else if (nAAv == 1) { // favor linesAndMarkers
           drawLinesAndMarkers = true;
@@ -7669,7 +7789,7 @@ public abstract class EDDGrid extends EDD {
           }
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "Either 1 or 2 axes must be active and have a range of values.");
         }
       } else {
@@ -7688,11 +7808,11 @@ public abstract class EDDGrid extends EDD {
           // ensure marker compatible
           if (axisVarI[0] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".var #0 must be an axis variable.");
           if (axisVarI[1] < 0 && dataVarI[1] < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".var #1 must be an axis or a data variable.");
           axisVarI[1] = -1;
           // var2 may be a dataVar or ""
@@ -7733,7 +7853,7 @@ public abstract class EDDGrid extends EDD {
         // but it is currently an assumption and what drives the creation of all graphs.
         // And the GUI always sets it up this way.
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The variable assigned to the x axis ("
                 + vars[0].destinationName()
                 + ") must be an axis variable.");
@@ -7757,7 +7877,7 @@ public abstract class EDDGrid extends EDD {
       if (drawSurface || drawVectors) {
         if (yAxisVar == null) // because yAxisIndex < 0
         throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "The variable assigned to the y axis ("
                   + vars[0].destinationName()
                   + ") must be an axis variable.");
@@ -7940,7 +8060,7 @@ public abstract class EDDGrid extends EDD {
           // put the data in a Table   0=xAxisVar 1=yAxisVar 2=dataVar1 3=dataVar2
           if (yAxisVar == null) // because yAxisIndex < 0      //redundant, since tested above
           throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "The variable assigned to the y axis ("
                     + vars[0].destinationName()
                     + ") must be an axis variable.");
@@ -8006,7 +8126,8 @@ public abstract class EDDGrid extends EDD {
                   varInfo,
                   title(),
                   otherInfo.toString(),
-                  MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+                  MessageFormat.format(
+                      EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
                   table,
                   null,
                   null,
@@ -8063,7 +8184,8 @@ public abstract class EDDGrid extends EDD {
                   title(),
                   otherInfo.toString(),
                   "",
-                  MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+                  MessageFormat.format(
+                      EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
                   table,
                   null,
                   null,
@@ -8080,7 +8202,7 @@ public abstract class EDDGrid extends EDD {
           // attributes
           if (yAxisVar == null) // because yAxisIndex < 0
           throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "The variable assigned to the y axis ("
                     + vars[0].destinationName()
                     + ") must be an axis variable.");
@@ -8097,7 +8219,7 @@ public abstract class EDDGrid extends EDD {
               continuousS = String2.parseBoolean(ts) ? "c" : "d"; // defaults to true
           }
 
-          if (String2.indexOf(EDStatic.palettes, palette) < 0) palette = "";
+          if (String2.indexOf(EDStatic.messages.palettes, palette) < 0) palette = "";
           if (EDV.VALID_SCALES.indexOf(scale) < 0) scale = "Linear";
           if (nSections < 0 || nSections >= 100) nSections = -1;
           boolean continuous = !continuousS.startsWith("d");
@@ -8217,7 +8339,8 @@ public abstract class EDDGrid extends EDD {
                       + zUnits, // boldTitle
                   title(),
                   otherInfo.toString(),
-                  MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+                  MessageFormat.format(
+                      EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
                   null,
                   grid,
                   null,
@@ -8259,7 +8382,7 @@ public abstract class EDDGrid extends EDD {
             if (continuousS.length() == 0 && ts != null)
               continuousS = String2.parseBoolean(ts) ? "c" : "d"; // defaults to true
 
-            if (String2.indexOf(EDStatic.palettes, palette) < 0) palette = "";
+            if (String2.indexOf(EDStatic.messages.palettes, palette) < 0) palette = "";
             if (EDV.VALID_SCALES.indexOf(scale) < 0) scale = "Linear";
             if (nSections < 0 || nSections >= 100) nSections = -1;
           }
@@ -8409,7 +8532,8 @@ public abstract class EDDGrid extends EDD {
                       : (reallySmall ? vars[2].destinationName() : vars[2].longName()) + zUnits,
                   vars[2] == null ? "" : title(),
                   otherInfo.toString(),
-                  MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+                  MessageFormat.format(
+                      EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
                   table,
                   null,
                   null,
@@ -8559,8 +8683,8 @@ public abstract class EDDGrid extends EDD {
               SgtMap.makeMap(
                   false,
                   SgtUtil.LEGEND_BELOW,
-                  EDStatic.legendTitle1,
-                  EDStatic.legendTitle2,
+                  EDStatic.messages.legendTitle1,
+                  EDStatic.messages.legendTitle2,
                   EDStatic.imageDir,
                   logoImageFile,
                   minX,
@@ -8577,7 +8701,8 @@ public abstract class EDDGrid extends EDD {
                   vars[2].longName() + zUnits,
                   title(),
                   otherInfo.toString(),
-                  MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+                  MessageFormat.format(
+                      EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
                   "off".equals(currentDrawLandMask)
                       ? SgtMap.NO_LAKES_AND_RIVERS
                       : palette.equals("Ocean") || palette.equals("Topography")
@@ -8623,8 +8748,8 @@ public abstract class EDDGrid extends EDD {
                 ? SgtMap.makeMap(
                     transparentPng,
                     SgtUtil.LEGEND_BELOW,
-                    EDStatic.legendTitle1,
-                    EDStatic.legendTitle2,
+                    EDStatic.messages.legendTitle1,
+                    EDStatic.messages.legendTitle2,
                     EDStatic.imageDir,
                     logoImageFile,
                     minX,
@@ -8672,8 +8797,8 @@ public abstract class EDDGrid extends EDD {
                         ? "."
                         : graphDataLayer.yAxisTitle, // avoid running into legend
                     SgtUtil.LEGEND_BELOW,
-                    EDStatic.legendTitle1,
-                    EDStatic.legendTitle2,
+                    EDStatic.messages.legendTitle1,
+                    EDStatic.messages.legendTitle2,
                     EDStatic.imageDir,
                     logoImageFile,
                     minX,
@@ -8941,22 +9066,22 @@ public abstract class EDDGrid extends EDD {
                 language,
                 MustBe.THERE_IS_NO_DATA
                     + " "
-                    + EDStatic.queryErrorAr[0]
+                    + EDStatic.messages.queryErrorAr[0]
                     + diagnostic0
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorGridGreaterMaxAr[0],
+                        EDStatic.messages.queryErrorGridGreaterMaxAr[0],
                         idAr[0],
                         stringValue,
                         stringMax,
                         coarseMaxString),
                 MustBe.THERE_IS_NO_DATA
                     + " "
-                    + EDStatic.queryErrorAr[language]
+                    + EDStatic.messages.queryErrorAr[language]
                     + diagnosticl
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorGridGreaterMaxAr[language],
+                        EDStatic.messages.queryErrorGridGreaterMaxAr[language],
                         idAr[language],
                         stringValue,
                         stringMax,
@@ -9011,22 +9136,22 @@ public abstract class EDDGrid extends EDD {
                 language,
                 MustBe.THERE_IS_NO_DATA
                     + " "
-                    + EDStatic.queryErrorAr[0]
+                    + EDStatic.messages.queryErrorAr[0]
                     + diagnostic0
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorGridLessMinAr[0],
+                        EDStatic.messages.queryErrorGridLessMinAr[0],
                         idAr[0],
                         stringValue,
                         stringMin,
                         coarseMinString),
                 MustBe.THERE_IS_NO_DATA
                     + " "
-                    + EDStatic.queryErrorAr[language]
+                    + EDStatic.messages.queryErrorAr[language]
                     + diagnosticl
                     + ": "
                     + MessageFormat.format(
-                        EDStatic.queryErrorGridLessMinAr[language],
+                        EDStatic.messages.queryErrorGridLessMinAr[language],
                         idAr[language],
                         stringValue,
                         stringMin,
@@ -9055,13 +9180,13 @@ public abstract class EDDGrid extends EDD {
     EDVGridAxis av = axisVariables[lonIndex];
     String diagnostic0 =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[0],
+            EDStatic.messages.queryErrorGridDiagnosticAr[0],
             av.destinationName(),
             "" + lonIndex,
             av.destinationName());
     String diagnosticl =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[language],
+            EDStatic.messages.queryErrorGridDiagnosticAr[language],
             av.destinationName(),
             "" + lonIndex,
             av.destinationName());
@@ -9073,7 +9198,7 @@ public abstract class EDDGrid extends EDD {
         "" + minX,
         av,
         false /* repair */,
-        EDStatic.advl_minLongitudeAr,
+        EDStatic.messages.advl_minLongitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9083,7 +9208,7 @@ public abstract class EDDGrid extends EDD {
         "" + maxX,
         av,
         false /* repair */,
-        EDStatic.advl_maxLongitudeAr,
+        EDStatic.messages.advl_maxLongitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9092,13 +9217,13 @@ public abstract class EDDGrid extends EDD {
     av = axisVariables[latIndex];
     diagnostic0 =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[0],
+            EDStatic.messages.queryErrorGridDiagnosticAr[0],
             av.destinationName(),
             "" + latIndex,
             av.destinationName());
     diagnosticl =
         MessageFormat.format(
-            EDStatic.queryErrorGridDiagnosticAr[language],
+            EDStatic.messages.queryErrorGridDiagnosticAr[language],
             av.destinationName(),
             "" + latIndex,
             av.destinationName());
@@ -9112,7 +9237,7 @@ public abstract class EDDGrid extends EDD {
         -91,
         "-91" /* coarseMin */,
         false /* repair */,
-        EDStatic.advl_minLatitudeAr,
+        EDStatic.messages.advl_minLatitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9125,7 +9250,7 @@ public abstract class EDDGrid extends EDD {
         91,
         "91" /* coarseMax */,
         false /* repair */,
-        EDStatic.advl_maxLatitudeAr,
+        EDStatic.messages.advl_maxLatitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9136,7 +9261,7 @@ public abstract class EDDGrid extends EDD {
         "" + minY,
         av,
         false /* repair */,
-        EDStatic.advl_minLatitudeAr,
+        EDStatic.messages.advl_minLatitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9146,7 +9271,7 @@ public abstract class EDDGrid extends EDD {
         "" + maxY,
         av,
         false /* repair */,
-        EDStatic.advl_maxLatitudeAr,
+        EDStatic.messages.advl_maxLatitudeAr,
         language,
         diagnostic0,
         diagnosticl);
@@ -9186,8 +9311,9 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-                EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+                EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpFunctionNameAr[0],
+                EDStatic.messages.queryErrorAr[language]
+                    + EDStatic.messages.errorJsonpFunctionNameAr[language]));
     }
 
     // get dataAccessor first, in case of error when parsing query
@@ -9364,8 +9490,9 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-                EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+                EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpFunctionNameAr[0],
+                EDStatic.messages.queryErrorAr[language]
+                    + EDStatic.messages.errorJsonpFunctionNameAr[language]));
     }
 
     // get dataAccessor first, in case of error when parsing query
@@ -9440,7 +9567,7 @@ public abstract class EDDGrid extends EDD {
     // lon and lat are required; time is not required
     if (isAxisDapQuery(userDapQuery) || lonIndex < 0 || latIndex < 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "The .kml format is for latitude longitude data requests only.");
 
     // parse the userDapQuery
@@ -9450,7 +9577,7 @@ public abstract class EDDGrid extends EDD {
     parseDataDapQuery(language, userDapQuery, tDestinationNames, tConstraints, false);
     if (tDestinationNames.size() != 1)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "The .kml format can only handle one data variable.");
 
     // find any &constraints (simplistic approach, but sufficient for here and hard to replace with
@@ -9493,13 +9620,13 @@ public abstract class EDDGrid extends EDD {
         timeStopd = timePa.getNiceDouble(nTimes - 1);
         if (nTimes > 500) // arbitrary: prevents requests that would take too long to respond to
         throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For .kml requests, the time dimension's size must be less than 500.");
 
       } else {
         if (tConstraints.get(av * 3 + 0) != tConstraints.get(av * 3 + 2))
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For .kml requests, the "
                   + axisVariables[av].destinationName()
                   + " dimension's size must be 1.");
@@ -9522,7 +9649,7 @@ public abstract class EDDGrid extends EDD {
     double lonStopd = lonEdv.destinationValue(lonStopi).getNiceDouble(0);
     if (lonStopd <= -180 || lonStartd >= 360)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "For .kml requests, there must be some longitude values must be between -180 and 360.");
     if (lonStartd < -180) {
       lonStarti = lonEdv.destinationToClosestIndex(-180);
@@ -9542,14 +9669,14 @@ public abstract class EDDGrid extends EDD {
     double latStopd = latEdv.destinationValue(latStopi).getNiceDouble(0);
     if (latStartd < -90 || latStopd > 90)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "For .kml requests, the latitude values must be between -90 and 90.");
     int latMidi = (latStarti + latStopi) / 2;
     double latMidd = latEdv.destinationValue(latMidi).getNiceDouble(0);
 
     if (lonStarti == lonStopi || latStarti == latStopi)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "For .kml requests, the lon and lat dimension sizes must be greater than 1.");
     // request is ok and compatible with .kml request!
 
@@ -9563,7 +9690,7 @@ public abstract class EDDGrid extends EDD {
               "");
     if (nTimes >= 2)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "For .kml requests, the time dimension size must be 1.");
     // timeString += " through " + limitedIsoStringT ... Math.max(timeStartd, timeStopd), "");
     String brTimeString = timeString.length() == 0 ? "" : "Time: " + timeString + "<br />\n";
@@ -9666,7 +9793,8 @@ public abstract class EDDGrid extends EDD {
                 "  <description><![CDATA["
                 + brTimeString
                 + MessageFormat.format(
-                    EDStatic.imageDataCourtesyOfAr[language], XML.encodeAsXML(institution()))
+                    EDStatic.messages.imageDataCourtesyOfAr[language],
+                    XML.encodeAsXML(institution()))
                 + "<br />\n"
                 +
                 // link to download data
@@ -9922,7 +10050,8 @@ public abstract class EDDGrid extends EDD {
     int randomInt = Math2.random(Integer.MAX_VALUE);
     String fullDosName = fullOutName + ".dos" + randomInt;
     String errorWhile =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + " while writing .wav file: ";
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+            + " while writing .wav file: ";
 
     // .kml not available for axis request
     if (isAxisDapQuery(userDapQuery))
@@ -10069,7 +10198,7 @@ public abstract class EDDGrid extends EDD {
       int nAV = axisVariables.length;
       if (nAV > 4)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "Igor Text Files can handle 4 dimensions, not "
                 + nAV);
 
@@ -10292,7 +10421,7 @@ public abstract class EDDGrid extends EDD {
           // that could be a memory nightmare
           // so just don't allow it
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "ERDDAP doesn't support String data in Matlab grid data files.");
         // largest = Math.max(largest,
         //    tDataVariables[dv].destinationBytesPerElement());
@@ -10323,7 +10452,9 @@ public abstract class EDDGrid extends EDD {
             Math2.memoryTooMuchData
                 + "  "
                 + MessageFormat.format(
-                    EDStatic.errorMoreThan2GBAr[0], ".mat", (cumSize / Math2.BytesPerMB) + " MB"));
+                    EDStatic.messages.errorMoreThan2GBAr[0],
+                    ".mat",
+                    (cumSize / Math2.BytesPerMB) + " MB"));
       // "Error: " +
       // "The requested data (" +
       // (cumSize / Math2.BytesPerMB) +
@@ -10434,7 +10565,7 @@ public abstract class EDDGrid extends EDD {
 
     if (gda.rowMajor())
       throw new SimpleException(
-          EDStatic.errorInternalAr[0]
+          EDStatic.messages.errorInternalAr[0]
               + "In EDDGrid.writeNDimensionalMatlabArray, the GridDataAccessor must be column-major.");
 
     // do the first part
@@ -10445,7 +10576,7 @@ public abstract class EDDGrid extends EDD {
       // that could be a memory nightmare
       // so just don't allow it
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "Matlab files can't have String data.");
     int nDataBytes = Matlab.writeNDimensionalArray1(stream, name, elementPAType, ndIndex);
 
@@ -10628,7 +10759,7 @@ public abstract class EDDGrid extends EDD {
             Math2.memoryTooMuchData
                 + "  "
                 + MessageFormat.format(
-                    EDStatic.errorMoreThan2GBAr[0],
+                    EDStatic.messages.errorMoreThan2GBAr[0],
                     ".nc",
                     ((gda.totalNBytes() + 100000) / Math2.BytesPerMB) + " MB"));
 
@@ -10834,8 +10965,9 @@ public abstract class EDDGrid extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-                EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+                EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpFunctionNameAr[0],
+                EDStatic.messages.queryErrorAr[language]
+                    + EDStatic.messages.errorJsonpFunctionNameAr[language]));
     }
 
     // handle axisDapQuery
@@ -11317,14 +11449,15 @@ public abstract class EDDGrid extends EDD {
     // do quick error checking
     if (isAxisDapQuery(userDapQuery))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "You can't save just axis data in on ODV .txt file. Please select a subset of a data variable.");
     if (lonIndex < 0 || latIndex < 0 || timeIndex < 0)
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + EDStatic.errorOdvLLTGridAr[0],
-              EDStatic.queryErrorAr[language] + EDStatic.errorOdvLLTGridAr[language]));
+              EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorOdvLLTGridAr[0],
+              EDStatic.messages.queryErrorAr[language]
+                  + EDStatic.messages.errorOdvLLTGridAr[language]));
     // lon can be +-180 or 0-360. See EDDTable.saveAsODV
 
     // get dataAccessor first, in case of error when parsing query
@@ -11473,7 +11606,7 @@ public abstract class EDDGrid extends EDD {
             true,
             true,
             -1, // tencodeAsHTML, tWriteUnits
-            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile);
+            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile);
     if (isAxisDapQuery) {
       saveAsTableWriter(ada, tw);
     } else {
@@ -11638,61 +11771,63 @@ public abstract class EDDGrid extends EDD {
     writer.write(widgets.beginTable("class=\"compact nowrap\""));
 
     // write the table's column names
-    String dimHelp = EDStatic.EDDGridDimensionTooltipAr[language] + "\n<br>";
-    String sss = dimHelp + EDStatic.EDDGridSSSTooltipAr[language] + "\n<br>";
-    String startTooltip = sss + EDStatic.EDDGridStartTooltipAr[language];
-    String stopTooltip = sss + EDStatic.EDDGridStopTooltipAr[language];
-    String strideTooltip = sss + EDStatic.EDDGridStrideTooltipAr[language];
-    String downloadTooltip = EDStatic.EDDGridDownloadTooltipAr[language];
+    String dimHelp = EDStatic.messages.EDDGridDimensionTooltipAr[language] + "\n<br>";
+    String sss = dimHelp + EDStatic.messages.EDDGridSSSTooltipAr[language] + "\n<br>";
+    String startTooltip = sss + EDStatic.messages.EDDGridStartTooltipAr[language];
+    String stopTooltip = sss + EDStatic.messages.EDDGridStopTooltipAr[language];
+    String strideTooltip = sss + EDStatic.messages.EDDGridStrideTooltipAr[language];
+    String downloadTooltip = EDStatic.messages.EDDGridDownloadTooltipAr[language];
     String gap = "&nbsp;&nbsp;&nbsp;";
     writer.write(
         "<tr>\n"
             + "  <th class=\"L\">"
-            + EDStatic.EDDGridDimensionAr[language]
+            + EDStatic.messages.EDDGridDimensionAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, dimHelp + EDStatic.EDDGridVarHasDimTooltipAr[language])
+                language,
+                loggedInAs,
+                dimHelp + EDStatic.messages.EDDGridVarHasDimTooltipAr[language])
             + " </th>\n"
             + "  <th class=\"L\">"
-            + EDStatic.EDDGridStartAr[language]
+            + EDStatic.messages.EDDGridStartAr[language]
             + " "
             + EDStatic.htmlTooltipImage(language, loggedInAs, startTooltip)
             + " </th>\n"
             + "  <th class=\"L\">"
-            + EDStatic.EDDGridStrideAr[language]
+            + EDStatic.messages.EDDGridStrideAr[language]
             + " "
             + EDStatic.htmlTooltipImage(language, loggedInAs, strideTooltip)
             + " </th>\n"
             + "  <th class=\"L\">"
-            + EDStatic.EDDGridStopAr[language]
+            + EDStatic.messages.EDDGridStopAr[language]
             + " "
             + EDStatic.htmlTooltipImage(language, loggedInAs, stopTooltip)
             + " </th>\n"
             +
-            // "  <th class=\"L\">&nbsp;" + EDStatic.EDDGridFirst + " " +
+            // "  <th class=\"L\">&nbsp;" + EDStatic.messages.EDDGridFirst + " " +
             //    EDStatic.htmlTooltipImage(language, loggedInAs,
-            // EDStatic.EDDGridDimensionFirstTooltip) + "</th>\n" +
+            // EDStatic.messages.EDDGridDimensionFirstTooltip) + "</th>\n" +
             "  <th class=\"L\">&nbsp;"
-            + EDStatic.EDDGridNValuesAr[language]
+            + EDStatic.messages.EDDGridNValuesAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.EDDGridNValuesHtmlAr[language])
+                language, loggedInAs, EDStatic.messages.EDDGridNValuesHtmlAr[language])
             + "</th>\n"
             + "  <th class=\"L\">"
             + gap
-            + EDStatic.EDDGridSpacingAr[language]
+            + EDStatic.messages.EDDGridSpacingAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.EDDGridSpacingTooltipAr[language]
+                    + EDStatic.messages.EDDGridSpacingTooltipAr[language]
                     + "</div>")
             + "</th>\n"
             +
-            // "  <th class=\"L\">" + gap + EDStatic.EDDGridLast + " " +
+            // "  <th class=\"L\">" + gap + EDStatic.messages.EDDGridLast + " " +
             //    EDStatic.htmlTooltipImage(language, loggedInAs,
-            // EDStatic.EDDGridDimensionLastTooltipAr[language]) + "</th>\n" +
+            // EDStatic.messages.EDDGridDimensionLastTooltipAr[language]) + "</th>\n" +
             "</tr>\n");
 
     // a row for each axisVariable
@@ -11824,7 +11959,7 @@ public abstract class EDDGrid extends EDD {
         widgets.beginTable("class=\"compact nowrap\"")
             + "<tr>\n"
             + "  <td>&nbsp;<br>"
-            + EDStatic.EDDGridGridVariableHtmlAr[language]
+            + EDStatic.messages.EDDGridGridVariableHtmlAr[language]
             + "&nbsp;");
 
     StringBuilder checkAll = new StringBuilder();
@@ -11839,15 +11974,15 @@ public abstract class EDDGrid extends EDD {
         widgets.button(
             "button",
             "CheckAll",
-            EDStatic.EDDGridCheckAllTooltipAr[language],
-            EDStatic.EDDGridCheckAllAr[language],
+            EDStatic.messages.EDDGridCheckAllTooltipAr[language],
+            EDStatic.messages.EDDGridCheckAllAr[language],
             "onclick=\"" + checkAll + "\""));
     writer.write(
         widgets.button(
             "button",
             "UncheckAll",
-            EDStatic.EDDGridUncheckAllTooltipAr[language],
-            EDStatic.EDDGridUncheckAllAr[language],
+            EDStatic.messages.EDDGridUncheckAllTooltipAr[language],
+            EDStatic.messages.EDDGridUncheckAllAr[language],
             "onclick=\"" + uncheckAll + "\""));
 
     writer.write("</td></tr>\n");
@@ -11891,17 +12026,17 @@ public abstract class EDDGrid extends EDD {
     // fileType
     writer.write(
         "<p><strong>"
-            + EDStatic.EDDFileTypeAr[language]
+            + EDStatic.messages.EDDFileTypeAr[language]
             + "</strong>\n"
             + " (<a rel=\"help\" href=\""
             + tErddapUrl
             + "/griddap/documentation.html#fileType\">"
-            + EDStatic.moreInformationAr[language]
+            + EDStatic.messages.moreInformationAr[language]
             + "</a>)\n");
     writer.write(
         widgets.select(
             "fileType",
-            EDStatic.EDDSelectFileTypeAr[language],
+            EDStatic.messages.EDDSelectFileTypeAr[language],
             1,
             allFileTypeOptionsAr[language],
             defaultFileTypeOption,
@@ -11973,18 +12108,21 @@ public abstract class EDDGrid extends EDD {
     String genViewHtml =
         "<div class=\"standard_max_width\">"
             + String2.replaceAll(
-                EDStatic.justGenerateAndViewTooltipAr[language], "&protocolName;", dapProtocol)
+                EDStatic.messages.justGenerateAndViewTooltipAr[language],
+                "&protocolName;",
+                dapProtocol)
             + "</div>";
     writer.write(
         widgets.button(
             "button",
             "getUrl",
             genViewHtml,
-            EDStatic.justGenerateAndViewAr[language],
+            EDStatic.messages.justGenerateAndViewAr[language],
             // "class=\"skinny\" " + //only IE needs it but only IE ignores it
             "onclick='" + javaScript + "'"));
     writer.write(
-        widgets.textField("tUrl", EDStatic.justGenerateAndViewUrlAr[language], 60, 1000, "", ""));
+        widgets.textField(
+            "tUrl", EDStatic.messages.justGenerateAndViewUrlAr[language], 60, 1000, "", ""));
     writer.write(
         "\n<br>(<a rel=\"help\" href=\""
             + tErddapUrl
@@ -12000,9 +12138,9 @@ public abstract class EDDGrid extends EDD {
                 "button",
                 "submit1",
                 "",
-                EDStatic.submitTooltipAr[language],
+                EDStatic.messages.submitTooltipAr[language],
                 "<span style=\"font-size:large;\"><strong>"
-                    + EDStatic.submitAr[language]
+                    + EDStatic.messages.submitAr[language]
                     + "</strong></span>",
                 "onclick='"
                     + javaScript
@@ -12010,7 +12148,7 @@ public abstract class EDDGrid extends EDD {
                     + // or open a new window: window.open(result);\n" +
                     "'")
             + " "
-            + EDStatic.patientDataAr[language]
+            + EDStatic.messages.patientDataAr[language]
             + "\n");
 
     // end of form
@@ -12046,43 +12184,56 @@ public abstract class EDDGrid extends EDD {
   public static void writeGeneralDapHtmlInstructions(
       int language, String tErddapUrl, Writer writer, boolean complete) throws Throwable {
 
-    String dapBase = EDStatic.EDDGridErddapUrlExample + dapProtocol + "/";
-    String datasetBase = dapBase + EDStatic.EDDGridIdExample;
+    String dapBase = EDStatic.messages.EDDGridErddapUrlExample + dapProtocol + "/";
+    String datasetBase = dapBase + EDStatic.messages.EDDGridIdExample;
     String ddsExample = datasetBase + ".dds";
-    String dds1VarExample = datasetBase + ".dds?" + EDStatic.EDDGridNoHyperExample;
+    String dds1VarExample = datasetBase + ".dds?" + EDStatic.messages.EDDGridNoHyperExample;
 
     // variants encoded to be Html Examples
     String fullDimensionExampleHE =
-        datasetBase + ".htmlTable?" + EDStatic.EDDGridDimensionExampleHE;
-    String fullIndexExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataIndexExampleHE;
-    String fullValueExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataValueExampleHE;
-    String fullTimeExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataTimeExampleHE;
-    String fullTimeCsvExampleHE = datasetBase + ".csv?" + EDStatic.EDDGridDataTimeExampleHE;
-    String fullTimeNcExampleHE = datasetBase + ".nc?" + EDStatic.EDDGridDataTimeExampleHE;
-    String fullMatExampleHE = datasetBase + ".mat?" + EDStatic.EDDGridDataTimeExampleHE;
-    String fullGraphExampleHE = datasetBase + ".png?" + EDStatic.EDDGridGraphExampleHE;
-    String fullGraphMAGExampleHE = datasetBase + ".graph?" + EDStatic.EDDGridGraphExampleHE;
-    String fullGraphDataExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDGridGraphExampleHE;
-    String fullMapExampleHE = datasetBase + ".png?" + EDStatic.EDDGridMapExampleHE;
-    String fullMapMAGExampleHE = datasetBase + ".graph?" + EDStatic.EDDGridMapExampleHE;
-    String fullMapDataExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDGridMapExampleHE;
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDimensionExampleHE;
+    String fullIndexExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataIndexExampleHE;
+    String fullValueExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataValueExampleHE;
+    String fullTimeExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataTimeExampleHE;
+    String fullTimeCsvExampleHE =
+        datasetBase + ".csv?" + EDStatic.messages.EDDGridDataTimeExampleHE;
+    String fullTimeNcExampleHE = datasetBase + ".nc?" + EDStatic.messages.EDDGridDataTimeExampleHE;
+    String fullMatExampleHE = datasetBase + ".mat?" + EDStatic.messages.EDDGridDataTimeExampleHE;
+    String fullGraphExampleHE = datasetBase + ".png?" + EDStatic.messages.EDDGridGraphExampleHE;
+    String fullGraphMAGExampleHE =
+        datasetBase + ".graph?" + EDStatic.messages.EDDGridGraphExampleHE;
+    String fullGraphDataExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridGraphExampleHE;
+    String fullMapExampleHE = datasetBase + ".png?" + EDStatic.messages.EDDGridMapExampleHE;
+    String fullMapMAGExampleHE = datasetBase + ".graph?" + EDStatic.messages.EDDGridMapExampleHE;
+    String fullMapDataExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridMapExampleHE;
 
     // variants encoded to be Html Attributes
     String fullDimensionExampleHA =
-        datasetBase + ".htmlTable?" + EDStatic.EDDGridDimensionExampleHA;
-    String fullIndexExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataIndexExampleHA;
-    String fullValueExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataValueExampleHA;
-    String fullTimeExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDGridDataTimeExampleHA;
-    String fullGraphExampleHA = datasetBase + ".png?" + EDStatic.EDDGridGraphExampleHA;
-    String fullGraphMAGExampleHA = datasetBase + ".graph?" + EDStatic.EDDGridGraphExampleHA;
-    String fullGraphDataExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDGridGraphExampleHA;
-    String fullMapExampleHA = datasetBase + ".png?" + EDStatic.EDDGridMapExampleHA;
-    String fullMapMAGExampleHA = datasetBase + ".graph?" + EDStatic.EDDGridMapExampleHA;
-    String fullMapDataExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDGridMapExampleHA;
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDimensionExampleHA;
+    String fullIndexExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataIndexExampleHA;
+    String fullValueExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataValueExampleHA;
+    String fullTimeExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridDataTimeExampleHA;
+    String fullGraphExampleHA = datasetBase + ".png?" + EDStatic.messages.EDDGridGraphExampleHA;
+    String fullGraphMAGExampleHA =
+        datasetBase + ".graph?" + EDStatic.messages.EDDGridGraphExampleHA;
+    String fullGraphDataExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridGraphExampleHA;
+    String fullMapExampleHA = datasetBase + ".png?" + EDStatic.messages.EDDGridMapExampleHA;
+    String fullMapMAGExampleHA = datasetBase + ".graph?" + EDStatic.messages.EDDGridMapExampleHA;
+    String fullMapDataExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDGridMapExampleHA;
 
     writer.write(
         "<h2><a class=\"selfLink\" id=\"instructions\" href=\"#instructions\" rel=\"bookmark\">"
-            + EDStatic.usingGriddapAr[language]
+            + EDStatic.messages.usingGriddapAr[language]
             + "</a></h2>\n"
             + longDapDescription(language, tErddapUrl)
             + "<p><strong>griddap request URLs must be in the form</strong>\n"
@@ -12104,12 +12255,12 @@ public abstract class EDDGrid extends EDD {
             + fullTimeExampleHE
             + "</kbd></a>\n"
             + "<br>Thus, the query is often a data variable name (e.g., <kbd>"
-            + EDStatic.EDDGridNoHyperExample
+            + EDStatic.messages.EDDGridNoHyperExample
             + "</kbd>),\n"
             + "followed by <kbd>[(<i>start</i>):<i>stride</i>:(<i>stop</i>)]</kbd>\n"
             + "(or a shorter variation of that) for each of the variable's dimensions\n"
             + "(for example, <kbd>"
-            + EDStatic.EDDGridDimNamesExample
+            + EDStatic.messages.EDDGridDimNamesExample
             + "</kbd>). \n"
             + "\n");
 
@@ -12137,7 +12288,7 @@ public abstract class EDDGrid extends EDD {
             "<li><a class=\"selfLink\" id=\"datasetID\" href=\"#datasetID\" rel=\"bookmark\""
             + "><strong>datasetID</strong></a> identifies the name that ERDDAP\n"
             + "  assigned to the dataset (for example, <kbd>"
-            + EDStatic.EDDGridIdExample
+            + EDStatic.messages.EDDGridIdExample
             + "</kbd>). \n"
             + "  You can see a list of "
             + "<a rel=\"bookmark\" href=\""
@@ -12188,14 +12339,14 @@ public abstract class EDDGrid extends EDD {
                   : "<a rel=\"help\" href=\""
                       + XML.encodeAsHTMLAttribute(dataFileTypeInfo.get(i))
                       + "\">info"
-                      + EDStatic.externalLinkHtml(language, tErddapUrl)
+                      + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                       + "</a>")
               + "</td>\n"
               + "      <td class=\"N\"><a rel=\"bookmark\" href=\""
               + datasetBase
               + dataFileTypeNames.get(i)
               + "?"
-              + EDStatic.EDDGridDataTimeExampleHA
+              + EDStatic.messages.EDDGridDataTimeExampleHA
               + "\">example</a></td>\n"
               + "    </tr>\n");
     }
@@ -12212,10 +12363,10 @@ public abstract class EDDGrid extends EDD {
 
             // ArcGIS
             "<p><strong><a rel=\"bookmark\" href=\"https://www.esri.com/en-us/arcgis/about-arcgis/overview\">ArcGIS"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a><a class=\"selfLink\" id=\"ArcGIS\" href=\"#ArcGIS\" rel=\"bookmark\">&nbsp;</a>\n"
             + "     <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/Esri_grid\">.esriAsc"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "   <br>.esriAsc is an old and inherently limited file format. If you have <strong>ArcGIS 10 or higher</strong>, we strongly recommend\n"
             + "   that you download gridded data from ERDDAP in a <a rel=\"help\" href=\"#nc\">NetCDF .nc file</a>,"
@@ -12223,7 +12374,7 @@ public abstract class EDDGrid extends EDD {
             + "   using the\n"
             + "   <a rel=\"help\" href=\"https://desktop.arcgis.com/en/arcmap/latest/tools/multidimension-toolbox/make-netcdf-raster-layer.htm\">Make\n"
             + "     NetCDF Raster Layer tool in the Multidimension Tools toolbox"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "   <p>If you have <strong>ArcGIS 9.x or lower</strong>:\n"
             + "   <br>ArcGIS is a family of Geographical Information Systems (GIS) products from ESRI: ArcView, ArcEditor, and ArcInfo.\n"
@@ -12284,13 +12435,13 @@ public abstract class EDDGrid extends EDD {
             +
             // Ferret
             "  <p><strong><a rel=\"bookmark\" href=\"https://ferret.pmel.noaa.gov/Ferret/\">Ferret"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"Ferret\" href=\"#Ferret\" rel=\"bookmark\">is</a> a free program for visualizing and analyzing large and complex gridded\n"
             + "  datasets. Ferret should work well with all datasets in griddap since griddap is\n"
             + "  fully compatible with OPeNDAP. See the\n"
             + "    <a rel=\"help\" href=\"https://ferret.pmel.noaa.gov/Ferret/documentation/ferret-documentation\">Ferret documentation"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  Note that the griddap dataset's OPeNDAP base URL that you use with Ferret's\n"
             + "  <kbd>set data</kbd>, for example,\n"
@@ -12302,20 +12453,20 @@ public abstract class EDDGrid extends EDD {
             +
             // IDL
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.harrisgeospatial.com/Software-Technology/IDL/\">IDL"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> - \n"
             + "    <a class=\"selfLink\" id=\"IDL\" href=\"#IDL\" rel=\"bookmark\">IDL</a> is a commercial scientific data visualization program. To get data from ERDDAP\n"
             + "  into IDL, first use ERDDAP to select a subset of data and download a .nc file.\n"
             + "  Then, use these\n"
             + "    <a rel=\"help\" href=\"https://northstar-www.dartmouth.edu/doc/idl/html_6.2/Using_Macros_to_Import_HDF_Files.html\">instructions"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    to import the data from the .nc file into IDL.\n"
             + "\n"
             +
             // json
             "  <p><strong><a rel=\"help\" href=\"https://www.json.org/\">JSON .json"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"json\" href=\"#json\" rel=\"bookmark\">files</a> are widely used to transfer data to JavaScript scripts running on web pages.\n"
             + "  All .json responses from ERDDAP (metadata, gridded data, and tabular/in-situ data) use the\n"
@@ -12350,10 +12501,10 @@ public abstract class EDDGrid extends EDD {
             +
             // jsonp
             "  <p><strong><a rel=\"help\" href=\"https://niryariv.wordpress.com/2009/05/05/jsonp-quickly/\">JSONP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    (from <a href=\"https://www.json.org/\">.json"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>)</strong> -\n"
             + "  <a class=\"selfLink\" id=\"jsonp\" href=\"#jsonp\" rel=\"bookmark\">Jsonp</a> is an easy way for a JavaScript script on a web page to\n"
             + "  import and access data from ERDDAP.  Requests for .geoJson, .json, and .ncoJson files may include an optional\n"
@@ -12367,16 +12518,16 @@ public abstract class EDDGrid extends EDD {
             + "  JavaScript script via that JavaScript function.\n"
             + "  Here is an example using \n"
             + "  <a rel=\"bookmark\" href=\"https://jsfiddle.net/jpatterson/0ycu1zjy/\">jsonp and Javascript with ERDDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> (thanks to Jenn Patterson Sevadjian of PolarWatch).\n"
             + "\n"
             +
             // matlab
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.mathworks.com/products/matlab/\">MATLAB"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a rel=\"help\" href=\"https://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf\">.mat"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"matlab\" href=\"#matlab\" rel=\"bookmark\">users</a> can use griddap's .mat file type to download data from within MATLAB.\n"
             + "  Here is a one line example:\n"
@@ -12386,16 +12537,16 @@ public abstract class EDDGrid extends EDD {
             + "  (You may need to <a rel=\"help\" href=\"#PercentEncoded\">percent encode</a> the query part of the URL.)\n"
             + "  The data will be in a MATLAB structure. The structure's name will be the datasetID\n"
             + "  (for example, <kbd>"
-            + EDStatic.EDDGridIdExample
+            + EDStatic.messages.EDDGridIdExample
             + "</kbd>). \n"
             + "  The structure's internal variables will have the same names as in ERDDAP,\n"
             + "  (for example, use <kbd>fieldnames("
-            + EDStatic.EDDGridIdExample
+            + EDStatic.messages.EDDGridIdExample
             + ")</kbd>). \n"
             + "  If you download a 2D matrix of data (as in the example above), you can plot it with\n"
             + "  (for example):\n"
             + "<pre>"
-            + EDStatic.EDDGridMatlabPlotExample
+            + EDStatic.messages.EDDGridMatlabPlotExample
             + "</pre>\n"
             + "  The numbers at the end of the first line specify the range for the color mapping. \n"
             + "  The 'set' command flips the map to make it upright.\n"
@@ -12404,7 +12555,7 @@ public abstract class EDDGrid extends EDD {
             + "    which are particularly useful for\n"
             + "  getting environmental data related to points along an animal's track (e.g.,\n"
             + "    <a rel=\"bookmark\" href=\"https://gtopp.org/\">GTOPP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> data).\n"
             + "  <p>ERDDAP stores datetime values in .mat files as \"seconds since 1970-01-01T00:00:00Z\".\n"
             + "  To display one of these values as a String in Matlab, you can use, e.g.,\n"
@@ -12422,10 +12573,10 @@ public abstract class EDDGrid extends EDD {
             +
             // nc
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\">NetCDF"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a rel=\"help\" href=\"https://github.com/Unidata/netcdf-c/blob/master/docs/file_format_specifications.md\">.nc"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    - <a class=\"selfLink\" id=\"nc\" href=\"#nc\" rel=\"bookmark\">Requests</a> for .nc files return the requested subset of the dataset in a\n"
             + "  standard, NetCDF-3, 32-bit, .nc file.\n"
@@ -12448,7 +12599,7 @@ public abstract class EDDGrid extends EDD {
             + "\n"
             + "  <p><a class=\"selfLink\" id=\"netcdfjava\" href=\"#netcdfjava\" rel=\"bookmark\">If</a> you are using\n"
             + "  <a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf-java/\">NetCDF-Java"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  don't try to directly access an ERDDAP dataset or subset\n"
             + "  as a .nc file. (It won't work, mostly because that .nc file isn't a static, persistent file. It is a\n"
@@ -12494,18 +12645,18 @@ public abstract class EDDGrid extends EDD {
             + "    - <a class=\"selfLink\" id=\"ncHeader\" href=\"#ncHeader\" rel=\"bookmark\">Requests</a> for .ncHeader files will return the header information (UTF-8 text) that\n"
             + "  would be generated if you used\n"
             + "    <a rel=\"help\" href=\"https://linux.die.net/man/1/ncdump\">ncdump -h <i>fileName</i>"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    on the corresponding .nc file.\n"
             + "\n"
             +
             // odv
             "  <p><strong><a rel=\"bookmark\" href=\"https://odv.awi.de/\">Ocean Data View"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> .odvTxt</strong>\n"
             + "    - <a class=\"selfLink\" id=\"ODV\" href=\"#ODV\" rel=\"bookmark\">ODV</a> users can download data in a\n"
             + "  <a rel=\"help\" href=\"https://odv.awi.de/en/documentation/\">ODV Generic Spreadsheet Format .txt file"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    by requesting griddap's .odvTxt fileType.\n"
             + "  The dataset MUST include longitude, latitude, and time dimensions.\n"
@@ -12540,21 +12691,21 @@ public abstract class EDDGrid extends EDD {
             // opendapLibraries
             "  <p><strong><a class=\"selfLink\" id=\"opendapLibraries\" href=\"#opendapLibraries\" rel=\"bookmark\">OPeNDAP Libraries</a></strong> - Since ERDDAP is an\n"
             + "    <a rel=\"bookmark\" href=\"https://www.opendap.org/\">OPeNDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>-compatible data server,\n"
             + "    you can use\n"
             + "  any OPeNDAP client library, such as\n"
             + "    <a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\">NetCDF-Java, NetCDF-C, NetCDF-Fortran, NetCDF-Perl"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  <a rel=\"bookmark\" href=\"https://www.opendap.org/deprecated-software/java-dap\">Java-DAP2"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  <a rel=\"bookmark\" href=\"https://ferret.pmel.noaa.gov/Ferret/\">Ferret"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>, or the\n"
             + "     <a rel=\"bookmark\" href=\"https://www.pydap.org/en/latest/client.html\">Pydap Client"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  to get data from an ERDDAP griddap dataset.\n"
             + "  When creating the initial connection to an ERDDAP griddap dataset from any OPeNDAP library:\n"
@@ -12588,17 +12739,17 @@ public abstract class EDDGrid extends EDD {
             +
             // Pydap Client
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.pydap.org/en/latest/client.html\">Pydap Client"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"PydapClient\" href=\"#PydapClient\" rel=\"bookmark\">users</a>\n"
             + "    can access griddap datasets via ERDDAP's standard OPeNDAP services.\n"
             + "  See the\n"
             + "    <a rel=\"help\" href=\"https://www.pydap.org/en/latest/client.html#accessing-gridded-data\">Pydap Client instructions for accessing gridded data"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  Note that the name of a dataset in ERDDAP will always be a single word,\n"
             + "  (e.g., "
-            + EDStatic.EDDGridIdExample
+            + EDStatic.messages.EDDGridIdExample
             + " in the OPeNDAP dataset URL\n"
             + "  <br>"
             + datasetBase
@@ -12609,7 +12760,7 @@ public abstract class EDDGrid extends EDD {
             +
             // Python
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.python.org\">Python"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"Python\" href=\"#Python\" rel=\"bookmark\">is</a> a widely-used computer language that is very popular among scientists.\n"
             + "    In addition to the <a rel=\"help\" href=\"#PydapClient\">Pydap Client</a>, you can use Python to download various files from ERDDAP\n"
@@ -12626,11 +12777,11 @@ public abstract class EDDGrid extends EDD {
             +
             // erddapy
             "  <p><a rel=\"bookmark\" href=\"https://github.com/ioos/erddapy#--erddapy\">erddapy"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a class=\"selfLink\" id=\"erddapy\" href=\"#erddapy\" rel=\"bookmark\">(ERDDAP + Python, by Filipe Pires Alvarenga Fernandes)</a> and\n"
             + "  <br><a rel=\"bookmark\" href=\"https://github.com/hmedrano/erddap-python\">erddap-python"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> (by Favio Medrano)\n"
             + "  <br>are Python libraries that \"take advantage of ERDDAP’s RESTful web services and create the\n"
             + "    ERDDAP URL for any request like searching for datasets, acquiring metadata, downloading data, etc.\"\n"
@@ -12640,7 +12791,7 @@ public abstract class EDDGrid extends EDD {
             //
             // Python/Jupyter Notebook
             "  <p>\"<a rel=\"bookmark\" href=\"https://jupyter.org/\">Jupyter Notebook"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "      <a class=\"selfLink\" id=\"JupyterNotebook\" href=\"#JupyterNotebook\" rel=\"bookmark\">is</a> an open-source web application that\n"
             + "      allows you to create and\n"
@@ -12650,18 +12801,18 @@ public abstract class EDDGrid extends EDD {
             + "    <a rel=\"bookmark\"\n"
             + "      href=\"https://github.com/rsignell-usgs/notebook/blob/master/ERDDAP/ERDDAP_advanced_search_test.ipynb/\"\n"
             + "      >ERDDAP Advanced Search Test"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and\n"
             + "    <a rel=\"bookmark\" \n"
             + "      href=\"https://github.com/rsignell-usgs/notebook/blob/master/ERDDAP/ERDDAP_timing.ipynb\"\n"
             + "      >ERDDAP Timing"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "    Thanks to Rich Signell.\n"
             +
             // R
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.r-project.org/\">R Statistical Package"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> -\n"
             + "    <a class=\"selfLink\" id=\"R\" href=\"#R\" rel=\"bookmark\">R</a> is an open source statistical package for many operating systems.\n"
             + "  In R, you can download a NetCDF version 3 .nc file from ERDDAP. For example:\n"
@@ -12671,7 +12822,7 @@ public abstract class EDDGrid extends EDD {
             + "  (You may need to <a rel=\"help\" href=\"#PercentEncoded\">percent encode</a> the query part of the URL.)\n"
             + "  Then import data from that .nc file into R with the RNetCDF, ncdf, or ncdf4 packages available\n"
             + "  from <a rel=\"bookmark\" href=\"https://cran.r-project.org/\">CRAN"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "    Or, if you want the data in tabular form, download and import the data in a .csv file.\n"
             + "  For example,\n"
@@ -12681,13 +12832,13 @@ public abstract class EDDGrid extends EDD {
             + "test&lt;-read.csv(file=\"/home/bsimons/test.csv\")</pre>\n"
             + "  There are third-party R packages designed to make it easier to work with ERDDAP from within R:\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/rerddap/index.html\">rerddap"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/rerddapXtracto/index.html\">rerddapXtracto"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>, and\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/plotdap/index.html\">plotdap"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  Thanks to \n"
             + "  <a rel=\"bookmark\" href=\"https://ropensci.org/\">rOpenSci<img \n"
@@ -12699,7 +12850,7 @@ public abstract class EDDGrid extends EDD {
             + "    which are particularly useful for getting\n"
             + "  environmental data related to points along an animal's track (e.g.,\n"
             + "    <a rel=\"bookmark\" href=\"https://gtopp.org/\">GTOPP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> data).\n"
             + "     <br>&nbsp;\n"
             + "\n"
@@ -12716,13 +12867,13 @@ public abstract class EDDGrid extends EDD {
             +
             // .wav
             "  <p><strong><a rel=\"bookmark\" href=\"https://en.wikipedia.org/wiki/WAV\">.wav"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> -\n"
             + "    <a class=\"selfLink\" id=\"wav\" href=\"#wav\" rel=\"bookmark\">ERDDAP can return data in .wav files,</a> which are uncompressed audio files.\n"
             + "  <ul>\n"
             + "  <li>You can save any numeric data in .wav files, but this file format is clearly intended to be used\n"
             + "    with <a rel=\"bookmark\" href=\"https://en.wikipedia.org/wiki/Pulse-code_modulation\">PCM"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> digitized sound waves.\n"
             + "    We do not recommend saving other types of data in .wav files.\n"
             + "  <li>All of the data variables you select to save in a .wav file must have the same data type, e.g., int.\n"
@@ -12789,7 +12940,7 @@ public abstract class EDDGrid extends EDD {
                   : "<a rel=\"help\" href=\""
                       + XML.encodeAsHTMLAttribute(imageFileTypeInfo.get(i))
                       + "\">info"
-                      + EDStatic.externalLinkHtml(language, tErddapUrl)
+                      + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                       + "</a>")
               + "</td>\n"
               + // must be mapExample below because kml doesn't work with graphExample
@@ -12797,7 +12948,7 @@ public abstract class EDDGrid extends EDD {
               + datasetBase
               + imageFileTypeNames.get(i)
               + "?"
-              + EDStatic.EDDGridMapExampleHA
+              + EDStatic.messages.EDDGridMapExampleHA
               + "\">example</a></td>\n"
               + "    </tr>\n");
     }
@@ -12851,7 +13002,7 @@ public abstract class EDDGrid extends EDD {
             + "Or, if you are comfortable running command line programs\n"
             + "(from a Linux or Windows command line, or a Mac OS Terminal), you can use curl (or a similar program like\n"
             + "  <a rel=\"bookmark\" href=\"https://www.gnu.org/software/wget/\">wget"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>)\n"
             + "to save results files from ERDDAP into files on your hard drive,\n"
             + "without using a browser or writing a computer program or script.\n"
@@ -12860,7 +13011,7 @@ public abstract class EDDGrid extends EDD {
             + "<br>On Mac OS X, to get to a command line, use \"Finder : Go : Utilities : Terminal\".\n"
             + "<br>On Windows, you need to\n"
             + "  <a rel=\"bookmark\" href=\"https://curl.haxx.se/download.html\">download curl"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  (the \"Windows 64 - binary, the curl project\" variant worked for me on Windows 10)\n"
             + "  and install it.\n"
@@ -12869,10 +13020,10 @@ public abstract class EDDGrid extends EDD {
             + "<br><strong>Please be kind to other ERDDAP users: run just one script or curl command at a time.</strong>\n"
             + "<br>Instructions for using curl are on the \n"
             + "<a rel=\"help\" href=\"https://curl.haxx.se/download.html\">curl man page"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and in this\n"
             + "<a rel=\"help\" href=\"https://curl.haxx.se/docs/httpscripting.html\">curl tutorial"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "<br>But here is a quick tutorial related to using curl with ERDDAP:\n"
             + "<ul>\n"
@@ -12886,7 +13037,7 @@ public abstract class EDDGrid extends EDD {
             + "<pre>curl --compressed -g \""
             + fullGraphExampleHA
             + "\" -o "
-            + EDStatic.EDDGridIdExample
+            + EDStatic.messages.EDDGridIdExample
             + "_example.png</pre>\n"
             + "  (That example includes <kbd>--compressed</kbd> because it is a generally useful option,\n"
             + "  but there is little benefit to <kbd>--compressed</kbd> when requesting .png files\n"
@@ -12896,7 +13047,7 @@ public abstract class EDDGrid extends EDD {
             // BAssta5day20100901.png</pre>\n" +
             "  <p><a class=\"selfLink\" id=\"PercentEncoded\" href=\"#PercentEncoded\" rel=\"bookmark\">In curl, as in many other programs, the query part of the erddapUrl must be</a>\n"
             + "  <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.  To do this, you need to convert\n"
             + "  special characters (other than the initial '&amp;' and the main '=' of a constraint)\n"
             + "  into the form %HH, where HH is the 2 digit hexadecimal value of the character.\n"
@@ -12911,21 +13062,21 @@ public abstract class EDDGrid extends EDD {
             + "  A-Za-z0-9_-!.~'()* .\n"
             + "  Programming languages have tools to do this (for example, see Java's\n"
             + "  <a rel=\"help\" href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URLEncoder.html\">java.net.URLEncoder"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "     and JavaScript's\n"
             + "<a rel=\"help\" href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent\">encodeURIComponent()"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>) and there are\n"
             + "   <a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  <br>&nbsp;\n"
             + "<li>To download and save many files in one step, use curl with the globbing feature enabled:\n"
             + "  <br><kbd>curl --compressed \"<i>erddapUrl</i>\" -o <i>fileDir/fileName#1.ext</i></kbd>\n"
             + "  <br>Since the globbing feature treats the characters [, ], {, and } as special, you must\n"
             + "  <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encode"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> \n"
             + "them in the erddapURL as &#37;5B, &#37;5D, &#37;7B, &#37;7D, respectively.\n"
             + "  Then, in the erddapUrl, replace a zero-padded number (for example <kbd>01</kbd>) with a range\n"
@@ -12957,13 +13108,13 @@ public abstract class EDDGrid extends EDD {
             + "  <br>It specifies the subset of data that you want to receive.\n"
             + "  In griddap, it is an optional\n"
             + "    <a rel=\"bookmark\" href=\"https://www.opendap.org\">OPeNDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n "
             + "    <a rel=\"help\" href=\"https://www.opendap.org/pdf/ESE-RFC-004v1.2.pdf\">DAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a rel=\"help\" href=\"https://opendap.github.io/documentation/UserGuideComprehensive.html#Constraint_Expressions\">projection constraint"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> query\n"
             + "  which can request:\n"
             + "   <ul>\n"
@@ -13041,7 +13192,7 @@ public abstract class EDDGrid extends EDD {
             + "     and/or stop values to be actual dimension values (for example, longitude values\n"
             + "     in degrees_east) within parentheses, instead of array indices.  \n"
             + "     This example with "
-            + EDStatic.EDDGridDimNamesExample
+            + EDStatic.messages.EDDGridDimNamesExample
             + " dimension values \n"
             + "     <br><a href=\""
             + fullValueExampleHA
@@ -13082,7 +13233,7 @@ public abstract class EDDGrid extends EDD {
             + "     <br>The more human-oriented fileTypes (notably, .csv, .tsv, .htmlTable, .odvTxt, and .xhtml)\n"
             + "     display date/time values as "
             + "       <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601:2004 \"extended\" date/time strings"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "     (e.g., 2002-08-03T12:30:00Z, but some variables include milliseconds, e.g.,\n"
             + "     2002-08-03T12:30:00.123Z).\n"
@@ -13100,7 +13251,7 @@ public abstract class EDDGrid extends EDD {
                 : "")
             + "   <li>For the time dimension, griddap extends the OPeNDAP standard by allowing you to specify an\n"
             + "     <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601:2004 \"extended\" date/time string"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "       in parentheses, which griddap then converts to the\n"
             + "     internal number (in seconds since 1970-01-01T00:00:00Z) and then to the appropriate\n"
@@ -13402,7 +13553,7 @@ public abstract class EDDGrid extends EDD {
             + "        Tied values are not allowed because requests for a single <kbd>[(value)]</kbd> must\n"
             + "        translate unambiguously to one index. Also, the\n"
             + "        <a rel=\"help\" href=\"https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology\">CF Conventions"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "        require that \"coordinate variables\", as it calls them, be \"ordered monotonically\".\n"
             + "      <li>Each axis variable has a name composed of a letter (A-Z, a-z) and then 0 or more\n"
@@ -13485,7 +13636,7 @@ public abstract class EDDGrid extends EDD {
             + "    <br>&nbsp;\n"
             + "  </ul>\n"
             + "<li>"
-            + EDStatic.acceptEncodingHtml(language, "h3", tErddapUrl)
+            + EDStatic.messages.acceptEncodingHtml(language, "h3", tErddapUrl)
             + "    <br>&nbsp;\n"
             + "<li><a class=\"selfLink\" id=\"citeDataset\" href=\"#citeDataset\" rel=\"bookmark\"><strong>How to Cite a Dataset in a Paper</strong></a>\n"
             + "<br>It is important to let readers of your paper know how you got the data that\n"
@@ -13754,13 +13905,13 @@ public abstract class EDDGrid extends EDD {
             + "\n"
             + "<p>"
             + String2.replaceAll(
-                EDStatic.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                EDStatic.messages.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
             + "\n"
             + "\n"
             + "<p>WCS clients send HTTP POST or GET requests (specially formed URLs) to the WCS service and get XML responses.\n"
             + "See this <a rel=\"bookmark\" href=\"https://en.wikipedia.org/wiki/Web_Coverage_Service#WCS_Implementations\" \n"
             + ">list of WCS clients (and servers)"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "<h2>Sample WCS Requests</h2>\n"
             + "<ul>\n"
@@ -13794,7 +13945,7 @@ public abstract class EDDGrid extends EDD {
 
     if (accessibleViaWCS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaWCS());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaWCS());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
     String wcsUrl = tErddapUrl + "/wcs/" + datasetID + "/" + wcsServer;
@@ -14161,7 +14312,7 @@ public abstract class EDDGrid extends EDD {
       */
     } else {
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "version="
               + version
               + " must be \""
@@ -14192,7 +14343,7 @@ public abstract class EDDGrid extends EDD {
 
     if (accessibleViaWCS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaWCS());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaWCS());
 
     EDVGridAxis lonEdv = axisVariables[lonIndex];
     EDVGridAxis latEdv = axisVariables[latIndex];
@@ -14203,7 +14354,7 @@ public abstract class EDDGrid extends EDD {
     for (String s : coverages) {
       if (String2.indexOf(dataVariableDestinationNames(), s) < 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "coverage="
                 + s
                 + " isn't a valid coverage name.");
@@ -14395,7 +14546,7 @@ public abstract class EDDGrid extends EDD {
 
     } else {
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "version="
               + version
               + " must be \""
@@ -14434,7 +14585,7 @@ public abstract class EDDGrid extends EDD {
 
     if (accessibleViaWCS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaWCS);
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaWCS);
 
     // parse the wcsQuery
     String dapQuery[] = wcsQueryToDapQuery(language, EDD.userQueryHashMap(wcsQuery, true));
@@ -14487,7 +14638,7 @@ public abstract class EDDGrid extends EDD {
     String service = wcsQueryMap.get("service"); // test name.toLowerCase()
     if (service == null || !service.equals("WCS"))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "service="
               + service
               + " should have been \"WCS\".");
@@ -14496,7 +14647,7 @@ public abstract class EDDGrid extends EDD {
     String version = wcsQueryMap.get("version"); // test name.toLowerCase()
     if (!wcsVersion.equals(version)) // String2.indexOf(wcsVersions, version) < 0)
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "version="
               + version
               + " should have been \""
@@ -14509,7 +14660,7 @@ public abstract class EDDGrid extends EDD {
     String request = wcsQueryMap.get("request"); // test name.toLowerCase()
     if (request == null || !request.equals("GetCoverage"))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "request="
               + request
               + " should have been \"GetCoverage\".");
@@ -14519,7 +14670,7 @@ public abstract class EDDGrid extends EDD {
     int fi = String2.caseInsensitiveIndexOf(wcsRequestFormats100, requestFormat);
     if (fi < 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "format="
               + requestFormat
               + " isn't supported.");
@@ -14528,7 +14679,7 @@ public abstract class EDDGrid extends EDD {
     // interpolation (1.0.0)
     if (wcsQueryMap.get("interpolation") != null) // test name.toLowerCase()
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "'interpolation' isn't supported.");
 
     // GridXxx (for regridding in 1.1.2)
@@ -14542,14 +14693,14 @@ public abstract class EDDGrid extends EDD {
         || // test name.toLowerCase()
         wcsQueryMap.get("gridoffsets") != null) // test name.toLowerCase()
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "regridding via 'GridXxx' parameters isn't supported.");
 
     // exceptions    optional
     String exceptions = wcsQueryMap.get("exceptions");
     if (exceptions != null && !exceptions.equals(wcsExceptions))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "exceptions="
               + exceptions
               + " must be "
@@ -14558,7 +14709,8 @@ public abstract class EDDGrid extends EDD {
 
     // store (1.1.2)
     // if (wcsQueryMap.get("store") != null)  //test name.toLowerCase()
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        "'store' isn't supported.");
 
     // 1.0.0 coverage or 1.1.2 identifier
@@ -14566,7 +14718,7 @@ public abstract class EDDGrid extends EDD {
     String coverage = wcsQueryMap.get(cName);
     if (String2.indexOf(dataVariableDestinationNames(), coverage) < 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + cName
               + "="
               + coverage
@@ -14597,7 +14749,7 @@ public abstract class EDDGrid extends EDD {
       String bboxSA[] = String2.split(bbox, ',');
       if (bboxSA.length < 4)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + bboxName
                 + " must have at least 4 comma-separated values.");
       minLon = bboxSA[0]; // note goofy ordering of options
@@ -14614,7 +14766,7 @@ public abstract class EDDGrid extends EDD {
     double maxLonD = String2.parseDouble(maxLon);
     if (Double.isNaN(minLonD) || Double.isNaN(maxLonD) || minLonD > maxLonD)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + bboxName
               + " minLongitude="
               + minLonD
@@ -14625,7 +14777,7 @@ public abstract class EDDGrid extends EDD {
     double maxLatD = String2.parseDouble(maxLat);
     if (Double.isNaN(minLatD) || Double.isNaN(maxLatD) || minLatD > maxLatD)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + bboxName
               + " minLatitude="
               + minLatD
@@ -14637,7 +14789,7 @@ public abstract class EDDGrid extends EDD {
     if ((altIndex >= 0 || depthIndex >= 0)
         && (Double.isNaN(minAltD) || Double.isNaN(maxAltD) || minAltD > maxAltD))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + bboxName
               + " minAltitude="
               + minAltD
@@ -14665,7 +14817,7 @@ public abstract class EDDGrid extends EDD {
         int ni = String2.parseInt(n);
         if (ni == Integer.MAX_VALUE || ni <= 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "width="
                   + n
                   + " must be > 0.");
@@ -14674,7 +14826,7 @@ public abstract class EDDGrid extends EDD {
         double resD = String2.parseDouble(res);
         if (Double.isNaN(resD) || resD <= 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "resx="
                   + res
                   + " must be > 0.");
@@ -14695,7 +14847,7 @@ public abstract class EDDGrid extends EDD {
         int ni = String2.parseInt(n);
         if (ni == Integer.MAX_VALUE || ni <= 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "height="
                   + n
                   + " must be > 0.");
@@ -14706,7 +14858,7 @@ public abstract class EDDGrid extends EDD {
         double resD = String2.parseDouble(res);
         if (Double.isNaN(resD) || resD <= 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "resy="
                   + res
                   + " must be > 0.");
@@ -14728,7 +14880,7 @@ public abstract class EDDGrid extends EDD {
           int ni = String2.parseInt(n);
           if (ni == Integer.MAX_VALUE || ni <= 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "depth="
                     + n
                     + " must be > 0.");
@@ -14737,7 +14889,7 @@ public abstract class EDDGrid extends EDD {
           double resD = String2.parseDouble(res);
           if (Double.isNaN(resD) || resD <= 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "resz="
                     + res
                     + " must be > 0.");
@@ -14784,7 +14936,7 @@ public abstract class EDDGrid extends EDD {
         } else {
           if (time.indexOf(',') >= 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "comma-separated lists of "
                     + paramName
                     + "s are not supported.");
@@ -14795,7 +14947,7 @@ public abstract class EDDGrid extends EDD {
           }
           if (timeSA.length == 0 || timeSA[0].length() == 0) {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "invalid "
                     + paramName
                     + "=\"\".");
@@ -14806,7 +14958,7 @@ public abstract class EDDGrid extends EDD {
             else dapQuery.append("[(" + timeSA[1] + "):(" + timeSA[0] + ")]");
           } else {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + paramName
                     + " resolution values are not supported.");
           }
@@ -14824,14 +14976,14 @@ public abstract class EDDGrid extends EDD {
         } else {
           if (val.indexOf(',') >= 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "comma-separated lists of "
                     + dName
                     + "'s are not supported.");
           String valSA[] = String2.split(val, '/');
           if (valSA.length == 0 || valSA[0].length() == 0) {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "invalid "
                     + paramName
                     + "=\"\".");
@@ -14846,7 +14998,7 @@ public abstract class EDDGrid extends EDD {
             double resD = String2.parseDouble(valSA[2]);
             if (Double.isNaN(minD) || Double.isNaN(maxD) || minD > maxD)
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + dName
                       + " min="
                       + valSA[0]
@@ -14862,7 +15014,7 @@ public abstract class EDDGrid extends EDD {
             }
             if (Double.isNaN(resD) || resD <= 0)
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + dName
                       + " res="
                       + valSA[2]
@@ -14873,7 +15025,7 @@ public abstract class EDDGrid extends EDD {
             else dapQuery.append("[(" + valSA[1] + "):" + stride + ":(" + valSA[0] + ")]");
           } else {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "number="
                     + valSA.length
                     + " of values for "
@@ -14984,7 +15136,7 @@ public abstract class EDDGrid extends EDD {
     writer.write(
         "<h2><a class=\"selfLink\" id=\"description\" href=\"#description\" rel=\"bookmark\">What</a> is WCS?</h2>\n"
             + String2.replaceAll(
-                EDStatic.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                EDStatic.messages.wcsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
             + "\n"
             + datasetListRef
             + "\n"
@@ -15129,7 +15281,7 @@ public abstract class EDDGrid extends EDD {
             + "<br>There are three types of WCS requests: GetCapabilities, DescribeCoverage, GetCoverage.\n"
             + "<br>For detailed information, please see the\n"
             + "  <a rel=\"help\" href=\"https://www.opengeospatial.org/standards/wcs\">WCS standard documentation"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "\n"
             + "<p><strong>GetCapabilities</strong> - A GetCapabilities request returns an XML document which provides\n"
@@ -15167,14 +15319,14 @@ public abstract class EDDGrid extends EDD {
             + "  <sup>*</sup> Parameter names are case-insensitive.\n"
             + "  <br>Parameter values are case sensitive and must be\n"
             + "    <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "   <br>all characters in query values (the parts after the '=' signs) other than A-Za-z0-9_-!.~'()* must be\n"
             + "   <br>encoded as %HH, where HH is the 2 digit hexadecimal value of the character, for example, space becomes %20.\n"
             + "   <br>Characters above #127 must be converted to UTF-8 bytes, then each UTF-8 byte must be percent encoded\n"
             + "   <br>(ask a programmer for help). There are\n"
             + "<a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  <br>The parameters may be in any order in the URL, separated by '&amp;' .\n"
             + "  <br>&nbsp;\n"
@@ -15224,14 +15376,14 @@ public abstract class EDDGrid extends EDD {
             + "  <sup>*</sup> Parameter names are case-insensitive.\n"
             + "  <br>Parameter values are case sensitive and must be\n"
             + "    <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "   <br>all characters in query values (the parts after the '=' signs) other than A-Za-z0-9_-!.~'()* must be\n"
             + "   <br>encoded as %HH, where HH is the 2 digit hexadecimal value of the character, for example, space becomes %20.\n"
             + "   <br>Characters above #127 must be converted to UTF-8 bytes, then each UTF-8 byte must be percent encoded\n"
             + "   <br>(ask a programmer for help). There are\n"
             + "<a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  <br>The parameters may be in any order in the URL, separated by '&amp;' .\n"
             + "  <br>&nbsp;\n"
@@ -15291,7 +15443,7 @@ public abstract class EDDGrid extends EDD {
             + "      <br>time=<i>beginTime/endTime</i></td>\n"
             + "    <td>The time values must be in\n"
             + "      <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601:2004 \"extended\" format"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "      for example, <span style=\"white-space:nowrap;\">\"1985-01-02T00:00:00Z\").</span>\n"
             + "      <br>In ERDDAP, any time value specified rounds to the nearest available time.\n"
@@ -15376,14 +15528,14 @@ public abstract class EDDGrid extends EDD {
             + "  <sup>*</sup> Parameter names are case-insensitive.\n"
             + "  <br>Parameter values are case sensitive and must be\n"
             + "    <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "   <br>all characters in query values (the parts after the '=' signs) other than A-Za-z0-9_-!.~'()* must be\n"
             + "   <br>encoded as %HH, where HH is the 2 digit hexadecimal value of the character, for example, space becomes %20.\n"
             + "   <br>Characters above #127 must be converted to UTF-8 bytes, then each UTF-8 byte must be percent encoded\n"
             + "   <br>(ask a programmer for help). There are\n"
             + "<a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  <br>The parameters may be in any order in the URL, separated by '&amp;' .\n"
             + "  <br>&nbsp;\n"
@@ -15437,8 +15589,8 @@ public abstract class EDDGrid extends EDD {
     // requirements
     if (lonIndex < 0 || latIndex < 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
-              + EDStatic.noXxxNoLLAr[language]);
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + EDStatic.messages.noXxxNoLLAr[language]);
 
     String tErddapUrl = EDStatic.preferredErddapUrl;
     String datasetUrl = tErddapUrl + "/" + dapProtocol + "/" + datasetID();
@@ -16518,8 +16670,8 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + EDStatic.noXxxNoLLAr[0],
-              EDStatic.queryErrorAr[language] + EDStatic.noXxxNoLLAr[language]));
+              EDStatic.messages.queryErrorAr[0] + EDStatic.messages.noXxxNoLLAr[0],
+              EDStatic.messages.queryErrorAr[language] + EDStatic.messages.noXxxNoLLAr[language]));
 
     String tErddapUrl = EDStatic.preferredErddapUrl;
     String datasetUrl = tErddapUrl + "/griddap/" + datasetID;
@@ -18070,14 +18222,14 @@ public abstract class EDDGrid extends EDD {
       EDD edd = oneFromDatasetsXml(null, datasetID);
       if (edd instanceof EDDTable)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "datasetID="
                 + datasetID
                 + " isn't an EDDGrid dataset.");
       EDDGrid eddGrid = (EDDGrid) edd;
       if (eddGrid.timeIndex() < 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "datasetID="
                 + datasetID
                 + " has no time variable.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
@@ -69,7 +69,7 @@ public class EDDGridAggregateExistingDimension extends EDDGrid {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -334,7 +334,8 @@ public class EDDGridAggregateExistingDimension extends EDDGrid {
       // sourceValues0=" + sourceValues0 + "\n");
       if (childDatasets[sib + 1].accessibleViaFiles) childAccessibleViaFiles = true;
     }
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles && childAccessibleViaFiles;
+    accessibleViaFiles =
+        EDStatic.config.filesActive && tAccessibleViaFiles && childAccessibleViaFiles;
 
     // create the aggregate dataset
     if (reallyVerbose) String2.log("\n+++ Creating the aggregate dataset\n");
@@ -522,7 +523,7 @@ public class EDDGridAggregateExistingDimension extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimension.java
@@ -257,7 +257,8 @@ public class EDDGridAggregateExistingDimension extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
@@ -253,7 +253,8 @@ public class EDDGridCopy extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridCopy.java
@@ -82,7 +82,7 @@ public class EDDGridCopy extends EDDGrid {
     String tDefaultDataQuery = null;
     String tDefaultGraphQuery = null;
     int tnThreads = -1; // interpret invalid values (like -1) as EDStatic.nGridThreads
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     boolean tDimensionValuesInMemory = true;
     String tOnlySince = null;
 
@@ -263,12 +263,12 @@ public class EDDGridCopy extends EDDGrid {
     setReloadEveryNMinutes(tReloadEveryNMinutes);
     matchAxisNDigits = tMatchAxisNDigits;
     onlySince = tOnlySince;
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles;
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles;
     nThreads = tnThreads; // interpret invalid values (like -1) as EDStatic.nGridThreads
     dimensionValuesInMemory = tDimensionValuesInMemory;
 
     // ensure copyDatasetDir exists
-    String copyDatasetDir = EDStatic.fullCopyDirectory + datasetID + "/";
+    String copyDatasetDir = EDStatic.config.fullCopyDirectory + datasetID + "/";
     File2.makeDirectory(copyDatasetDir);
 
     // assign copy tasks to taskThread
@@ -398,7 +398,7 @@ public class EDDGridCopy extends EDDGrid {
             .ensureTaskThreadIsRunningIfNeeded(); // clients (like this class) are responsible for
         // checking on it
 
-        if (EDStatic.forceSynchronousLoading) {
+        if (EDStatic.config.forceSynchronousLoading) {
           while (EDStatic.lastFinishedTask.get() < taskNumber) {
             Thread.sleep(2000);
           }
@@ -600,7 +600,7 @@ public class EDDGridCopy extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromAudioFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromAudioFiles.java
@@ -357,7 +357,7 @@ public class EDDGridFromAudioFiles extends EDDGridFromFiles {
         FileVisitorDNLS.decompressIfNeeded(
             sampleFileName,
             tFileDir,
-            EDStatic.fullDecompressedGenerateDatasetsXmlDirectory,
+            EDStatic.config.fullDecompressedGenerateDatasetsXmlDirectory,
             EDStatic.decompressedCacheMaxGB,
             false); // reuseExisting
     table.readAudioFile(decomSampleFileName, false, true); // getData, addElapsedTimeColumn
@@ -406,7 +406,7 @@ public class EDDGridFromAudioFiles extends EDDGridFromFiles {
     varName = table.getColumnName(0); // Table.ELAPSED_TIME
     sourceAtts = table.columnAttributes(0);
     addAtts = new Attributes();
-    if (EDStatic.variablesMustHaveIoosCategory) addAtts.set("ioos_category", "Time");
+    if (EDStatic.config.variablesMustHaveIoosCategory) addAtts.set("ioos_category", "Time");
     pa = table.getColumn(0);
     axisSourceTable.addColumn(1, varName, pa, sourceAtts);
     axisAddTable.addColumn(1, varName, pa, addAtts);
@@ -417,7 +417,7 @@ public class EDDGridFromAudioFiles extends EDDGridFromFiles {
       pa = table.getColumn(col);
       sourceAtts = table.columnAttributes(col);
       addAtts = new Attributes();
-      if (EDStatic.variablesMustHaveIoosCategory) addAtts.set("ioos_category", "Other");
+      if (EDStatic.config.variablesMustHaveIoosCategory) addAtts.set("ioos_category", "Other");
       if (pa.isIntegerType()) {
         addAtts
             .add("colorBarMinimum", Math2.niceDouble(-pa.missingValueAsDouble(), 2))

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromBinaryFile.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromBinaryFile.javaINACTIVE
@@ -198,7 +198,7 @@ public class EDDGridFromBinaryFile extends EDDGrid {
         setGraphsAccessibleTo(tGraphsAccessibleTo);
         if (!tAccessibleViaWMS) 
             accessibleViaWMS = String2.canonical(
-                MessageFormat.format(EDStatic.noXxx, "WMS"));
+                MessageFormat.format(EDStatic.messages.noXxx, "WMS"));
         onChange = tOnChange;
         fgdcFile = tFgdcFile;
         iso19115File = tIso19115File;
@@ -212,7 +212,7 @@ public class EDDGridFromBinaryFile extends EDDGrid {
         String tLicense = combinedGlobalAttributes.getString("license");
         if (tLicense != null)
             combinedGlobalAttributes.set("license", 
-                String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+                String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
         combinedGlobalAttributes.removeValue("\"null\"");
         if (combinedGlobalAttributes.getString("cdm_data_type") == null)
             combinedGlobalAttributes.add("cdm_data_type", "Grid");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromBinaryFile.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromBinaryFile.javaINACTIVE
@@ -287,7 +287,7 @@ public class EDDGridFromBinaryFile extends EDDGrid {
      * source for this EDDGrid.     
      * Because this is called by GridDataAccessor, the request won't be the 
      * full user's request, but will be a partial request (for less than
-     * EDStatic.partialRequestMaxBytes).
+     * EDStatic.config.partialRequestMaxBytes).
      * 
      * @param language the index of the selected language
      * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null. 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
@@ -215,7 +215,7 @@ public class EDDGridFromDap extends EDDGrid {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense.
+   *     be converted to the EDStatic.messages.standardLicense.
    * @param tAxisVariables is an Object[nAxisVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source), <br>
    *     [1]=String destinationName (the name to be presented to the ERDDAP user, or null to use the
@@ -277,7 +277,8 @@ public class EDDGridFromDap extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -349,7 +350,7 @@ public class EDDGridFromDap extends EDDGrid {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
     if (combinedGlobalAttributes.getString("cdm_data_type") == null)
       combinedGlobalAttributes.add("cdm_data_type", "Grid");
@@ -638,7 +639,7 @@ public class EDDGridFromDap extends EDDGrid {
     int newSize = dad.getSize();
     if (newSize < oldSize)
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + "["
@@ -692,7 +693,7 @@ public class EDDGridFromDap extends EDDGrid {
     }
     if (oldValues.elementType() != newValues.elementType()) // they're canonical, so != works
     throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + edvga.destinationName()
@@ -706,7 +707,7 @@ public class EDDGridFromDap extends EDDGrid {
     // ensure last old value is unchanged
     if (oldValues.getDouble(oldSize - 1) != newValues.getDouble(0)) // they should be exactly equal
     throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + edvga.destinationName()
@@ -742,7 +743,7 @@ public class EDDGridFromDap extends EDDGrid {
     String error = edvga.isAscending() ? newValues.isAscending() : newValues.isDescending();
     if (error.length() > 0)
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + edvga.destinationName()
               + " was "
@@ -995,9 +996,9 @@ public class EDDGridFromDap extends EDDGrid {
         throw t instanceof WaitThenTryAgainException
             ? t
             : new WaitThenTryAgainException(
-                EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                     + "\n("
-                    + EDStatic.errorFromDataSource
+                    + EDStatic.messages.errorFromDataSource
                     + t
                     + ")",
                 t);
@@ -1030,7 +1031,7 @@ public class EDDGridFromDap extends EDDGrid {
             String tError = results[av].almostEqual(pa[av + 1]);
             if (tError.length() > 0)
               throw new WaitThenTryAgainException(
-                  EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                       + "\nDetails: The axis values for dataVariable=0,axis="
                       + av
                       + ")\ndon't equal the axis values for dataVariable="
@@ -1044,7 +1045,7 @@ public class EDDGridFromDap extends EDDGrid {
 
       } else {
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\nDetails: An unexpected data structure was returned from the source (size observed="
                 + pa.length
                 + ", expected="

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
@@ -295,7 +295,7 @@ public class EDDGridFromDap extends EDDGrid {
 
     // quickRestart
     Attributes quickRestartAttributes = null;
-    if (EDStatic.quickRestart
+    if (EDStatic.config.quickRestart
         && EDStatic.initialLoadDatasets()
         && File2.isFile(quickRestartFullFileName())) {
       // try to do quick initialLoadDatasets()
@@ -946,7 +946,7 @@ public class EDDGridFromDap extends EDDGrid {
   /**
    * This gets source data (not yet converted to destination data) from the data source for this
    * EDDGrid. Because this is called by GridDataAccessor, the request won't be the full user's
-   * request, but will be a partial request (for less than EDStatic.partialRequestMaxBytes).
+   * request, but will be a partial request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
@@ -69,7 +69,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -299,7 +299,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
       accessibleViaWMS =
           String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     accessibleViaFiles =
-        EDStatic.filesActive && tAccessibleViaFiles && tEDDTable.accessibleViaFiles;
+        EDStatic.config.filesActive && tAccessibleViaFiles && tEDDTable.accessibleViaFiles;
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -506,7 +506,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
   /**
    * This gets source data (not yet converted to destination data) from the data source for this
    * EDDGrid. Because this is called by GridDataAccessor, the request won't be the full user's
-   * request, but will be a partial request (for less than EDStatic.partialRequestMaxBytes).
+   * request, but will be a partial request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTable.java
@@ -230,7 +230,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense.
+   *     be converted to the EDStatic.messages.standardLicense.
    * @param tAxisVariables is an Object[nAxisVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source), <br>
    *     [1]=String destinationName (the name to be presented to the ERDDAP user, or null to use the
@@ -296,7 +296,8 @@ public class EDDGridFromEDDTable extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     accessibleViaFiles =
         EDStatic.filesActive && tAccessibleViaFiles && tEDDTable.accessibleViaFiles;
     onChange = tOnChange;
@@ -323,7 +324,7 @@ public class EDDGridFromEDDTable extends EDDGrid {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
     if (combinedGlobalAttributes.getString("cdm_data_type") == null)
       combinedGlobalAttributes.add("cdm_data_type", "Grid");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
@@ -221,7 +221,8 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -568,7 +569,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     int newSize = dad.getSize();
     if (newSize < oldSize)
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + "["
@@ -622,7 +623,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     }
     if (oldValues.elementType() != newValues.elementType())
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + edvga.destinationName()
@@ -636,7 +637,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     // ensure last old value is unchanged
     if (oldValues.getDouble(oldSize - 1) != newValues.getDouble(0)) // they should be exactly equal
     throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + msg
               + edvga.destinationName()
@@ -672,7 +673,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     String error = edvga.isAscending() ? newValues.isAscending() : newValues.isDescending();
     if (error.length() > 0)
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n("
               + edvga.destinationName()
               + " was "
@@ -936,16 +937,16 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
         throw t instanceof WaitThenTryAgainException
             ? t
             : new WaitThenTryAgainException(
-                EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                     + "\n("
-                    + EDStatic.errorFromDataSource
+                    + EDStatic.messages.errorFromDataSource
                     + t
                     + ")",
                 t);
       }
       if (pa.length != axisVariables.length + 1)
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\n(Details: An unexpected data structure was returned from the source.)");
       results[axisVariables.length + dv] = pa[0];
       if (dv == 0) {
@@ -956,7 +957,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
           String tError = results[av].almostEqual(pa[av + 1]);
           if (tError.length() > 0)
             throw new WaitThenTryAgainException(
-                EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                     + "\n(Details: The axis values for dataVariable=0,axis="
                     + av
                     + "\ndon't equal the axis values for dataVariable="

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromErddap.java
@@ -82,8 +82,8 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
-    boolean tSubscribeToRemoteErddapDataset = EDStatic.subscribeToRemoteErddapDataset;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
+    boolean tSubscribeToRemoteErddapDataset = EDStatic.config.subscribeToRemoteErddapDataset;
     boolean tRedirect = true;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
@@ -241,11 +241,11 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
     redirect = tRedirect;
     nThreads = tnThreads; // interpret invalid values (like -1) as EDStatic.nGridThreads
     dimensionValuesInMemory = tDimensionValuesInMemory;
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles; // tentative. see below
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles; // tentative. see below
 
     // quickRestart
     Attributes quickRestartAttributes = null;
-    if (EDStatic.quickRestart
+    if (EDStatic.config.quickRestart
         && EDStatic.initialLoadDatasets()
         && File2.isFile(quickRestartFullFileName())) {
       // try to do quick initialLoadDatasets()
@@ -325,7 +325,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
 
           // deal with remote not having ioos_category, but this ERDDAP requiring it
           Attributes tAddAttributes = new Attributes();
-          if (EDStatic.variablesMustHaveIoosCategory
+          if (EDStatic.config.variablesMustHaveIoosCategory
               && tSourceAttributes.getString("ioos_category") == null) {
 
             // guess ioos_category   (alternative is always assign "Unknown")
@@ -361,7 +361,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
 
           // deal with remote not having ioos_category, but this ERDDAP requiring it
           Attributes tAddAttributes = new Attributes();
-          if (EDStatic.variablesMustHaveIoosCategory
+          if (EDStatic.config.variablesMustHaveIoosCategory
               && tSourceAttributes.getString("ioos_category") == null) {
 
             // guess ioos_category   (alternative is always assign "Unknown")
@@ -888,7 +888,7 @@ public class EDDGridFromErddap extends EDDGrid implements FromErddap {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
@@ -83,7 +83,7 @@ public class EDDGridFromEtopo extends EDDGrid {
     if (verbose) String2.log("\n*** constructing EDDGridFromEtopo(xmlReader)...");
     String tDatasetID = xmlReader.attributeValue("datasetID");
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     int tnThreads = -1; // interpret invalid values (like -1) as EDStatic.nGridThreads
     boolean tDimensionValuesInMemory = true;
 
@@ -147,7 +147,7 @@ public class EDDGridFromEtopo extends EDDGrid {
     if (!tAccessibleViaWMS)
       accessibleViaWMS =
           String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles;
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles;
     nThreads = tnThreads; // interpret invalid values (like -1) as EDStatic.nGridThreads
     dimensionValuesInMemory = tDimensionValuesInMemory;
 
@@ -270,7 +270,7 @@ public class EDDGridFromEtopo extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopo.java
@@ -145,7 +145,8 @@ public class EDDGridFromEtopo extends EDDGrid {
         is180 || datasetID.equals("etopo360"),
         errorInMethod + "datasetID must be \"etopo180\" or \"etopo360\".");
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles;
     nThreads = tnThreads; // interpret invalid values (like -1) as EDStatic.nGridThreads
     dimensionValuesInMemory = tDimensionValuesInMemory;
@@ -172,7 +173,7 @@ public class EDDGridFromEtopo extends EDDGrid {
     sourceGlobalAttributes.add("institution", "NOAA NGDC");
     sourceGlobalAttributes.add("keywords", "Oceans > Bathymetry/Seafloor Topography > Bathymetry");
     sourceGlobalAttributes.add("keywords_vocabulary", "GCMD Science Keywords");
-    sourceGlobalAttributes.add("license", EDStatic.standardLicense);
+    sourceGlobalAttributes.add("license", EDStatic.messages.standardLicense);
     sourceGlobalAttributes.add("naming_authority", "gov.noaa.pfeg.coastwatch");
     sourceGlobalAttributes.add("project", "NOAA NGDC ETOPO");
     sourceGlobalAttributes.add("projection", "geographic");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromFiles.java
@@ -440,7 +440,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense
+   *     be converted to the EDStatic.messages.standardLicense
    * @param tAxisVariables is an Object[nAxisVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source), <br>
    *     [1]=String destinationName (the name to be presented to the ERDDAP user, or null to use the
@@ -534,7 +534,8 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -920,7 +921,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
         updateEveryNMillis = 0; // disable the inotify system for this instance
         String subject = String2.ERROR + " in " + datasetID + " constructor (inotify)";
         String tmsg = MustBe.throwableToString(t);
-        if (tmsg.indexOf("inotify instances") >= 0) tmsg += EDStatic.inotifyFixAr[0];
+        if (tmsg.indexOf("inotify instances") >= 0) tmsg += EDStatic.messages.inotifyFixAr[0];
         EDStatic.email(EDStatic.adminEmail, subject, tmsg);
       }
     }
@@ -1096,7 +1097,8 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
       elapsedTime = System.currentTimeMillis();
       while (tFileListPo < tFileNamePA.size()) {
         if (Thread.currentThread().isInterrupted())
-          throw new SimpleException("EDDGridFromFiles.init" + EDStatic.caughtInterruptedAr[0]);
+          throw new SimpleException(
+              "EDDGridFromFiles.init" + EDStatic.messages.caughtInterruptedAr[0]);
 
         int tDirI = tFileDirIndexPA.get(tFileListPo);
         String tFileS = tFileNamePA.get(tFileListPo);
@@ -1425,7 +1427,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
     if (combinedGlobalAttributes.getString("cdm_data_type") == null)
       combinedGlobalAttributes.add("cdm_data_type", "Grid");
@@ -1851,7 +1853,8 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
     int ndv = sourceDataAttributes.length;
     for (int evi = 0; evi < nEvents; evi++) {
       if (Thread.currentThread().isInterrupted())
-        throw new SimpleException("EDDGridFromFiles.lowUpdate" + EDStatic.caughtInterruptedAr[0]);
+        throw new SimpleException(
+            "EDDGridFromFiles.lowUpdate" + EDStatic.messages.caughtInterruptedAr[0]);
 
       String fullName = contexts.get(evi);
       String dirName = File2.getDirectory(fullName);
@@ -2726,7 +2729,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
       if (tFileTable == null) tFileTable = getFileTable();
     } catch (Exception e) {
       throw new WaitThenTryAgainException(
-          EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
               + "\n(Details: unable to read fileTable.)");
     }
 
@@ -2783,7 +2786,7 @@ public abstract class EDDGridFromFiles extends EDDGrid implements WatchUpdateHan
       if (Thread.currentThread().isInterrupted()) {
         if (workManager != null) workManager.forceShutdown();
         throw new SimpleException(
-            "EDDGridFromFiles.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+            "EDDGridFromFiles.getDataForDapQuery" + EDStatic.messages.caughtInterruptedAr[0]);
       }
 
       // find next relevant file

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromMatFiles.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromMatFiles.javaINACTIVE
@@ -308,7 +308,7 @@ public class EDDGridFromMatFiles extends EDDGridFromFiles {
 
         //make tables to hold variables
         String decomSampleFileName = FileVisitorDNLS.decompressIfNeeded(sampleFileName, 
-            tFileDir, EDStatic.fullDecompressedGenerateDatasetsXmlDirectory, 
+            tFileDir, EDStatic.config.fullDecompressedGenerateDatasetsXmlDirectory, 
             EDStatic.decompressedCacheMaxGB, false); //reuseExisting
         
         NetcdfFile ncFile = NcHelper.openFile(decomSampleFileName);
@@ -714,9 +714,9 @@ public class EDDGridFromMatFiles extends EDDGridFromFiles {
 
         //*** test getting das for entire dataset
         String2.log("\n*** .nc test das dds for entire dataset\n");
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Entire", ".das"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 "Attributes {\n" +
@@ -871,9 +871,9 @@ expected = " http://localhost:8080/cwexperimental/griddap/testGriddedNcFiles.das
             expected, "results=\n" + results);
         
         //*** test getting dds for entire dataset
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Entire", ".dds"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 "Dataset {\n" +
@@ -916,9 +916,9 @@ expected = " http://localhost:8080/cwexperimental/griddap/testGriddedNcFiles.das
         //.csv  with data from one file
         String2.log("\n*** .nc test read from one file\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 //verified with 
@@ -945,9 +945,9 @@ String csvExpected =
         //.csvp  with data from one file
         String2.log("\n*** .nc test read from one file  .csvp\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".csvp"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 //verified with 
@@ -959,9 +959,9 @@ csvExpected;
         //.csv0  with data from one file
         String2.log("\n*** .nc test read from one file  .csv0\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".csv0"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = csvExpected;
 //verified with 
@@ -972,9 +972,9 @@ csvExpected;
         //.csv  with data from several files
         String2.log("\n*** .nc test read from several files\n");       
         userDapQuery = "y_wind[(1.1991888e9):3:(1.1999664e9)][0][(36.5)][(230)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 //verified with 
@@ -991,9 +991,9 @@ csvExpected;
         //.tsv  with data from one file
         String2.log("\n*** .nc test read from one file\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".tsv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 //verified with 
@@ -1020,9 +1020,9 @@ String tsvExpected =
         //.tsvp  with data from one file
         String2.log("\n*** .nc test read from one file  .tsvp\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".tsvp"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 //verified with 
@@ -1034,9 +1034,9 @@ tsvExpected;
         //.tsv0  with data from one file
         String2.log("\n*** .nc test read from one file  .tsv0\n");       
         userDapQuery = "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
-        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             eddGrid.className() + "_Data1", ".tsv0"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = tsvExpected;
 //verified with 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromMatFiles.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromMatFiles.javaINACTIVE
@@ -233,7 +233,7 @@ public class EDDGridFromMatFiles extends EDDGridFromFiles {
                 Variable var = ncFile.findVariable(tDataVariables[dvi].sourceName());  
                 if (var == null) 
                     throw new RuntimeException(
-                        MessageFormat.format(EDStatic.errorNotFoundIn,
+                        MessageFormat.format(EDStatic.messages.errorNotFoundIn,
                             "dataVariableSourceName=" + tDataVariables[dvi].sourceName(),
                             fileName)); //don't show directory
                 Array array = var.read(selection);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromNcLow.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromNcLow.java
@@ -538,7 +538,7 @@ public abstract class EDDGridFromNcLow extends EDDGridFromFiles {
         FileVisitorDNLS.decompressIfNeeded(
             sampleFileName,
             tFileDir,
-            EDStatic.fullDecompressedGenerateDatasetsXmlDirectory,
+            EDStatic.config.fullDecompressedGenerateDatasetsXmlDirectory,
             EDStatic.decompressedCacheMaxGB,
             false); // reuseExisting
     String2.log("Let's see if netcdf-java can tell us the structure of the sample file:");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
@@ -239,7 +239,8 @@ public class EDDGridLon0360 extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -517,7 +518,7 @@ public class EDDGridLon0360 extends EDDGrid {
       if (tChildDataset == null) {
         EDD.requestReloadASAP(localChildDatasetID);
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\n(underlying local datasetID="
                 + localChildDatasetID
                 + " not found)");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLon0360.java
@@ -81,7 +81,7 @@ public class EDDGridLon0360 extends EDDGrid {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -284,10 +284,11 @@ public class EDDGridLon0360 extends EDDGrid {
       tChildDataset = oChildDataset;
     }
     // for rest of constructor, use temporary, stable tChildDataset reference.
-    // String2.log(">> accessibleViaFiles " + EDStatic.filesActive + " " + tAccessibleViaFiles + " "
+    // String2.log(">> accessibleViaFiles " + EDStatic.config.filesActive + " " +
+    // tAccessibleViaFiles + " "
     // + tChildDataset.accessibleViaFiles);
     accessibleViaFiles =
-        EDStatic.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
+        EDStatic.config.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
 
     // UNUSUAL: if valid value not specified, copy from childDataset
     setReloadEveryNMinutes(
@@ -634,7 +635,7 @@ public class EDDGridLon0360 extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
@@ -239,7 +239,8 @@ public class EDDGridLonPM180 extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;
@@ -493,7 +494,7 @@ public class EDDGridLonPM180 extends EDDGrid {
       if (tChildDataset == null) {
         EDD.requestReloadASAP(localChildDatasetID);
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\n(underlying local datasetID="
                 + localChildDatasetID
                 + " not found)");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180.java
@@ -81,7 +81,7 @@ public class EDDGridLonPM180 extends EDDGrid {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -284,10 +284,11 @@ public class EDDGridLonPM180 extends EDDGrid {
       tChildDataset = oChildDataset;
     }
     // for rest of constructor, use temporary, stable tChildDataset reference.
-    // String2.log(">> accessibleViaFiles " + EDStatic.filesActive + " " + tAccessibleViaFiles + " "
+    // String2.log(">> accessibleViaFiles " + EDStatic.config.filesActive + " " +
+    // tAccessibleViaFiles + " "
     // + tChildDataset.accessibleViaFiles);
     accessibleViaFiles =
-        EDStatic.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
+        EDStatic.config.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
 
     // UNUSUAL: if valid value not specified, copy from childDataset
     setReloadEveryNMinutes(
@@ -610,7 +611,7 @@ public class EDDGridLonPM180 extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
@@ -245,7 +245,8 @@ public class EDDGridSideBySide extends EDDGrid {
     setAccessibleTo(tAccessibleTo);
     setGraphsAccessibleTo(tGraphsAccessibleTo);
     if (!tAccessibleViaWMS)
-      accessibleViaWMS = String2.canonical(MessageFormat.format(EDStatic.noXxxAr[0], "WMS"));
+      accessibleViaWMS =
+          String2.canonical(MessageFormat.format(EDStatic.messages.noXxxAr[0], "WMS"));
     onChange = tOnChange;
     fgdcFile = tFgdcFile;
     iso19115File = tIso19115File;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridSideBySide.java
@@ -30,8 +30,8 @@ import java.util.Arrays;
  * for axis[1+].
  *
  * <p>If there is an exception while creating the first child, this throws the exception. If there
- * is an exception while creating other children, this emails EDStatic.emailEverythingToCsv and
- * continues.
+ * is an exception while creating other children, this emails EDStatic.config.emailEverythingToCsv
+ * and continues.
  *
  * <p>Children created by this method are held privately. They are not separately accessible
  * datasets (e.g., by queries or by flag files).
@@ -75,7 +75,7 @@ public class EDDGridSideBySide extends EDDGrid {
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
     boolean tAccessibleViaWMS = true;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     int tMatchAxisNDigits = DEFAULT_MATCH_AXIS_N_DIGITS;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
@@ -175,7 +175,7 @@ public class EDDGridSideBySide extends EDDGrid {
     }
     if (messages.length() > 0) {
       EDStatic.email(
-          EDStatic.emailEverythingToCsv,
+          EDStatic.config.emailEverythingToCsv,
           "Error in EDDGridSideBySide constructor for " + tDatasetID,
           messages.toString());
     }
@@ -266,7 +266,7 @@ public class EDDGridSideBySide extends EDDGrid {
         break;
       }
     }
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles && cAccessibleViaFiles;
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles && cAccessibleViaFiles;
 
     // check the siblings and create childStopsAt
     EDDGrid firstChild = childDatasets[0];
@@ -515,7 +515,7 @@ public class EDDGridSideBySide extends EDDGrid {
   /**
    * This gets data (not yet standardized) from the data source for this EDDGrid. Because this is
    * called by GridDataAccessor, the request won't be the full user's request, but will be a partial
-   * request (for less than EDStatic.partialRequestMaxBytes).
+   * request (for less than EDStatic.config.partialRequestMaxBytes).
    *
    * @param language the index of the selected language
    * @param tDirTable If EDDGridFromFiles, this MAY be the dirTable, else null.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
@@ -430,65 +430,65 @@ public abstract class EDDTable extends EDD {
     int nDFTN = dataFileTypeNames.size();
     int nIFTN = imageFileTypeNames.size();
 
-    dataFileTypeDescriptionsAr = new String[EDStatic.nLanguages][nDFTN];
-    imageFileTypeDescriptionsAr = new String[EDStatic.nLanguages][nIFTN];
+    dataFileTypeDescriptionsAr = new String[EDStatic.messages.nLanguages][nDFTN];
+    imageFileTypeDescriptionsAr = new String[EDStatic.messages.nLanguages][nIFTN];
 
-    for (int tl = 0; tl < EDStatic.nLanguages; tl++) {
+    for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++) {
       dataFileTypeDescriptionsAr[tl] =
           new String[] {
-            EDStatic.fileHelp_ascAr[tl],
-            EDStatic.fileHelp_csvAr[tl],
-            EDStatic.fileHelp_csvpAr[tl],
-            EDStatic.fileHelp_csv0Ar[tl],
-            EDStatic.fileHelp_dataTableAr[tl],
-            EDStatic.fileHelp_dasAr[tl],
-            EDStatic.fileHelp_ddsAr[tl],
-            EDStatic.fileHelp_dodsAr[tl],
-            EDStatic.fileHelpTable_esriCsvAr[tl],
-            EDStatic.fileHelp_fgdcAr[tl],
-            EDStatic.fileHelp_geoJsonAr[tl],
-            EDStatic.fileHelp_graphAr[tl],
-            EDStatic.fileHelpTable_helpAr[tl],
-            EDStatic.fileHelp_htmlAr[tl],
-            EDStatic.fileHelp_htmlTableAr[tl],
-            EDStatic.fileHelp_iso19115Ar[tl],
-            EDStatic.fileHelp_itxTableAr[tl],
-            EDStatic.fileHelp_jsonAr[tl],
-            EDStatic.fileHelp_jsonlCSV1Ar[tl],
-            EDStatic.fileHelp_jsonlCSVAr[tl],
-            EDStatic.fileHelp_jsonlKVPAr[tl],
-            EDStatic.fileHelp_matAr[tl],
-            EDStatic.fileHelpTable_nc3Ar[tl],
-            EDStatic.fileHelp_nc3HeaderAr[tl],
-            EDStatic.fileHelp_ncCFAr[tl],
-            EDStatic.fileHelp_ncCFHeaderAr[tl],
-            EDStatic.fileHelp_ncCFMAAr[tl],
-            EDStatic.fileHelp_ncCFMAHeaderAr[tl],
-            //        EDStatic.fileHelpTable_nc4Ar[tl],
-            //        EDStatic.fileHelp_nc4HeaderAr[tl],
-            EDStatic.fileHelp_nccsvAr[tl],
-            EDStatic.fileHelp_nccsvMetadataAr[tl],
-            EDStatic.fileHelp_ncoJsonAr[tl],
-            EDStatic.fileHelpTable_odvTxtAr[tl],
-            EDStatic.fileHelp_parquetAr[tl],
-            EDStatic.fileHelp_parquet_with_metaAr[tl],
-            EDStatic.fileHelp_subsetAr[tl],
-            EDStatic.fileHelp_tsvAr[tl],
-            EDStatic.fileHelp_tsvpAr[tl],
-            EDStatic.fileHelp_tsv0Ar[tl],
-            EDStatic.fileHelp_wavAr[tl],
-            EDStatic.fileHelp_xhtmlAr[tl]
+            EDStatic.messages.fileHelp_ascAr[tl],
+            EDStatic.messages.fileHelp_csvAr[tl],
+            EDStatic.messages.fileHelp_csvpAr[tl],
+            EDStatic.messages.fileHelp_csv0Ar[tl],
+            EDStatic.messages.fileHelp_dataTableAr[tl],
+            EDStatic.messages.fileHelp_dasAr[tl],
+            EDStatic.messages.fileHelp_ddsAr[tl],
+            EDStatic.messages.fileHelp_dodsAr[tl],
+            EDStatic.messages.fileHelpTable_esriCsvAr[tl],
+            EDStatic.messages.fileHelp_fgdcAr[tl],
+            EDStatic.messages.fileHelp_geoJsonAr[tl],
+            EDStatic.messages.fileHelp_graphAr[tl],
+            EDStatic.messages.fileHelpTable_helpAr[tl],
+            EDStatic.messages.fileHelp_htmlAr[tl],
+            EDStatic.messages.fileHelp_htmlTableAr[tl],
+            EDStatic.messages.fileHelp_iso19115Ar[tl],
+            EDStatic.messages.fileHelp_itxTableAr[tl],
+            EDStatic.messages.fileHelp_jsonAr[tl],
+            EDStatic.messages.fileHelp_jsonlCSV1Ar[tl],
+            EDStatic.messages.fileHelp_jsonlCSVAr[tl],
+            EDStatic.messages.fileHelp_jsonlKVPAr[tl],
+            EDStatic.messages.fileHelp_matAr[tl],
+            EDStatic.messages.fileHelpTable_nc3Ar[tl],
+            EDStatic.messages.fileHelp_nc3HeaderAr[tl],
+            EDStatic.messages.fileHelp_ncCFAr[tl],
+            EDStatic.messages.fileHelp_ncCFHeaderAr[tl],
+            EDStatic.messages.fileHelp_ncCFMAAr[tl],
+            EDStatic.messages.fileHelp_ncCFMAHeaderAr[tl],
+            //        EDStatic.messages.fileHelpTable_nc4Ar[tl],
+            //        EDStatic.messages.fileHelp_nc4HeaderAr[tl],
+            EDStatic.messages.fileHelp_nccsvAr[tl],
+            EDStatic.messages.fileHelp_nccsvMetadataAr[tl],
+            EDStatic.messages.fileHelp_ncoJsonAr[tl],
+            EDStatic.messages.fileHelpTable_odvTxtAr[tl],
+            EDStatic.messages.fileHelp_parquetAr[tl],
+            EDStatic.messages.fileHelp_parquet_with_metaAr[tl],
+            EDStatic.messages.fileHelp_subsetAr[tl],
+            EDStatic.messages.fileHelp_tsvAr[tl],
+            EDStatic.messages.fileHelp_tsvpAr[tl],
+            EDStatic.messages.fileHelp_tsv0Ar[tl],
+            EDStatic.messages.fileHelp_wavAr[tl],
+            EDStatic.messages.fileHelp_xhtmlAr[tl]
           };
       imageFileTypeDescriptionsAr[tl] =
           new String[] {
-            EDStatic.fileHelpTable_kmlAr[tl],
-            EDStatic.fileHelp_smallPdfAr[tl],
-            EDStatic.fileHelp_pdfAr[tl],
-            EDStatic.fileHelp_largePdfAr[tl],
-            EDStatic.fileHelp_smallPngAr[tl],
-            EDStatic.fileHelp_pngAr[tl],
-            EDStatic.fileHelp_largePngAr[tl],
-            EDStatic.fileHelp_transparentPngAr[tl]
+            EDStatic.messages.fileHelpTable_kmlAr[tl],
+            EDStatic.messages.fileHelp_smallPdfAr[tl],
+            EDStatic.messages.fileHelp_pdfAr[tl],
+            EDStatic.messages.fileHelp_largePdfAr[tl],
+            EDStatic.messages.fileHelp_smallPngAr[tl],
+            EDStatic.messages.fileHelp_pngAr[tl],
+            EDStatic.messages.fileHelp_largePngAr[tl],
+            EDStatic.messages.fileHelp_transparentPngAr[tl]
           };
     }
 
@@ -533,16 +533,16 @@ public abstract class EDDTable extends EDD {
     publicGraphFileTypeNames[5] = ".iso19115";
 
     // construct allFileTypeOptionsAr
-    allFileTypeOptionsAr = new String[EDStatic.nLanguages][nDFTN + nIFTN];
+    allFileTypeOptionsAr = new String[EDStatic.messages.nLanguages][nDFTN + nIFTN];
     allFileTypeNames = new String[nDFTN + nIFTN];
     for (int i = 0; i < nDFTN; i++) {
-      for (int tl = 0; tl < EDStatic.nLanguages; tl++)
+      for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++)
         allFileTypeOptionsAr[tl][i] =
             dataFileTypeNames.get(i) + " - " + dataFileTypeDescriptionsAr[tl][i];
       allFileTypeNames[i] = dataFileTypeNames.get(i);
     }
     for (int i = 0; i < nIFTN; i++) {
-      for (int tl = 0; tl < EDStatic.nLanguages; tl++)
+      for (int tl = 0; tl < EDStatic.messages.nLanguages; tl++)
         allFileTypeOptionsAr[tl][nDFTN + i] =
             imageFileTypeNames.get(i) + " - " + imageFileTypeDescriptionsAr[tl][i];
       allFileTypeNames[nDFTN + i] = imageFileTypeNames.get(i);
@@ -753,7 +753,7 @@ public abstract class EDDTable extends EDD {
    */
   @Override
   public String dapDescription(int language) {
-    return EDStatic.EDDTableDapDescriptionAr[language];
+    return EDStatic.messages.EDDTableDapDescriptionAr[language];
   }
 
   /**
@@ -764,7 +764,7 @@ public abstract class EDDTable extends EDD {
    */
   public static String longDapDescription(int language, String tErddapUrl) {
     return String2.replaceAll(
-        EDStatic.EDDTableDapLongDescriptionAr[language], "&erddapUrl;", tErddapUrl);
+        EDStatic.messages.EDDTableDapLongDescriptionAr[language], "&erddapUrl;", tErddapUrl);
   }
 
   /**
@@ -1285,12 +1285,12 @@ public abstract class EDDTable extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorConstraintNaNAr[0], constraintValue),
-                  EDStatic.queryErrorAr[language]
+                          EDStatic.messages.queryErrorConstraintNaNAr[0], constraintValue),
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorConstraintNaNAr[language], constraintValue)));
+                          EDStatic.messages.queryErrorConstraintNaNAr[language], constraintValue)));
         }
       }
       if (reallyVerbose)
@@ -1328,13 +1328,13 @@ public abstract class EDDTable extends EDD {
                   MustBe.THERE_IS_NO_DATA
                       + " "
                       + MessageFormat.format(
-                          EDStatic.noDataFixedValueAr[0],
+                          EDStatic.messages.noDataFixedValueAr[0],
                           edv.destinationName(),
                           edv.fixedValue() + constraintOp + constraintValueD),
                   MustBe.THERE_IS_NO_DATA
                       + " "
                       + MessageFormat.format(
-                          EDStatic.noDataFixedValueAr[language],
+                          EDStatic.messages.noDataFixedValueAr[language],
                           edv.destinationName(),
                           edv.fixedValue() + constraintOp + constraintValueD)));
 
@@ -1455,12 +1455,13 @@ public abstract class EDDTable extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + MessageFormat.format(
-                        EDStatic.queryErrorNeverTrueAr[0], edv1.destinationName() + op1 + val1),
-                EDStatic.queryErrorAr[language]
+                        EDStatic.messages.queryErrorNeverTrueAr[0],
+                        edv1.destinationName() + op1 + val1),
+                EDStatic.messages.queryErrorAr[language]
                     + MessageFormat.format(
-                        EDStatic.queryErrorNeverTrueAr[language],
+                        EDStatic.messages.queryErrorNeverTrueAr[language],
                         edv1.destinationName() + op1 + val1)));
 
       for (int cv2 = cv1 + 1; cv2 < constraintVariables.size(); cv2++) {
@@ -1540,14 +1541,14 @@ public abstract class EDDTable extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + MessageFormat.format(
-                          EDStatic.queryErrorNeverBothTrueAr[0],
+                          EDStatic.messages.queryErrorNeverBothTrueAr[0],
                           edv1.destinationName() + op1 + val1,
                           edv2.destinationName() + op2 + val2),
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + MessageFormat.format(
-                          EDStatic.queryErrorNeverBothTrueAr[language],
+                          EDStatic.messages.queryErrorNeverBothTrueAr[language],
                           edv1.destinationName() + op1 + val1,
                           edv2.destinationName() + op2 + val2)));
       }
@@ -2319,7 +2320,7 @@ public abstract class EDDTable extends EDD {
           if (!repair) {
             if (tVar.equals(SEQUENCE_NAME))
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "If "
                       + SEQUENCE_NAME
                       + " is requested, it must be the only requested variable.");
@@ -2327,13 +2328,13 @@ public abstract class EDDTable extends EDD {
               int opPo = tVar.indexOf(OPERATORS.get(op));
               if (opPo >= 0)
                 throw new SimpleException(
-                    EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                    EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                         + "All constraints (including \""
                         + tVar.substring(0, opPo + OPERATORS.get(op).length())
                         + "...\") must be preceded by '&'.");
             }
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "Unrecognized variable=\""
                     + tVar
                     + "\".");
@@ -2343,7 +2344,7 @@ public abstract class EDDTable extends EDD {
           if (resultsVariables.indexOf(tVar) >= 0) {
             if (!repair)
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "variable="
                       + tVar
                       + " is listed twice in the results variables list.");
@@ -2381,12 +2382,13 @@ public abstract class EDDTable extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorOrderByVariableAr[0], obv.get(obvi)),
-                      EDStatic.queryErrorAr[language]
+                              EDStatic.messages.queryErrorOrderByVariableAr[0], obv.get(obvi)),
+                      EDStatic.messages.queryErrorAr[language]
                           + MessageFormat.format(
-                              EDStatic.queryErrorOrderByVariableAr[language], obv.get(obvi))));
+                              EDStatic.messages.queryErrorOrderByVariableAr[language],
+                              obv.get(obvi))));
           }
         }
         continue;
@@ -2413,12 +2415,13 @@ public abstract class EDDTable extends EDD {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorOrderByVariableAr[0], obv.get(obvi)),
-                      EDStatic.queryErrorAr[language]
+                              EDStatic.messages.queryErrorOrderByVariableAr[0], obv.get(obvi)),
+                      EDStatic.messages.queryErrorAr[language]
                           + MessageFormat.format(
-                              EDStatic.queryErrorOrderByVariableAr[language], obv.get(obvi))));
+                              EDStatic.messages.queryErrorOrderByVariableAr[language],
+                              obv.get(obvi))));
           }
         }
         continue;
@@ -2446,7 +2449,9 @@ public abstract class EDDTable extends EDD {
           if (obv.size() < 2)
             throw new SimpleException(
                 EDStatic.bilingual(
-                        language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+                        language,
+                        EDStatic.messages.queryErrorAr,
+                        EDStatic.messages.queryErrorOrderByClosestAr)
                     + (language == 0 ? " " : "\n")
                     + "csv.length<2.");
           for (int obvi = 0; obvi < obv.size() - 1; obvi++) { // -1 since last item is interval
@@ -2455,7 +2460,9 @@ public abstract class EDDTable extends EDD {
             if (item.length() > 0 && resultsVariables.indexOf(item) < 0)
               throw new SimpleException(
                   EDStatic.bilingual(
-                          language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+                          language,
+                          EDStatic.messages.queryErrorAr,
+                          EDStatic.messages.queryErrorOrderByClosestAr)
                       + (language == 0 ? " " : "\n")
                       + "col="
                       + obv.get(obvi)
@@ -2478,7 +2485,9 @@ public abstract class EDDTable extends EDD {
           if (obv.size() == 0)
             throw new SimpleException(
                 EDStatic.bilingual(
-                        language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+                        language,
+                        EDStatic.messages.queryErrorAr,
+                        EDStatic.messages.queryErrorOrderByLimitAr)
                     + (language == 0 ? " " : "\n")
                     + "csv.length=0.");
           for (int obvi = 0; obvi < obv.size() - 1; obvi++) { // -1 since last item is limitN
@@ -2487,7 +2496,9 @@ public abstract class EDDTable extends EDD {
             if (item.length() > 0 && resultsVariables.indexOf(item) < 0)
               throw new SimpleException(
                   EDStatic.bilingual(
-                          language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+                          language,
+                          EDStatic.messages.queryErrorAr,
+                          EDStatic.messages.queryErrorOrderByLimitAr)
                       + (language == 0 ? " " : "\n")
                       + "col="
                       + obv.get(obvi)
@@ -2513,7 +2524,9 @@ public abstract class EDDTable extends EDD {
             if (item.length() > 0 && resultsVariables.indexOf(item) < 0)
               throw new SimpleException(
                   EDStatic.bilingual(
-                          language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByMeanAr)
+                          language,
+                          EDStatic.messages.queryErrorAr,
+                          EDStatic.messages.queryErrorOrderByMeanAr)
                       + (language == 0 ? " " : "\n")
                       + "col="
                       + obv.get(obvi)
@@ -2537,7 +2550,9 @@ public abstract class EDDTable extends EDD {
             if (item.length() > 0 && resultsVariables.indexOf(item) < 0)
               throw new SimpleException(
                   EDStatic.bilingual(
-                          language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderBySumAr)
+                          language,
+                          EDStatic.messages.queryErrorAr,
+                          EDStatic.messages.queryErrorOrderBySumAr)
                       + (language == 0 ? " " : "\n")
                       + "col="
                       + obv.get(obvi)
@@ -2563,7 +2578,7 @@ public abstract class EDDTable extends EDD {
             || !String2.isSomething(obv.get(0))
             || !String2.isSomething(obv.get(1))) {
           String tmsg =
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "&addVariablesWhere() MUST have 2 parameters: attributeName and attributeValue.";
           if (repair)
             // ignore the problem
@@ -2594,7 +2609,7 @@ public abstract class EDDTable extends EDD {
           constraintBeforeQuotes = quotePo >= 0 ? constraint.substring(0, quotePo) : constraint;
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "Use '=' instead of '==' in constraints.");
         }
       }
@@ -2607,7 +2622,7 @@ public abstract class EDDTable extends EDD {
           constraintBeforeQuotes = quotePo >= 0 ? constraint.substring(0, quotePo) : constraint;
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "Use '=~' instead of '~=' in constraints.");
         }
       }
@@ -2621,7 +2636,7 @@ public abstract class EDDTable extends EDD {
         if (repair) continue; // was IllegalArgumentException
         else
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "No operator found in constraint=\""
                   + constraint
                   + "\".");
@@ -2639,7 +2654,7 @@ public abstract class EDDTable extends EDD {
         if (repair) continue;
         else
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "Unrecognized constraint variable=\""
                   + tName
                   + "\"."); // + "\nValid=" + String2.toCSSVString(dataVariableDestionNames())
@@ -2663,7 +2678,7 @@ public abstract class EDDTable extends EDD {
           int cpo = tValue.indexOf(')');
           if (cpo < 0)
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "')' not found after \""
                     + mmString
                     + "(\".");
@@ -2677,7 +2692,7 @@ public abstract class EDDTable extends EDD {
                   mVar.destinationMaxDouble();
           if (Double.isNaN(conValueD))
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "\""
                     + mmString
                     + "("
@@ -2755,7 +2770,7 @@ public abstract class EDDTable extends EDD {
                 constraintValues.set(constraintValues.size() - 1, tValue);
               } else {
                 throw new SimpleException(
-                    EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                    EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                         + "Test for missing time values must use \"NaN\" or \"\", not value=\""
                         + tValue
                         + "\".");
@@ -2779,7 +2794,7 @@ public abstract class EDDTable extends EDD {
 
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For constraints of String variables, the right-hand-side value must be surrounded by double quotes. Bad constraint: "
                   + constraint);
         }
@@ -2799,7 +2814,7 @@ public abstract class EDDTable extends EDD {
             constraintValues.set(constraintValues.size() - 1, tValue);
           } else {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "For =~ constraints of numeric variables, the right-hand-side value must be surrounded by double quotes. Bad constraint: "
                     + constraint);
           }
@@ -2813,7 +2828,7 @@ public abstract class EDDTable extends EDD {
               constraintValues.set(constraintValues.size() - 1, tValue);
             } else {
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "For non =~ constraints of numeric variables, the right-hand-side value must not be surrounded by double quotes. Bad constraint: "
                       + constraint);
             }
@@ -2828,7 +2843,7 @@ public abstract class EDDTable extends EDD {
               constraintValues.set(constraintValues.size() - 1, tValue);
             } else {
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "Numeric tests of NaN must use \"NaN\", not value=\""
                       + tValue
                       + "\".");
@@ -2894,13 +2909,13 @@ public abstract class EDDTable extends EDD {
                   tValue;
           String msg0 =
               MessageFormat.format(
-                  EDStatic.queryErrorActualRangeAr[0],
+                  EDStatic.messages.queryErrorActualRangeAr[0],
                   tName + constraintOp + tv,
                   Double.isFinite(destMin) ? conEdv.destinationMinString() : "NaN",
                   Double.isFinite(destMax) ? conEdv.destinationMaxString() : "NaN");
           String msgl =
               MessageFormat.format(
-                  EDStatic.queryErrorActualRangeAr[language],
+                  EDStatic.messages.queryErrorActualRangeAr[language],
                   tName + constraintOp + tv,
                   Double.isFinite(destMin) ? conEdv.destinationMinString() : "NaN",
                   Double.isFinite(destMax) ? conEdv.destinationMaxString() : "NaN");
@@ -2999,7 +3014,7 @@ public abstract class EDDTable extends EDD {
       int conDVI = String2.indexOf(dataVariableDestinationNames(), destName);
       if (conDVI < 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "constraint variable="
                 + destName
                 + " wasn't found.");
@@ -3043,7 +3058,7 @@ public abstract class EDDTable extends EDD {
           String maxS =
               i == 3 ? Calendar2.epochSecondsToIsoStringTZ(requestedMax[3]) : "" + requestedMax[i];
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "The requested "
                   + tName
                   + " min="
@@ -3093,7 +3108,7 @@ public abstract class EDDTable extends EDD {
           String maxS =
               i == 3 ? Calendar2.epochSecondsToIsoStringTZ(requestedMax[3]) : "" + requestedMax[i];
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + tName
                   + " min="
                   + minS
@@ -3194,10 +3209,11 @@ public abstract class EDDTable extends EDD {
     throw new SimpleException(
         EDStatic.bilingual(
             language,
-            EDStatic.queryErrorAr[0]
-                + MessageFormat.format(EDStatic.queryErrorFileTypeAr[0], fileTypeName),
-            EDStatic.queryErrorAr[language]
-                + MessageFormat.format(EDStatic.queryErrorFileTypeAr[language], fileTypeName)));
+            EDStatic.messages.queryErrorAr[0]
+                + MessageFormat.format(EDStatic.messages.queryErrorFileTypeAr[0], fileTypeName),
+            EDStatic.messages.queryErrorAr[language]
+                + MessageFormat.format(
+                    EDStatic.messages.queryErrorFileTypeAr[language], fileTypeName)));
   }
 
   /**
@@ -3289,7 +3305,8 @@ public abstract class EDDTable extends EDD {
           // downloads of e.g., erddap2.css don't work right if not closed. (just if gzip'd?)
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaFGDC);
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                  + accessibleViaFGDC);
         }
         return;
       }
@@ -3300,7 +3317,7 @@ public abstract class EDDTable extends EDD {
         && (fileTypeName.equals(".insert") || fileTypeName.equals(".delete"))) {
       if (!EDStatic.developmentMode && loggedInAs == null)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + fileTypeName
                 + " requests must be made to the https URL.");
 
@@ -3347,7 +3364,7 @@ public abstract class EDDTable extends EDD {
       try {
         writer.write(
             EDStatic.startHeadHtml(
-                language, tErddapUrl, title() + " - " + EDStatic.dafAr[language]));
+                language, tErddapUrl, title() + " - " + EDStatic.messages.dafAr[language]));
         writer.write("\n" + rssHeadLink());
         writer.write("\n</head>\n");
         writer.write(
@@ -3370,13 +3387,13 @@ public abstract class EDDTable extends EDD {
                 language,
                 loggedInAs,
                 dapProtocol,
-                EDStatic.dafAr[language],
+                EDStatic.messages.dafAr[language],
                 "<div class=\"standard_max_width\">"
-                    + EDStatic.dafTableTooltipAr[language]
+                    + EDStatic.messages.dafTableTooltipAr[language]
                     + "<p>"
-                    + EDStatic.EDDTableDownloadDataTooltipAr[language]
+                    + EDStatic.messages.EDDTableDownloadDataTooltipAr[language]
                     + "</ol>\n"
-                    + EDStatic.dafTableBypassTooltipAr[language]
+                    + EDStatic.messages.dafTableBypassTooltipAr[language]
                     + "</div>"));
         writeHtmlDatasetInfo(
             language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
@@ -3391,7 +3408,7 @@ public abstract class EDDTable extends EDD {
         writer.write("<hr>\n");
         writer.write(
             "<h2><a class=\"selfLink\" id=\"DAS\" href=\"#DAS\" rel=\"bookmark\">"
-                + EDStatic.dasTitleAr[language]
+                + EDStatic.messages.dasTitleAr[language]
                 + "</a></h2>\n"
                 + "<pre style=\"white-space:pre-wrap;\">\n");
         table.writeDAS(
@@ -3437,8 +3454,9 @@ public abstract class EDDTable extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0] + EDStatic.errorFileNotFoundImageAr[0],
-                EDStatic.queryErrorAr[language] + EDStatic.errorFileNotFoundImageAr[language]));
+                EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorFileNotFoundImageAr[0],
+                EDStatic.messages.queryErrorAr[language]
+                    + EDStatic.messages.errorFileNotFoundImageAr[language]));
 
       // ok, copy it  (and don't close the outputStream)
       try (OutputStream out = outputStreamSource.outputStream(File2.UTF_8)) {
@@ -3459,7 +3477,8 @@ public abstract class EDDTable extends EDD {
           // downloads of e.g., erddap2.css don't work right if not closed. (just if gzip'd?)
         } else {
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaISO19115);
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                  + accessibleViaISO19115);
         }
         return;
       }
@@ -3555,8 +3574,10 @@ public abstract class EDDTable extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-                    EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+                    EDStatic.messages.queryErrorAr[0]
+                        + EDStatic.messages.errorJsonpFunctionNameAr[0],
+                    EDStatic.messages.queryErrorAr[language]
+                        + EDStatic.messages.errorJsonpFunctionNameAr[language]));
         }
         switch (fileTypeName) {
           case ".geoJson" ->
@@ -3631,7 +3652,8 @@ public abstract class EDDTable extends EDD {
                   true,
                   true,
                   -1,
-                  EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile);
+                  EDStatic.imageDirUrl(loggedInAs, language)
+                      + EDStatic.messages.questionMarkImageFile);
       case ".itx" -> {
         // tableWriter = new TableWriterIgor(this, tNewHistory, outputStreamSource);
         twawm =
@@ -3674,8 +3696,9 @@ public abstract class EDDTable extends EDD {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + EDStatic.errorOdvLLTTableAr[0],
-                  EDStatic.queryErrorAr[language] + EDStatic.errorOdvLLTTableAr[language]));
+                  EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorOdvLLTTableAr[0],
+                  EDStatic.messages.queryErrorAr[language]
+                      + EDStatic.messages.errorOdvLLTTableAr[language]));
         twawm =
             new TableWriterAllWithMetadata(
                 language,
@@ -3741,7 +3764,8 @@ public abstract class EDDTable extends EDD {
                   true,
                   true,
                   -1,
-                  EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile);
+                  EDStatic.imageDirUrl(loggedInAs, language)
+                      + EDStatic.messages.questionMarkImageFile);
     }
 
     if (tableWriter != null) {
@@ -3845,7 +3869,7 @@ public abstract class EDDTable extends EDD {
 
         if (EDStatic.accessibleViaNC4.length() > 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + EDStatic.accessibleViaNC4);
 
         // if .nc4Header, make sure the .nc4 file exists
@@ -3869,7 +3893,8 @@ public abstract class EDDTable extends EDD {
         // quick reject?
         if (accessibleViaNcCF().length() > 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaNcCF);
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+                  + accessibleViaNcCF);
 
         // check that query includes required variables
         if (userDapQuery == null) userDapQuery = "";
@@ -3884,7 +3909,8 @@ public abstract class EDDTable extends EDD {
           for (String requiredCfRequestVariable : requiredCfRequestVariables) {
             if (String2.indexOf(varList, requiredCfRequestVariable) < 0)
               addVars.append(requiredCfRequestVariable + ",");
-            // throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+            // throw new SimpleException(EDStatic.simpleBilingual(language,
+            // EDStatic.messages.queryErrorAr) +
             //    ".ncCF queries for this dataset must include all of these variables: " +
             // String2.toCSSVString(requiredCfRequestVariables) + ".");
           }
@@ -3902,7 +3928,7 @@ public abstract class EDDTable extends EDD {
           }
           if (!ok) {
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + ".ncCF and .ncCFMA queries for this dataset must at least one variable not on this list: "
                     + String2.toCSSVString(outerCfVariables)
                     + ".");
@@ -3962,11 +3988,12 @@ public abstract class EDDTable extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
-                        + MessageFormat.format(EDStatic.queryErrorFileTypeAr[0], fileTypeName),
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[0]
                         + MessageFormat.format(
-                            EDStatic.queryErrorFileTypeAr[language], fileTypeName)));
+                            EDStatic.messages.queryErrorFileTypeAr[0], fileTypeName),
+                    EDStatic.messages.queryErrorAr[language]
+                        + MessageFormat.format(
+                            EDStatic.messages.queryErrorFileTypeAr[language], fileTypeName)));
           }
         } finally {
           if (fos != null)
@@ -4153,7 +4180,7 @@ public abstract class EDDTable extends EDD {
           if (String2.indexOf(dataVariableDestinationNames(), twob.orderBy[ob]) < 0) {
             twob.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderBy' variable="
                     + twob.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4175,7 +4202,7 @@ public abstract class EDDTable extends EDD {
           if (String2.indexOf(dataVariableDestinationNames(), twobd.orderBy[ob]) < 0) {
             twobd.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderByDescending' variable="
                     + twobd.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4199,7 +4226,9 @@ public abstract class EDDTable extends EDD {
             twobc.close();
             throw new SimpleException(
                 EDStatic.bilingual(
-                        language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+                        language,
+                        EDStatic.messages.queryErrorAr,
+                        EDStatic.messages.queryErrorOrderByClosestAr)
                     + "\nunknown column name="
                     + twobc.orderBy[ob]
                     + ".");
@@ -4223,7 +4252,7 @@ public abstract class EDDTable extends EDD {
               < 0) {
             twobc.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderByCount' variable="
                     + twobc.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4248,7 +4277,9 @@ public abstract class EDDTable extends EDD {
             twobl.close();
             throw new SimpleException(
                 EDStatic.bilingual(
-                        language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+                        language,
+                        EDStatic.messages.queryErrorAr,
+                        EDStatic.messages.queryErrorOrderByLimitAr)
                     + "\nunknown column name="
                     + twobl.orderBy[ob]
                     + ".");
@@ -4291,7 +4322,7 @@ public abstract class EDDTable extends EDD {
               < 0) {
             twobm.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderByMax' variable="
                     + twobm.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4315,7 +4346,7 @@ public abstract class EDDTable extends EDD {
               < 0) {
             twobm.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderByMin' variable="
                     + twobm.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4338,7 +4369,7 @@ public abstract class EDDTable extends EDD {
               < 0) {
             twobm.close();
             throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "'orderByMinMax' variable="
                     + twobm.orderBy[ob]
                     + " isn't in the dataset.");
@@ -4560,9 +4591,10 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + MessageFormat.format(EDStatic.queryErrorLLAr[0], ".kml"),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(EDStatic.queryErrorLLAr[language], ".kml")));
+              EDStatic.messages.queryErrorAr[0]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLAr[0], ".kml"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLAr[language], ".kml")));
 
     // get the table with all the data
     TableWriterAllWithMetadata twawm =
@@ -4582,9 +4614,10 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + MessageFormat.format(EDStatic.queryErrorLLAr[0], ".kml"),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(EDStatic.queryErrorLLAr[language], ".kml")));
+              EDStatic.messages.queryErrorAr[0]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLAr[0], ".kml"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLAr[language], ".kml")));
 
     // remember this may be many stations one time, or one station many times, or many/many
     // sort table by lat, lon, depth, then time (if possible)
@@ -4614,8 +4647,8 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              MustBe.THERE_IS_NO_DATA + " " + EDStatic.noDataNoLLAr[0],
-              MustBe.THERE_IS_NO_DATA + " " + EDStatic.noDataNoLLAr[language]));
+              MustBe.THERE_IS_NO_DATA + " " + EDStatic.messages.noDataNoLLAr[0],
+              MustBe.THERE_IS_NO_DATA + " " + EDStatic.messages.noDataNoLLAr[language]));
     double lonRange = maxLon - minLon;
     double latRange = maxLat - minLat;
     double maxRange = Math.max(lonRange, latRange);
@@ -4694,7 +4727,8 @@ public abstract class EDDTable extends EDD {
     String courtesy =
         institution().length() == 0
             ? ""
-            : MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution());
+            : MessageFormat.format(
+                EDStatic.messages.imageDataCourtesyOfAr[language], institution());
     double iconSize =
         maxRange > 90
             ? 1.2
@@ -5000,20 +5034,20 @@ public abstract class EDDTable extends EDD {
     boolean transparentPng = fileTypeName.equals(".transparentPng");
     if (!pdf && !png)
       throw new SimpleException(
-          EDStatic.errorInternalAr[0] + "Unexpected image type=" + fileTypeName);
+          EDStatic.messages.errorInternalAr[0] + "Unexpected image type=" + fileTypeName);
     Object pdfInfo[] = null;
     BufferedImage bufferedImage = null;
     Graphics2D g2 = null;
     int imageWidth, imageHeight;
     if (pdf) {
-      imageWidth = EDStatic.pdfWidths[sizeIndex];
-      imageHeight = EDStatic.pdfHeights[sizeIndex];
+      imageWidth = EDStatic.messages.pdfWidths[sizeIndex];
+      imageHeight = EDStatic.messages.pdfHeights[sizeIndex];
     } else if (transparentPng) {
-      imageWidth = EDStatic.imageWidths[sizeIndex];
+      imageWidth = EDStatic.messages.imageWidths[sizeIndex];
       imageHeight = imageWidth;
     } else {
-      imageWidth = EDStatic.imageWidths[sizeIndex];
-      imageHeight = EDStatic.imageHeights[sizeIndex];
+      imageWidth = EDStatic.messages.imageWidths[sizeIndex];
+      imageHeight = EDStatic.messages.imageHeights[sizeIndex];
     }
 
     Color transparentColor =
@@ -5042,10 +5076,11 @@ public abstract class EDDTable extends EDD {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
-                    + MessageFormat.format(EDStatic.queryError2VarAr[0], fileTypeName),
-                EDStatic.queryErrorAr[language]
-                    + MessageFormat.format(EDStatic.queryError2VarAr[language], fileTypeName)));
+                EDStatic.messages.queryErrorAr[0]
+                    + MessageFormat.format(EDStatic.messages.queryError2VarAr[0], fileTypeName),
+                EDStatic.messages.queryErrorAr[language]
+                    + MessageFormat.format(
+                        EDStatic.messages.queryError2VarAr[language], fileTypeName)));
       // xVar,yVar are 1st and 2nd request variables
       EDV xVar = findVariableByDestinationName(resultsVariables.get(0));
       EDV yVar = findVariableByDestinationName(resultsVariables.get(1));
@@ -5158,7 +5193,7 @@ public abstract class EDDTable extends EDD {
           if (pParts.length > 4 && pParts[4].length() > 0)
             paletteMax = String2.parseDouble(pParts[4]);
           if (pParts.length > 5 && pParts[5].length() > 0) nSections = String2.parseInt(pParts[5]);
-          if (String2.indexOf(EDStatic.palettes, palette) < 0) palette = "";
+          if (String2.indexOf(EDStatic.messages.palettes, palette) < 0) palette = "";
           if (EDV.VALID_SCALES.indexOf(scale) < 0) scale = "Linear";
           if (nSections < 0 || nSections >= 100) nSections = -1;
           if (reallyVerbose)
@@ -5565,7 +5600,8 @@ public abstract class EDDTable extends EDD {
               varTitle.length() > 0 ? varTitle : title,
               varTitle.length() > 0 ? title : "",
               constraintTitle.toString(), // title2.toString(),
-              MessageFormat.format(EDStatic.imageDataCourtesyOfAr[language], institution()),
+              MessageFormat.format(
+                  EDStatic.messages.imageDataCourtesyOfAr[language], institution()),
               table,
               null,
               null,
@@ -5623,8 +5659,9 @@ public abstract class EDDTable extends EDD {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0] + EDStatic.noDataNoLLAr[0],
-                    EDStatic.queryErrorAr[language] + EDStatic.noDataNoLLAr[language]));
+                    EDStatic.messages.queryErrorAr[0] + EDStatic.messages.noDataNoLLAr[0],
+                    EDStatic.messages.queryErrorAr[language]
+                        + EDStatic.messages.noDataNoLLAr[language]));
 
           // old way  (too tied to big round numbers like 100, 200, 300)
           // often had big gap on one side
@@ -5761,8 +5798,8 @@ public abstract class EDDTable extends EDD {
             SgtMap.makeMap(
                 transparentPng,
                 SgtUtil.LEGEND_BELOW,
-                EDStatic.legendTitle1,
-                EDStatic.legendTitle2,
+                EDStatic.messages.legendTitle1,
+                EDStatic.messages.legendTitle2,
                 EDStatic.imageDir,
                 logoImageFile,
                 xMin,
@@ -5824,8 +5861,8 @@ public abstract class EDDTable extends EDD {
                 xVar.longName() + xUnits, // x,yAxisTitle  for now, always std units
                 png && drawLegend.equals(LEGEND_ONLY) ? "." : yLabel, // avoid running into legend
                 SgtUtil.LEGEND_BELOW,
-                EDStatic.legendTitle1,
-                EDStatic.legendTitle2,
+                EDStatic.messages.legendTitle1,
+                EDStatic.messages.legendTitle2,
                 EDStatic.imageDir,
                 logoImageFile,
                 xMin,
@@ -5981,7 +6018,9 @@ public abstract class EDDTable extends EDD {
           Math2.memoryTooMuchData
               + "  "
               + MessageFormat.format(
-                  EDStatic.errorMoreThan2GBAr[0], ".mat", tnRows + " " + EDStatic.rowsAr[0]));
+                  EDStatic.messages.errorMoreThan2GBAr[0],
+                  ".mat",
+                  tnRows + " " + EDStatic.messages.rowsAr[0]));
     int nCols = twawm.nColumns();
     int nRows = (int) tnRows; // safe since checked above
 
@@ -6018,7 +6057,9 @@ public abstract class EDDTable extends EDD {
           Math2.memoryTooMuchData
               + "  "
               + MessageFormat.format(
-                  EDStatic.errorMoreThan2GBAr[0], ".mat", (cumSize / Math2.BytesPerMB) + " MB"));
+                  EDStatic.messages.errorMoreThan2GBAr[0],
+                  ".mat",
+                  (cumSize / Math2.BytesPerMB) + " MB"));
 
     // open a dataOutputStream
     DataOutputStream stream = new DataOutputStream(outputStreamSource.outputStream(""));
@@ -6346,7 +6387,9 @@ public abstract class EDDTable extends EDD {
           Math2.memoryTooMuchData
               + "  "
               + MessageFormat.format(
-                  EDStatic.errorMoreThan2GBAr[0], ".nc", twawm.nRows() + " " + EDStatic.rowsAr[0]));
+                  EDStatic.messages.errorMoreThan2GBAr[0],
+                  ".nc",
+                  twawm.nRows() + " " + EDStatic.messages.rowsAr[0]));
     int nRows = (int) twawm.nRows(); // safe since checked above
     int nColumns = twawm.nColumns();
     if (nRows == 0)
@@ -6566,11 +6609,11 @@ public abstract class EDDTable extends EDD {
     // double check that this dataset supports .ncCF (but it should have been tested earlier)
     if (accessibleViaNcCF.length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaNcCF);
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaNcCF);
     String cdmType = combinedGlobalAttributes.getString("cdm_data_type");
     if (!CDM_POINT.equals(cdmType)) // but already checked before calling this method
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "cdm_data_type for convertFlatNcToNcCF0() must be Point, not "
               + cdmType
               + ".");
@@ -6644,7 +6687,7 @@ public abstract class EDDTable extends EDD {
     // double check that this dataset supports .ncCF (but it should have been tested earlier)
     if (accessibleViaNcCF.length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaNcCF);
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaNcCF);
     String cdmType = combinedGlobalAttributes.getString("cdm_data_type");
     String lcCdmType = cdmType == null ? null : cdmType.toLowerCase();
 
@@ -6656,7 +6699,7 @@ public abstract class EDDTable extends EDD {
     else if (CDM_TRAJECTORY.equals(cdmType)) idDVI = trajectory_idIndex;
     else {
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + // but already checked before calling this method
               "For convertFlatNcToNcCF1(), cdm_data_type must be TimeSeries, Profile, or Trajectory, not "
               + cdmType
@@ -6665,7 +6708,7 @@ public abstract class EDDTable extends EDD {
 
     if (idDVI < 0) // but already checked by accessibleViaNcCF
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "No variable has a cf_role="
               + lcCdmType
               + "_id attribute.");
@@ -6696,7 +6739,7 @@ public abstract class EDDTable extends EDD {
       int idPo = String2.indexOf(ncColNames, idName);
       if (idPo < 0) // but already checked before calling this method
       throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The .nc file must have "
                 + idName);
 
@@ -7017,7 +7060,7 @@ public abstract class EDDTable extends EDD {
     // double check that this dataset supports .ncCF (but it should have been tested earlier)
     if (accessibleViaNcCF.length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaNcCF);
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaNcCF);
     String cdmType = combinedGlobalAttributes.getString("cdm_data_type");
 
     // ensure profile_id and timeseries_id|trajectory_id variable is defined
@@ -7033,20 +7076,20 @@ public abstract class EDDTable extends EDD {
       olcCdmName = "trajectory";
     } else
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + // but already checked before calling this method
               "For convertFlatNcToNcCF2(), cdm_data_type must be TimeSeriesProfile or TrajectoryProfile, not "
               + cdmType
               + ".");
     if (oidDVI < 0) // but already checked by accessibleViaNcCF
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "No variable has a cf_role="
               + olcCdmName
               + "_id attribute.");
     if (pidDVI < 0) // but already checked by accessibleViaNcCF
     throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "No variable has a cf_role=profile_id attribute.");
     String oidName = dataVariableDestinationNames()[oidDVI]; // var name of ..._id var
     String pidName = dataVariableDestinationNames()[pidDVI];
@@ -7084,12 +7127,12 @@ public abstract class EDDTable extends EDD {
       int pidPo = String2.indexOf(ncColNames, pidName);
       if (oidPo < 0) // but already checked before calling this method
       throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The .nc file must have "
                 + oidName);
       if (pidPo < 0) // but already checked before calling this method
       throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "The .nc file must have "
                 + pidName);
 
@@ -7608,13 +7651,14 @@ public abstract class EDDTable extends EDD {
     // the other params are all required by EDD, so it's a programming error if they are missing
     if (!String2.isSomething(tDatasetID))
       throw new SimpleException(
-          EDStatic.errorInternalAr[0] + "saveAsODV error: datasetID wasn't specified.");
+          EDStatic.messages.errorInternalAr[0] + "saveAsODV error: datasetID wasn't specified.");
     if (!String2.isSomething(tPublicSourceUrl))
       throw new SimpleException(
-          EDStatic.errorInternalAr[0] + "saveAsODV error: publicSourceUrl wasn't specified.");
+          EDStatic.messages.errorInternalAr[0]
+              + "saveAsODV error: publicSourceUrl wasn't specified.");
     if (!String2.isSomething(tInfoUrl))
       throw new SimpleException(
-          EDStatic.errorInternalAr[0] + "saveAsODV error: infoUrl wasn't specified.");
+          EDStatic.messages.errorInternalAr[0] + "saveAsODV error: infoUrl wasn't specified.");
 
     // make sure there isn't too much data before getting outputStream
     Table table = twawm.cumulativeTable(); // it checks memory usage
@@ -7632,10 +7676,10 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
-                  + MessageFormat.format(EDStatic.queryErrorLLTAr[0], ".odvTxt"),
-              EDStatic.queryErrorAr[language]
-                  + MessageFormat.format(EDStatic.queryErrorLLTAr[language], ".odvTxt")));
+              EDStatic.messages.queryErrorAr[0]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLTAr[0], ".odvTxt"),
+              EDStatic.messages.queryErrorAr[language]
+                  + MessageFormat.format(EDStatic.messages.queryErrorLLTAr[language], ".odvTxt")));
 
     // Move columns into preferred order, see table 3-1, 3-2, 3-3, 3-4
     // This would be very complicated if you worked forwards, because some vars are in a couple of
@@ -7850,7 +7894,7 @@ public abstract class EDDTable extends EDD {
       else if (paType == PAType.STRING) odvType = "INDEXED_TEXT";
       else
         throw new SimpleException(
-            EDStatic.errorInternalAr[0]
+            EDStatic.messages.errorInternalAr[0]
                 + "No odvDataType specified for type="
                 + pas[col].elementTypeString()
                 + ".");
@@ -8162,13 +8206,13 @@ public abstract class EDDTable extends EDD {
     writer.write(
         "<tr>\n"
             + "  <th class=\"L\">"
-            + EDStatic.EDDTableVariableAr[language]
+            + EDStatic.messages.EDDTableVariableAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.EDDTableTabularDatasetTooltipAr[language]
+                    + EDStatic.messages.EDDTableTabularDatasetTooltipAr[language]
                     + "</div>"));
 
     StringBuilder checkAll = new StringBuilder();
@@ -8182,65 +8226,65 @@ public abstract class EDDTable extends EDD {
         widgets.button(
             "button",
             "CheckAll",
-            EDStatic.EDDTableCheckAllTooltipAr[language],
-            EDStatic.EDDTableCheckAllAr[language],
+            EDStatic.messages.EDDTableCheckAllTooltipAr[language],
+            EDStatic.messages.EDDTableCheckAllAr[language],
             "onclick=\"" + checkAll + "\""));
     writer.write(
         widgets.button(
             "button",
             "UncheckAll",
-            EDStatic.EDDTableUncheckAllTooltipAr[language],
-            EDStatic.EDDTableUncheckAllAr[language],
+            EDStatic.messages.EDDTableUncheckAllTooltipAr[language],
+            EDStatic.messages.EDDTableUncheckAllAr[language],
             "onclick=\"" + uncheckAll + "\""));
 
     writer.write(
         "  &nbsp;</th>\n"
             + "  <th colspan=\"2\">"
-            + EDStatic.EDDTableOptConstraint1HtmlAr[language]
+            + EDStatic.messages.EDDTableOptConstraint1HtmlAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.EDDTableConstraintTooltipAr[language]
+                    + EDStatic.messages.EDDTableConstraintTooltipAr[language]
                     + "</div>")
             + "</th>\n"
             + "  <th colspan=\"2\">"
-            + EDStatic.EDDTableOptConstraint2HtmlAr[language]
+            + EDStatic.messages.EDDTableOptConstraint2HtmlAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.EDDTableConstraintTooltipAr[language]
+                    + EDStatic.messages.EDDTableConstraintTooltipAr[language]
                     + "</div>")
             + "</th>\n"
             + "  <th>"
             + gap
-            + EDStatic.EDDMinimumAr[language]
+            + EDStatic.messages.EDDMinimumAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.EDDTableMinimumTooltipAr[language])
+                language, loggedInAs, EDStatic.messages.EDDTableMinimumTooltipAr[language])
             + (distinctOptions == null
                 ? "<br>&nbsp;"
                 : "<br>"
                     + gap
-                    + EDStatic.orAListOfValuesAr[language]
+                    + EDStatic.messages.orAListOfValuesAr[language]
                     + " "
                     + // 2014-07-17 was Distinct Values
                     EDStatic.htmlTooltipImage(
                         language,
                         loggedInAs,
                         "<div class=\"narrow_max_width\">"
-                            + EDStatic.distinctValuesTooltipAr[language]
+                            + EDStatic.messages.distinctValuesTooltipAr[language]
                             + "</div>"))
             + "</th>\n"
             + "  <th>"
             + gap
-            + EDStatic.EDDMaximumAr[language]
+            + EDStatic.messages.EDDMaximumAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.EDDTableMaximumTooltipAr[language])
+                language, loggedInAs, EDStatic.messages.EDDTableMaximumTooltipAr[language])
             + "<br>&nbsp;"
             + "</th>\n"
             + "</tr>\n");
@@ -8277,7 +8321,7 @@ public abstract class EDDTable extends EDD {
       writer.write(
           widgets.checkbox(
               "varch" + dv,
-              EDStatic.EDDTableCheckTheVariablesAr[language],
+              EDStatic.messages.EDDTableCheckTheVariablesAr[language],
               userDapQuery.length() == 0 || (resultsVariables.indexOf(edv.destinationName()) >= 0),
               edv.destinationName(),
               edv.destinationName()
@@ -8330,15 +8374,15 @@ public abstract class EDDTable extends EDD {
       String valueWidgetName = "val" + dv + "_";
       String tTooltip =
           isTimeStamp
-              ? EDStatic.EDDTableTimeConstraintTooltipAr[language]
+              ? EDStatic.messages.EDDTableTimeConstraintTooltipAr[language]
               : isString || isChar
-                  ? EDStatic.EDDTableStringConstraintTooltipAr[language]
-                  : EDStatic.EDDTableNumericConstraintTooltipAr[language];
+                  ? EDStatic.messages.EDDTableStringConstraintTooltipAr[language]
+                  : EDStatic.messages.EDDTableNumericConstraintTooltipAr[language];
       if (edv.destinationMinString().length() > 0)
         tTooltip +=
             "<br>&nbsp;<br>"
                 + MessageFormat.format(
-                    EDStatic.rangesFromToAr[language],
+                    EDStatic.messages.rangesFromToAr[language],
                     edv.destinationName(),
                     edv.destinationMinString(),
                     edv.destinationMaxString().length() > 0 ? edv.destinationMaxString() : "(?)");
@@ -8347,7 +8391,7 @@ public abstract class EDDTable extends EDD {
         writer.write(
             widgets.select(
                 "op" + dv + "_" + con,
-                EDStatic.EDDTableSelectAnOperatorAr[language],
+                EDStatic.messages.EDDTableSelectAnOperatorAr[language],
                 1,
                 OPERATORS,
                 PPE_OPERATORS,
@@ -8425,7 +8469,7 @@ public abstract class EDDTable extends EDD {
                 + "minus.gif\""
                 + // vertical-align: 'b'ottom
                 "  "
-                + widgets.completeTooltip(EDStatic.selectPreviousAr[language])
+                + widgets.completeTooltip(EDStatic.messages.selectPreviousAr[language])
                 + " alt=\"-\"\n"
                 +
                 // onMouseUp works much better than onClick and onDblClick
@@ -8458,7 +8502,7 @@ public abstract class EDDTable extends EDD {
                 + "plus.gif\""
                 + // vertical-align: 'b'ottom
                 "  "
-                + widgets.completeTooltip(EDStatic.selectNextAr[language])
+                + widgets.completeTooltip(EDStatic.messages.selectNextAr[language])
                 + " alt=\"+\"\n"
                 +
                 // onMouseUp works much better than onClick and onDblClick
@@ -8491,7 +8535,7 @@ public abstract class EDDTable extends EDD {
                     language,
                     loggedInAs,
                     "<div class=\"narrow_max_width\">"
-                        + EDStatic.EDDTableSelectConstraintTooltipAr[language]
+                        + EDStatic.messages.EDDTableSelectConstraintTooltipAr[language]
                         + "</div>")
                 + "  </tr>\n"
                 + "  </table>\n"
@@ -8608,13 +8652,14 @@ public abstract class EDDTable extends EDD {
                 // make the Select widget
                 widgets.select(
                     "avwav" + attNamei,
-                    EDStatic.addVarWhereAttValueAr[language],
+                    EDStatic.messages.addVarWhereAttValueAr[language],
                     1,
                     addVariablesWhereAttValues.get(attNamei).toArray(),
                     attValuei,
                     "")
                 + "\n"
-                + EDStatic.htmlTooltipImage(language, loggedInAs, EDStatic.addVarWhereAr[language])
+                + EDStatic.htmlTooltipImage(
+                    language, loggedInAs, EDStatic.messages.addVarWhereAr[language])
                 + "</tr>\n");
       }
       writer.write(widgets.endTable());
@@ -8628,17 +8673,17 @@ public abstract class EDDTable extends EDD {
     // fileType
     writer.write(
         "<p><strong>"
-            + EDStatic.EDDFileTypeAr[language]
+            + EDStatic.messages.EDDFileTypeAr[language]
             + "</strong>\n"
             + " (<a rel=\"help\" href=\""
             + tErddapUrl
             + "/tabledap/documentation.html#fileType\">"
-            + EDStatic.moreInformationAr[language]
+            + EDStatic.messages.moreInformationAr[language]
             + "</a>)\n");
     writer.write(
         widgets.select(
             "fileType",
-            EDStatic.EDDSelectFileTypeAr[language],
+            EDStatic.messages.EDDSelectFileTypeAr[language],
             1,
             allFileTypeOptionsAr[language],
             defaultFileTypeOption,
@@ -8711,18 +8756,21 @@ public abstract class EDDTable extends EDD {
     String genViewHtml =
         "<div class=\"standard_max_width\">"
             + String2.replaceAll(
-                EDStatic.justGenerateAndViewTooltipAr[language], "&protocolName;", dapProtocol)
+                EDStatic.messages.justGenerateAndViewTooltipAr[language],
+                "&protocolName;",
+                dapProtocol)
             + "</div>";
     writer.write(
         widgets.button(
             "button",
             "getUrl",
             genViewHtml,
-            EDStatic.justGenerateAndViewAr[language],
+            EDStatic.messages.justGenerateAndViewAr[language],
             // "class=\"skinny\" " + //only IE needs it but only IE ignores it
             "onclick='" + javaScript + "'"));
     writer.write(
-        widgets.textField("tUrl", EDStatic.justGenerateAndViewUrlAr[language], 60, 1000, "", ""));
+        widgets.textField(
+            "tUrl", EDStatic.messages.justGenerateAndViewUrlAr[language], 60, 1000, "", ""));
     writer.write(
         "\n<br>(<a rel=\"help\" href=\""
             + tErddapUrl
@@ -8739,9 +8787,9 @@ public abstract class EDDTable extends EDD {
                 "button",
                 "submit1",
                 "",
-                EDStatic.submitTooltipAr[language],
+                EDStatic.messages.submitTooltipAr[language],
                 "<span style=\"font-size:large;\"><strong>"
-                    + EDStatic.submitAr[language]
+                    + EDStatic.messages.submitAr[language]
                     + "</strong></span>",
                 "onclick='"
                     + javaScript
@@ -8749,7 +8797,7 @@ public abstract class EDDTable extends EDD {
                     + // or open a new window: window.open(result);\n" +
                     "'")
             + " "
-            + EDStatic.patientDataAr[language]
+            + EDStatic.messages.patientDataAr[language]
             + "\n");
 
     // end of form
@@ -8791,13 +8839,13 @@ public abstract class EDDTable extends EDD {
     writer.write(widgets.beginTable("class=\"compact W\"")); // not nowrap
     writer.write(
         "<tr><td><strong>"
-            + EDStatic.functionsAr[language]
+            + EDStatic.messages.functionsAr[language]
             + "</strong> "
             + EDStatic.htmlTooltipImage(
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
-                    + EDStatic.functionTooltipAr[language]
+                    + EDStatic.messages.functionTooltipAr[language]
                     + "</div>")
             + "</td></tr>\n");
 
@@ -8806,7 +8854,7 @@ public abstract class EDDTable extends EDD {
     writer.write(
         widgets.checkbox(
             "distinct",
-            EDStatic.functionDistinctCheckAr[language],
+            EDStatic.messages.functionDistinctCheckAr[language],
             String2.indexOf(queryParts, "distinct()") >= 0,
             "true",
             "distinct()",
@@ -8816,7 +8864,7 @@ public abstract class EDDTable extends EDD {
             language,
             loggedInAs,
             "<div class=\"narrow_max_width\">"
-                + EDStatic.functionDistinctTooltipAr[language]
+                + EDStatic.messages.functionDistinctTooltipAr[language]
                 + "</div>"));
     writer.write("</td></tr>\n");
 
@@ -8829,17 +8877,17 @@ public abstract class EDDTable extends EDD {
             ?
             // "most", "second most", "third most", ["fourth most",] "least"};
             new String[] {
-              EDStatic.functionOrderBySort1Ar[language],
-              EDStatic.functionOrderBySort2Ar[language],
-              EDStatic.functionOrderBySort3Ar[language],
-              EDStatic.functionOrderBySortLeastAr[language]
+              EDStatic.messages.functionOrderBySort1Ar[language],
+              EDStatic.messages.functionOrderBySort2Ar[language],
+              EDStatic.messages.functionOrderBySort3Ar[language],
+              EDStatic.messages.functionOrderBySortLeastAr[language]
             }
             : new String[] {
-              EDStatic.functionOrderBySort1Ar[language],
-              EDStatic.functionOrderBySort2Ar[language],
-              EDStatic.functionOrderBySort3Ar[language],
-              EDStatic.functionOrderBySort4Ar[language],
-              EDStatic.functionOrderBySortLeastAr[language]
+              EDStatic.messages.functionOrderBySort1Ar[language],
+              EDStatic.messages.functionOrderBySort2Ar[language],
+              EDStatic.messages.functionOrderBySort3Ar[language],
+              EDStatic.messages.functionOrderBySort4Ar[language],
+              EDStatic.messages.functionOrderBySortLeastAr[language]
             };
     // find first part that uses orderBy...
     String obPart = null;
@@ -8869,12 +8917,12 @@ public abstract class EDDTable extends EDD {
     writer.write(widgets.select("orderBy", "", 1, orderByOptions, whichOb, ""));
     writer.write(
         EDStatic.htmlTooltipImage(
-            language, loggedInAs, EDStatic.functionOrderByTooltipAr[language]));
+            language, loggedInAs, EDStatic.messages.functionOrderByTooltipAr[language]));
     writer.write("(\"");
     for (int ob = 0; ob < nOrderByComboBox; ob++) {
       // if (ob > 0) writer.write(",\n");
       String tooltip =
-          MessageFormat.format(EDStatic.functionOrderBySortAr[language], important[ob]);
+          MessageFormat.format(EDStatic.messages.functionOrderBySortAr[language], important[ob]);
       writer.write(
           widgets.comboBox(
               language,
@@ -8954,33 +9002,44 @@ public abstract class EDDTable extends EDD {
   public static void writeGeneralDapHtmlInstructions(
       int language, String tErddapUrl, Writer writer, boolean complete) throws Throwable {
 
-    String dapBase = EDStatic.EDDTableErddapUrlExample + dapProtocol + "/";
-    String datasetBase = dapBase + EDStatic.EDDTableIdExample;
+    String dapBase = EDStatic.messages.EDDTableErddapUrlExample + dapProtocol + "/";
+    String datasetBase = dapBase + EDStatic.messages.EDDTableIdExample;
 
     // all of the fullXxx examples are encoded for Html-Example or Html-Attribute-Encoded
     String fullDdsExample = datasetBase + ".dds";
 
     // variants encoded to be Html Examples
-    String fullValueExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDTableDataValueExampleHE;
-    String fullTimeExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDTableDataTimeExampleHE;
-    String fullTimeCsvExampleHE = datasetBase + ".csv?" + EDStatic.EDDTableDataTimeExampleHE;
-    String fullTimeMatExampleHE = datasetBase + ".mat?" + EDStatic.EDDTableGraphExampleHE;
-    String fullGraphExampleHE = datasetBase + ".png?" + EDStatic.EDDTableGraphExampleHE;
-    String fullGraphMAGExampleHE = datasetBase + ".graph?" + EDStatic.EDDTableGraphExampleHE;
-    String fullGraphDataExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDTableGraphExampleHE;
-    String fullMapExampleHE = datasetBase + ".png?" + EDStatic.EDDTableMapExampleHE;
-    String fullMapMAGExampleHE = datasetBase + ".graph?" + EDStatic.EDDTableMapExampleHE;
-    String fullMapDataExampleHE = datasetBase + ".htmlTable?" + EDStatic.EDDTableMapExampleHE;
+    String fullValueExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableDataValueExampleHE;
+    String fullTimeExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableDataTimeExampleHE;
+    String fullTimeCsvExampleHE =
+        datasetBase + ".csv?" + EDStatic.messages.EDDTableDataTimeExampleHE;
+    String fullTimeMatExampleHE = datasetBase + ".mat?" + EDStatic.messages.EDDTableGraphExampleHE;
+    String fullGraphExampleHE = datasetBase + ".png?" + EDStatic.messages.EDDTableGraphExampleHE;
+    String fullGraphMAGExampleHE =
+        datasetBase + ".graph?" + EDStatic.messages.EDDTableGraphExampleHE;
+    String fullGraphDataExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableGraphExampleHE;
+    String fullMapExampleHE = datasetBase + ".png?" + EDStatic.messages.EDDTableMapExampleHE;
+    String fullMapMAGExampleHE = datasetBase + ".graph?" + EDStatic.messages.EDDTableMapExampleHE;
+    String fullMapDataExampleHE =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableMapExampleHE;
 
     // variants encoded to be Html Attributes
-    String fullValueExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDTableDataValueExampleHA;
-    String fullTimeExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDTableDataTimeExampleHA;
-    String fullGraphExampleHA = datasetBase + ".png?" + EDStatic.EDDTableGraphExampleHA;
-    String fullGraphMAGExampleHA = datasetBase + ".graph?" + EDStatic.EDDTableGraphExampleHA;
-    String fullGraphDataExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDTableGraphExampleHA;
-    String fullMapExampleHA = datasetBase + ".png?" + EDStatic.EDDTableMapExampleHA;
-    String fullMapMAGExampleHA = datasetBase + ".graph?" + EDStatic.EDDTableMapExampleHA;
-    String fullMapDataExampleHA = datasetBase + ".htmlTable?" + EDStatic.EDDTableMapExampleHA;
+    String fullValueExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableDataValueExampleHA;
+    String fullTimeExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableDataTimeExampleHA;
+    String fullGraphExampleHA = datasetBase + ".png?" + EDStatic.messages.EDDTableGraphExampleHA;
+    String fullGraphMAGExampleHA =
+        datasetBase + ".graph?" + EDStatic.messages.EDDTableGraphExampleHA;
+    String fullGraphDataExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableGraphExampleHA;
+    String fullMapExampleHA = datasetBase + ".png?" + EDStatic.messages.EDDTableMapExampleHA;
+    String fullMapMAGExampleHA = datasetBase + ".graph?" + EDStatic.messages.EDDTableMapExampleHA;
+    String fullMapDataExampleHA =
+        datasetBase + ".htmlTable?" + EDStatic.messages.EDDTableMapExampleHA;
 
     GregorianCalendar daysAgo7Gc = Calendar2.newGCalendarZulu();
     daysAgo7Gc.add(Calendar2.DATE, -7);
@@ -8989,7 +9048,7 @@ public abstract class EDDTable extends EDD {
     writer.write(
         "<h2><a class=\"selfLink\" id=\"instructions\" href=\"#instructions\" rel=\"bookmark\"\n"
             + "      >"
-            + EDStatic.usingTabledapAr[language]
+            + EDStatic.messages.usingTabledapAr[language]
             + "</a></h2>\n"
             + longDapDescription(language, tErddapUrl)
             + "<p><strong>Tabledap request URLs must be in the form</strong>\n"
@@ -9042,7 +9101,7 @@ public abstract class EDDTable extends EDD {
             + "      identifies the name that ERDDAP\n"
             + "  assigned to the source website and dataset\n"
             + "  (for example, <kbd>"
-            + EDStatic.EDDTableIdExample
+            + EDStatic.messages.EDDTableIdExample
             + "</kbd>). You can see a list of\n"
             + "    <a rel=\"bookmark\" href=\""
             + EDStatic.phEncode(tErddapUrl + "/" + dapProtocol)
@@ -9090,14 +9149,14 @@ public abstract class EDDTable extends EDD {
                   : "<a rel=\"help\" href=\""
                       + XML.encodeAsHTMLAttribute(dataFileTypeInfo.get(i))
                       + "\">info"
-                      + EDStatic.externalLinkHtml(language, tErddapUrl)
+                      + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                       + "</a>")
               + "</td>\n"
               + "      <td class=\"N\"><a rel=\"bookmark\" href=\""
               + datasetBase
               + dataFileTypeNames.get(i)
               + "?"
-              + EDStatic.EDDTableDataTimeExampleHA
+              + EDStatic.messages.EDDTableDataTimeExampleHA
               + "\">example</a></td>\n"
               + "    </tr>\n");
     }
@@ -9114,10 +9173,10 @@ public abstract class EDDTable extends EDD {
 
             // ArcGIS
             "<p><strong><a rel=\"bookmark\" href=\"https://www.esri.com/en-us/arcgis/about-arcgis/overview\">ArcGIS"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  <a rel=\"help\" href=\"https://desktop.arcgis.com/en/arcmap/latest/manage-data/tables/adding-an-ascii-or-text-file-table.htm\">.esriCsv"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "  - <a class=\"selfLink\" id=\"ArcGIS\" href=\"#ArcGIS\" rel=\"bookmark\">ArcGIS</a>\n"
             + "      is a family of Geographical Information Systems (GIS) products from ESRI:\n"
@@ -9149,13 +9208,13 @@ public abstract class EDDTable extends EDD {
             + "  (These instructions are a modified version of\n"
             + "    <a rel=\"help\" href=\"https://desktop.arcgis.com/en/arcmap/latest/manage-data/tables/adding-an-ascii-or-text-file-table.htm\"\n"
             + "      >ESRI's instructions"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.)\n"
             + "\n"
             +
             // Ferret
             "  <p><strong><a rel=\"bookmark\" href=\"https://ferret.pmel.noaa.gov/Ferret/\">Ferret"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> \n"
             + "    <a class=\"selfLink\" id=\"Ferret\" href=\"#Ferret\" rel=\"bookmark\">is</a>\n"
             + "    a free program for visualizing and analyzing large and complex\n"
@@ -9177,21 +9236,21 @@ public abstract class EDDTable extends EDD {
             +
             // IDL
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.harrisgeospatial.com/Software-Technology/IDL/\">IDL"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> - \n"
             + "    <a class=\"selfLink\" id=\"IDL\" href=\"#IDL\" rel=\"bookmark\">IDL</a>\n"
             + "    is a commercial scientific data visualization program. To get data from\n"
             + "  ERDDAP into IDL, first use ERDDAP to select a subset of data and download a .nc file.\n"
             + "  Then, use these\n"
             + "    <a rel=\"help\" href=\"https://northstar-www.dartmouth.edu/doc/idl/html_6.2/Using_Macros_to_Import_HDF_Files.html\">instructions"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    to import the data from the .nc file into IDL.\n"
             + "\n"
             +
             // json
             "  <p><strong><a rel=\"help\" href=\"https://www.json.org/\">JSON .json"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"json\" href=\"#json\" rel=\"bookmark\">files</a>\n"
             + "    are widely used to transfer data to JavaScript scripts running on web pages.\n"
@@ -9229,13 +9288,13 @@ public abstract class EDDTable extends EDD {
             +
             // jsonp
             "  <p><strong><a rel=\"help\" href=\"https://niryariv.wordpress.com/2009/05/05/jsonp-quickly/\">JSONP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    (from <a href=\"https://www.json.org/\">.json"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and\n"
             + "    <a rel=\"help\" href=\"http://wiki.geojson.org/Main_Page\">.geoJson"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>)</strong> -\n"
             + "  <a class=\"selfLink\" id=\"jsonp\" href=\"#jsonp\" rel=\"bookmark\">Jsonp</a>\n"
             + "       is an easy way for a JavaScript script on a web\n"
@@ -9253,16 +9312,16 @@ public abstract class EDDTable extends EDD {
             + "  script via that JavaScript function.\n"
             + "  Here is an example using \n"
             + "  <a rel=\"bookmark\" href=\"https://jsfiddle.net/jpatterson/0ycu1zjy/\">jsonp and Javascript with ERDDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> (thanks to Jenn Patterson Sevadjian of PolarWatch).\n"
             + "\n"
             +
             // matlab
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.mathworks.com/products/matlab/\">MATLAB"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "     <a rel=\"help\" href=\"https://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf\">.mat"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "   - <a class=\"selfLink\" id=\"matlab\" href=\"#matlab\" rel=\"bookmark\">Matlab</a>\n"
             + "      users can use tabledap's .mat file type to download data from within\n"
@@ -9273,15 +9332,15 @@ public abstract class EDDTable extends EDD {
             + "  (You may need to <a rel=\"help\" href=\"#PercentEncoded\">percent encode</a> the query part of the URL.)\n"
             + "  The data will be in a MATLAB structure. The structure's name will be the datasetID\n"
             + "  (for example, <kbd>"
-            + EDStatic.EDDTableIdExample
+            + EDStatic.messages.EDDTableIdExample
             + "</kbd>). \n"
             + "  The structure's internal variables will be column vectors with the same names\n"
             + "  as in ERDDAP \n"
             + "    (for example, use <kbd>fieldnames("
-            + EDStatic.EDDTableIdExample
+            + EDStatic.messages.EDDTableIdExample
             + ")</kbd>). \n"
             + "  You can then make a scatterplot of any two columns. For example:<pre>\n"
-            + EDStatic.EDDTableMatlabPlotExample
+            + EDStatic.messages.EDDTableMatlabPlotExample
             + "</pre>\n"
             + "  <p>ERDDAP stores datetime values in .mat files as \"seconds since 1970-01-01T00:00:00Z\".\n"
             + "  To display one of these values as a String in Matlab, you can use, e.g.,\n"
@@ -9299,10 +9358,10 @@ public abstract class EDDTable extends EDD {
             +
             // nc
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\">NetCDF"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a rel=\"help\" href=\"https://github.com/Unidata/netcdf-c/blob/master/docs/file_format_specifications.md\">.nc"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "     - <a class=\"selfLink\" id=\"nc\" href=\"#nc\" rel=\"bookmark\">Requests</a>\n"
             + "      for .nc files will always return the data in a table-like, NetCDF-3,\n"
@@ -9362,17 +9421,17 @@ public abstract class EDDTable extends EDD {
             "  <p><a class=\"selfLink\" id=\"ncCF\" href=\"#ncCF\" rel=\"bookmark\"><strong>.ncCF</strong></a>\n"
             + "     - Requests for a .ncCF file will return a version 3, 32-bit,\n"
             + "  <a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\">NetCDF .nc"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  file with the\n"
             + "  Contiguous Ragged Array Representation associated with the dataset's cdm_data_type,\n"
             + "  as defined in the\n"
             + "    <a rel=\"help\" href=\"https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html\">CF"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a rel=\"help\" href=\"https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#discrete-sampling-geometries\"\n"
             + "      >Discrete Geometries"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> conventions\n"
             + "  (which were previously named \"CF Point Observation Conventions\").\n"
             + "  <ul>\n"
@@ -9396,7 +9455,7 @@ public abstract class EDDTable extends EDD {
             + "      for .ncCFHeader files will return the header information (text) that\n"
             + "  would be generated if you used\n"
             + "    <a rel=\"help\" href=\"https://linux.die.net/man/1/ncdump\">ncdump -h <i>fileName</i>"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    on the corresponding .ncCF file.\n"
             + "\n"
@@ -9405,20 +9464,20 @@ public abstract class EDDTable extends EDD {
             "  <p><a class=\"selfLink\" id=\"ncCFMA\" href=\"#ncCFMA\" rel=\"bookmark\"><strong>.ncCFMA</strong></a>\n"
             + "     - Requests for a .ncCFMA file will return a version 3, 32-bit,\n"
             + "    <a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\">NetCDF .nc"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> file\n"
             + "   with the Complete or Incomplete, depending on the data, Multidimensional Array Representation\n"
             + "   associated with the dataset's cdm_data_type, as defined in the\n"
             + "     <a rel=\"help\" href=\"https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html\">CF"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "     <a rel=\"help\" href=\"https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#discrete-sampling-geometries\"\n"
             + "      >Discrete Sampling Geometries"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "   conventions, which were previously named \"CF Point Observation Conventions\".\n"
             + "   This is the file type used by the <a rel=\"help\" href=\"https://www.ncei.noaa.gov/netcdf-templates\">NODC Templates"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "   A request will succeed only if the dataset has a cdm_data_type other than \"Other\"\n"
             + "   and if the request includes at least one data variable (not just the outer, descriptive variables).\n"
@@ -9432,7 +9491,7 @@ public abstract class EDDTable extends EDD {
             + "      for .ncCFMAHeader files will return the header information (text) that\n"
             + "  would be generated if you used\n"
             + "    <a rel=\"help\" href=\"https://linux.die.net/man/1/ncdump\">ncdump -h <i>fileName</i>"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    on the corresponding .ncCFMA file.\n"
             + "\n"
@@ -9440,7 +9499,7 @@ public abstract class EDDTable extends EDD {
             // netcdfjava
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\"\n"
             + "      >NetCDF-Java, NetCDF-C, NetCDF-Fortran, and NetCDF-Perl"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "  <a class=\"selfLink\" id=\"netcdfjava\" href=\"#netcdfjava\" rel=\"bookmark\">-</a>\n"
             + "  Don't try to access an ERDDAP tabledap dataset URL directly with a NetCDF library or tool\n"
@@ -9473,11 +9532,11 @@ public abstract class EDDTable extends EDD {
             +
             // odv
             "  <p><strong><a rel=\"bookmark\" href=\"https://odv.awi.de/\">Ocean Data View"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> .odvTxt</strong>\n"
             + "   - <a class=\"selfLink\" id=\"ODV\" href=\"#ODV\" rel=\"bookmark\">ODV</a> users can download data in a\n"
             + "    <a rel=\"help\" href=\"https://odv.awi.de/en/documentation/\">ODV Generic Spreadsheet Format .txt file"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  by requesting tabledap's .odvTxt fileType.\n"
             + "  The selected data MUST include longitude, latitude, and time variables.\n"
@@ -9499,17 +9558,17 @@ public abstract class EDDTable extends EDD {
             "  <p><strong><a class=\"selfLink\" id=\"opendapLibraries\" href=\"#opendapLibraries\" rel=\"bookmark\"\n"
             + "      >OPeNDAP Libraries</a></strong> - Although ERDDAP is an\n"
             + "    <a rel=\"bookmark\" href=\"https://www.opendap.org/\">OPeNDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>-compatible data server,\n"
             + "    you can't use\n"
             + "  most OPeNDAP client libraries, including\n"
             + "  <a rel=\"bookmark\" href=\"https://www.unidata.ucar.edu/software/netcdf/\"\n"
             + "      >NetCDF-Java, NetCDF-C, NetCDF-Fortran, NetCDF-Perl"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  or\n"
             + "  <a rel=\"bookmark\" href=\"https://ferret.pmel.noaa.gov/Ferret/\">Ferret"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  to get data directly from an ERDDAP tabledap dataset because those libraries don't\n"
             + "  support the OPeNDAP Selection constraints that tabledap datasets use for requesting\n"
@@ -9517,7 +9576,7 @@ public abstract class EDDTable extends EDD {
             + "  (But see this <a href=\"#netcdfjava\">other approach</a> that works with NetCDF libraries.)\n"
             + "  But you can use the <a href=\"#PydapClient\">Pydap Client</a> or\n"
             + "  <a rel=\"bookmark\" href=\"https://www.opendap.org/deprecated-software/java-dap\">Java-DAP2"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "  because they both support Selection\n"
             + "  constraints.  With both the Pydap Client and Java-DAP2, when creating the initial\n"
@@ -9536,17 +9595,17 @@ public abstract class EDDTable extends EDD {
             +
             // Pydap Client
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.pydap.org/en/latest/client.html\">Pydap Client"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"PydapClient\" href=\"#PydapClient\" rel=\"bookmark\">users</a>\n"
             + "    can access tabledap datasets via ERDDAP's standard OPeNDAP services.\n"
             + "  See the\n"
             + "    <a rel=\"help\" href=\"https://www.pydap.org/en/latest/client.html#accessing-sequential-data\"\n"
             + "      >Pydap Client instructions for accessing sequential data"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  Note that the name of a dataset in tabledap will always be a single word, e.g.,\n"
-            + EDStatic.EDDTableIdExample
+            + EDStatic.messages.EDDTableIdExample
             + "\n"
             + "  in the OPeNDAP dataset URL\n"
             + "  <br><kbd>"
@@ -9562,7 +9621,7 @@ public abstract class EDDTable extends EDD {
             +
             // Python
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.python.org\">Python"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong>\n"
             + "    <a class=\"selfLink\" id=\"Python\" href=\"#Python\" rel=\"bookmark\">is</a>\n"
             + "    a widely-used computer language that is very popular among scientists.\n"
@@ -9581,11 +9640,11 @@ public abstract class EDDTable extends EDD {
             +
             // erddapy
             "  <p><a rel=\"bookmark\" href=\"https://github.com/ioos/erddapy#--erddapy\">erddapy"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "    <a class=\"selfLink\" id=\"erddapy\" href=\"#erddapy\" rel=\"bookmark\">(ERDDAP + Python, by Filipe Pires Alvarenga Fernandes)</a> and\n"
             + "  <br><a rel=\"bookmark\" href=\"https://github.com/hmedrano/erddap-python\">erddap-python"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> (by Favio Medrano)\n"
             + "  <br>are Python libraries that \"take advantage of ERDDAP’s RESTful web services and create the\n"
             + "    ERDDAP URL for any request like searching for datasets, acquiring metadata, downloading data, etc.\"\n"
@@ -9595,7 +9654,7 @@ public abstract class EDDTable extends EDD {
             //
             // Python/Jupyter Notebook
             "  <p>\"<a rel=\"bookmark\" href=\"https://jupyter.org/\">Jupyter Notebook"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "      <a class=\"selfLink\" id=\"JupyterNotebook\" href=\"#JupyterNotebook\" rel=\"bookmark\">is</a>\n"
             + "      an open-source web application that\n"
@@ -9606,18 +9665,18 @@ public abstract class EDDTable extends EDD {
             + "    <a rel=\"bookmark\"\n"
             + "      href=\"https://github.com/rsignell-usgs/notebook/blob/master/ERDDAP/ERDDAP_advanced_search_test.ipynb/\"\n"
             + "      >ERDDAP Advanced Search Test"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and\n"
             + "    <a rel=\"bookmark\" \n"
             + "      href=\"https://github.com/rsignell-usgs/notebook/blob/master/ERDDAP/ERDDAP_timing.ipynb\"\n"
             + "      >ERDDAP Timing"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "    Thanks to Rich Signell.\n"
             +
             // R
             "  <p><strong><a rel=\"bookmark\" href=\"https://www.r-project.org/\">R Statistical Package"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> -\n"
             + "    <a class=\"selfLink\" id=\"R\" href=\"#R\" rel=\"bookmark\">R</a>\n"
             + "    is an open source statistical package for many operating systems.\n"
@@ -9631,13 +9690,13 @@ public abstract class EDDTable extends EDD {
             + "  (You may need to <a rel=\"help\" href=\"#PercentEncoded\">percent encode</a> the query part of the URL.)\n"
             + "  <p>There are third-party R packages designed to make it easier to work with ERDDAP from within R:\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/rerddap/index.html\">rerddap"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/rerddapXtracto/index.html\">rerddapXtracto"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>, and\n"
             + "    <a rel=\"bookmark\" href=\"https://cran.r-project.org/web/packages/plotdap/index.html\">plotdap"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  Thanks to \n"
             + "  <a rel=\"bookmark\" href=\"https://ropensci.org/\">rOpenSci<img \n"
@@ -9649,14 +9708,14 @@ public abstract class EDDTable extends EDD {
             +
             // .wav
             "  <p><strong><a rel=\"bookmark\" href=\"https://en.wikipedia.org/wiki/WAV\">.wav"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></strong> -\n"
             + "    <a class=\"selfLink\" id=\"wav\" href=\"#wav\" rel=\"bookmark\">ERDDAP can return data in .wav files,</a>\n"
             + "    which are uncompressed audio files.\n"
             + "  <ul>\n"
             + "  <li>You can save any numeric data in .wav files, but this file format is clearly intended to be used\n"
             + "    with <a rel=\"bookmark\" href=\"https://en.wikipedia.org/wiki/Pulse-code_modulation\">PCM"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> digitized sound waves.\n"
             + "    We do not recommend saving other types of data in .wav files.\n"
             + "  <li>All of the data variables you select to save in a .wav file must have the same data type, e.g., int.\n"
@@ -9723,7 +9782,7 @@ public abstract class EDDTable extends EDD {
                   : "<a rel=\"help\" href=\""
                       + imageFileTypeInfo.get(i)
                       + "\">info"
-                      + EDStatic.externalLinkHtml(language, tErddapUrl)
+                      + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
                       + "</a>")
               + "</td>\n"
               + // must be mapExample below because kml doesn't work with graphExample
@@ -9731,7 +9790,7 @@ public abstract class EDDTable extends EDD {
               + datasetBase
               + imageFileTypeNames.get(i)
               + "?"
-              + EDStatic.EDDTableMapExampleHA
+              + EDStatic.messages.EDDTableMapExampleHA
               + "\">example</a></td>\n"
               + "    </tr>\n");
     }
@@ -9779,7 +9838,7 @@ public abstract class EDDTable extends EDD {
             + "Or, if you are comfortable running command line programs\n"
             + "(from a Linux or Windows command line, or a Mac OS Terminal), you can use curl (or a similar program like\n"
             + "  <a rel=\"bookmark\" href=\"https://www.gnu.org/software/wget/\">wget"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>)\n"
             + "to save results files from ERDDAP into files on your hard drive,\n"
             + "without using a browser or writing a computer program or script.\n"
@@ -9788,7 +9847,7 @@ public abstract class EDDTable extends EDD {
             + "<br>On Mac OS X, to get to a command line, use \"Finder : Go : Utilities : Terminal\".\n"
             + "<br>On Windows, you need to\n"
             + "  <a rel=\"bookmark\" href=\"https://curl.haxx.se/download.html\">download curl"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  (the \"Windows 64 - binary, the curl project\" variant worked for me on Windows 10)\n"
             + "  and install it.\n"
@@ -9797,10 +9856,10 @@ public abstract class EDDTable extends EDD {
             + "<br><strong>Please be kind to other ERDDAP users: run just one script or curl command at a time.</strong>\n"
             + "<br>Instructions for using curl are on the \n"
             + "<a rel=\"help\" href=\"https://curl.haxx.se/download.html\">curl man page"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and in this\n"
             + "<a rel=\"help\" href=\"https://curl.haxx.se/docs/httpscripting.html\">curl tutorial"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "<br>But here is a quick tutorial related to using curl with ERDDAP:\n"
             + "<ul>\n"
@@ -9815,7 +9874,7 @@ public abstract class EDDTable extends EDD {
             + "  <a class=\"N selfLink\" id=\"PercentEncoded\" href=\"#PercentEncoded\" rel=\"bookmark\"\n"
             + "  >In curl, as in many other programs, the query part of the erddapUrl must be</a>\n"
             + "  <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.  To do this, you need to convert\n"
             + "  special characters (other than the initial '&amp;' and the main '=') in all constraints\n"
             + "  into the form %HH, where HH is the 2 digit hexadecimal value of the character.\n"
@@ -9833,22 +9892,22 @@ public abstract class EDDTable extends EDD {
             + "  Programming languages have tools to do this (for example, see Java's\n"
             + "  <a rel=\"help\" href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URLEncoder.html\"\n"
             + "      >java.net.URLEncoder"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "     and JavaScript's\n"
             + "<a rel=\"help\" href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent\"\n"
             + "      >encodeURIComponent()"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>) and there are\n"
             + "  <a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "  <br>&nbsp;\n"
             + "<li>To download and save many files in one step, use curl with the globbing feature enabled:\n"
             + "  <br><kbd>curl --compressed \"<i>erddapUrl</i>\" -o <i>fileDir/fileName#1.ext</i></kbd>\n"
             + "  <br>Since the globbing feature treats the characters [, ], {, and } as special, you must also\n"
             + "  <br><a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encode"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> \n"
             + "them in the erddapURL as &#37;5B, &#37;5D, &#37;7B, &#37;7D, respectively.\n"
             + "  Fortunately, these are rare in tabledap URLs.\n"
@@ -9885,26 +9944,27 @@ public abstract class EDDTable extends EDD {
             + "  It specifies the subset of data that you want to receive.\n"
             + "  In tabledap, it is an \n"
             + "  <a rel=\"bookmark\" href=\"https://www.opendap.org/\">OPeNDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> "
             + "  <a rel=\"help\" href=\"https://www.opendap.org/pdf/ESE-RFC-004v1.2.pdf\">DAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "  <a rel=\"help\" href=\"https://docs.opendap.org/index.php/UserGuideOPeNDAPMessages#Constraint_Expressions\"\n"
             + "      >selection constraint"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> query"
             + "  in the form: <kbd>{<i>resultsVariables</i>}{<i>constraints</i>}</kbd> .\n "
             + "  For example,\n"
             + "  <br><kbd>"
             + XML.encodeAsHTML(
-                EDStatic.EDDTableVariablesExample + EDStatic.EDDTableConstraintsExample)
+                EDStatic.messages.EDDTableVariablesExample
+                    + EDStatic.messages.EDDTableConstraintsExample)
             + "</kbd>\n"
             + "  <ul>\n"
             + "  <li><i><strong>resultsVariables</strong></i> is an optional comma-separated list of variables\n"
             + "        (for example,\n"
             + "    <br><kbd>"
-            + XML.encodeAsHTML(EDStatic.EDDTableVariablesExample)
+            + XML.encodeAsHTML(EDStatic.messages.EDDTableVariablesExample)
             + "</kbd>).\n"
             + "    <br>For each variable in resultsVariables, there will be a column in the \n"
             + "    results table, in the same order.\n"
@@ -9913,7 +9973,7 @@ public abstract class EDDTable extends EDD {
             + "  <li><i><strong>constraints</strong></i> is an optional list of constraints, each preceded by &amp;\n"
             + "    (for example,\n"
             + "    <br><kbd>"
-            + XML.encodeAsHTML(EDStatic.EDDTableConstraintsExample)
+            + XML.encodeAsHTML(EDStatic.messages.EDDTableConstraintsExample)
             + "</kbd>).\n"
             + "    <ul>\n"
             + "    <li>The constraints determine which rows of data from the original table\n"
@@ -9936,14 +9996,14 @@ public abstract class EDDTable extends EDD {
             + "      may result in a very large results table.\n"
             + "    <li>tabledap constraints are consistent with \n"
             + "      <a rel=\"bookmark\" href=\"https://www.opendap.org/\">OPeNDAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> "
             + "      <a rel=\"help\" href=\"https://www.opendap.org/pdf/ESE-RFC-004v1.2.pdf\">DAP"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "      <a rel=\"help\" href=\"https://docs.opendap.org/index.php/UserGuideOPeNDAPMessages#Constraint_Expressions\"\n"
             + "      >selection constraints"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "      but with a few additional features.\n"
             + "    <li>Each constraint is in the form <kbd><i>VariableOperatorValue</i></kbd>\n"
@@ -9968,7 +10028,7 @@ public abstract class EDDTable extends EDD {
             + "    <li><a class=\"selfLink\" id=\"PercentEncode\" href=\"#PercentEncode\" rel=\"bookmark\">For</a>\n"
             + "         all constraints, the value part of the <kbd><i>VariableOperatorValue</i></kbd>\n"
             + "        MUST be <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "        special characters in the query values (the parts after the '=' signs) are encoded as %HH, where\n"
             + "        HH is the 2 digit hexadecimal value of the character (for example, ' ' is replaced with \"%20\").\n"
@@ -9978,14 +10038,14 @@ public abstract class EDDTable extends EDD {
             + "        percent encoding itself.  If so, you need to encode all characters other than A-Za-z0-9_-!.~'()*\n"
             + "        in all query values. Programming languages have tools to do this (for example, see Java's\n"
             + "<a rel=\"help\" href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/net/URLEncoder.html\">java.net.URLEncoder"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> and JavaScript's\n"
             + "<a rel=\"help\" href=\"https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent\"\n"
             + "        >encodeURIComponent()"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>) and there are\n"
             + "       <a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "      <li><a class=\"selfLink\" id=\"comparingFloats\" href=\"#comparingFloats\" rel=\"bookmark\">WARNING:</a>\n"
             + "          Numeric queries involving =, !=, &lt;=, or &gt;= may not work as desired with\n"
@@ -9994,13 +10054,13 @@ public abstract class EDDTable extends EDD {
             + "          floating point numbers are "
             + "          <a rel=\"help\" href=\"https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/\"\n"
             + "          >not represented exactly within computers"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "          When ERDDAP performs these tests, it allows for minor variations and tries\n"
             + "          to avoid the problem. But it is possible that some datasets will still\n"
             + "          have problems with these queries and return unexpected and incorrect results.\n"
             + "      <li><a rel=\"help\" href=\"https://en.wikipedia.org/wiki/NaN\">NaN (Not-a-Number)"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> -\n"
             + "          <a class=\"selfLink\" id=\"NaN\" href=\"#NaN\" rel=\"bookmark\">Many</a>\n"
             + "          numeric variables have an attribute which identifies a\n"
@@ -10030,17 +10090,17 @@ public abstract class EDDTable extends EDD {
             + "          tests if the value from the variable on the left matches the \n"
             + "          <a rel=\"help\" href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\"\n"
             + "          >regular expression"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "         on the right.\n"
             + "        <ul>\n"
             + "        <li>tabledap uses the same \n"
             + "          <a rel=\"help\" href=\"https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html\"\n"
             + "          >regular expression syntax"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "             (<a rel=\"help\" href=\"https://www.vogella.com/tutorials/JavaRegularExpressions/article.html\">tutorial"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>) as is used by Java.\n"
             + "        <li>A common use of regular expressions is to provide the equivalent of an OR constraint,\n"
             + "          which DAP doesn't support.\n"
@@ -10092,7 +10152,7 @@ public abstract class EDDTable extends EDD {
             + "      <br>The more human-oriented fileTypes (notably, .csv, .tsv, .htmlTable, .odvTxt, and .xhtml)\n"
             + "      display date/time values as \n"
             + "        <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601:2004 \"extended\" date/time strings"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "      (e.g., <kbd>2002-08-03T12:30:00Z</kbd>, but some time variables in some datasets include\n"
             + "      milliseconds, e.g., <kbd>2002-08-03T12:30:00.123Z</kbd>).\n"
@@ -10474,12 +10534,12 @@ public abstract class EDDTable extends EDD {
             + "      <br>If you add <kbd>&amp;units(\"UDUNITS\")</kbd> to the end of a query, the units will be described\n"
             + "      via the\n"
             + "        <a rel=\"help\" href=\"https://www.unidata.ucar.edu/software/udunits/\">UDUNITS"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> standard (for example, <kbd>degree_C</kbd>).\n"
             + "      <br>If you add <kbd>&amp;units(\"UCUM\")</kbd> to the end of a query, the units will be described\n"
             + "      via the\n"
             + "        <a rel=\"help\" href=\"https://unitsofmeasure.org/ucum.html\">UCUM"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> standard (for example, <kbd>Cel</kbd>).\n"
             + "      <br>On this ERDDAP, the default for most/all datasets is "
             + EDStatic.units_standard
@@ -10789,7 +10849,7 @@ public abstract class EDDTable extends EDD {
             + "    <br>&nbsp;\n"
             + "  </ul>\n"
             + "<li>"
-            + EDStatic.acceptEncodingHtml(language, "h3", tErddapUrl)
+            + EDStatic.messages.acceptEncodingHtml(language, "h3", tErddapUrl)
             + "    <br>&nbsp;\n"
             + "<li><a class=\"selfLink\" id=\"citeDataset\" href=\"#citeDataset\" rel=\"bookmark\"\n"
             + "      ><strong>How to Cite a Dataset in a Paper</strong></a>\n"
@@ -10945,7 +11005,7 @@ public abstract class EDDTable extends EDD {
 
     if (accessibleViaMAG().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaMAG());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaMAG());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
     if (userDapQuery == null) userDapQuery = "";
@@ -11027,7 +11087,7 @@ public abstract class EDDTable extends EDD {
                 + "&nbsp;=&nbsp;"
                 + tMin
                 + "&nbsp;"
-                + EDStatic.magRangeToAr[language]
+                + EDStatic.messages.magRangeToAr[language]
                 + "&nbsp;"
                 + tMax
                 + (llati == 0 ? "&deg;E" : llati == 1 ? "&deg;N" : llati == 2 ? "m" : "")
@@ -11039,7 +11099,7 @@ public abstract class EDDTable extends EDD {
       llatRange.setLength(llatRange.length() - 2); // remove last ", "
       otherRows =
           "  <tr><td>"
-              + EDStatic.magRangeAr[language]
+              + EDStatic.messages.magRangeAr[language]
               + ":&nbsp;</td>"
               + "<td>"
               + llatRange
@@ -11052,7 +11112,8 @@ public abstract class EDDTable extends EDD {
     try {
       HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
       writer.write(
-          EDStatic.startHeadHtml(language, tErddapUrl, title() + " - " + EDStatic.magAr[language]));
+          EDStatic.startHeadHtml(
+              language, tErddapUrl, title() + " - " + EDStatic.messages.magAr[language]));
       writer.write("\n" + rssHeadLink());
       writer.write("\n</head>\n");
       writer.write(
@@ -11072,9 +11133,9 @@ public abstract class EDDTable extends EDD {
               language,
               loggedInAs,
               "tabledap",
-              EDStatic.magAr[language],
+              EDStatic.messages.magAr[language],
               "<div class=\"standard_max_width\">"
-                  + EDStatic.magTableTooltipAr[language]
+                  + EDStatic.messages.magTableTooltipAr[language]
                   + "</div>"));
       writeHtmlDatasetInfo(
           language, loggedInAs, writer, true, true, true, false, userDapQuery, otherRows);
@@ -11524,7 +11585,7 @@ public abstract class EDDTable extends EDD {
       writer.write(
           "<tr>\n"
               + "  <td><strong>"
-              + EDStatic.magGraphTypeAr[language]
+              + EDStatic.messages.magGraphTypeAr[language]
               + ":&nbsp;</strong>"
               + "  </td>\n"
               + "  <td>\n");
@@ -11548,7 +11609,7 @@ public abstract class EDDTable extends EDD {
                   language,
                   loggedInAs,
                   "<div class=\"standard_max_width\">"
-                      + EDStatic.magGraphTypeTooltipTableAr[language]
+                      + EDStatic.messages.magGraphTypeTooltipTableAr[language]
                       + "</div>")
               + "  </td>\n"
               + "</tr>\n");
@@ -11583,10 +11644,14 @@ public abstract class EDDTable extends EDD {
         nVars = 2;
         variablesShowPM = 1;
         varLabel =
-            new String[] {EDStatic.magAxisXAr[language] + ":", EDStatic.magAxisYAr[language] + ":"};
+            new String[] {
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":"
+            };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language], EDStatic.magAxisHelpGraphYAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+              EDStatic.messages.magAxisHelpGraphYAr[language]
             };
         varOptions = new String[][] {numDvNames, numDvNames};
         if (useDefaultVars || resultsVariables.size() < 2) {
@@ -11610,15 +11675,15 @@ public abstract class EDDTable extends EDD {
         variablesShowPM = 2;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisYAr[language] + ":",
-              EDStatic.magAxisColorAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":",
+              EDStatic.messages.magAxisColorAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language],
-              EDStatic.magAxisHelpGraphYAr[language],
-              EDStatic.magAxisHelpMarkerColorAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+              EDStatic.messages.magAxisHelpGraphYAr[language],
+              EDStatic.messages.magAxisHelpMarkerColorAr[language]
             };
         varOptions = new String[][] {numDvNames, numDvNames, numDvNames0};
         if (useDefaultVars || resultsVariables.size() < 2) {
@@ -11643,15 +11708,15 @@ public abstract class EDDTable extends EDD {
         variablesShowPM = 1;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisStickXAr[language] + ":",
-              EDStatic.magAxisStickYAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisStickXAr[language] + ":",
+              EDStatic.messages.magAxisStickYAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpGraphXAr[language],
-              EDStatic.magAxisHelpStickXAr[language],
-              EDStatic.magAxisHelpStickYAr[language]
+              EDStatic.messages.magAxisHelpGraphXAr[language],
+              EDStatic.messages.magAxisHelpStickXAr[language],
+              EDStatic.messages.magAxisHelpStickYAr[language]
             };
         varOptions = new String[][] {numDvNames, numDvNames, numDvNames};
         if (useDefaultVars || resultsVariables.size() < 3) {
@@ -11666,15 +11731,17 @@ public abstract class EDDTable extends EDD {
         variablesShowPM = 100;
         varLabel =
             new String[] {
-              EDStatic.magAxisXAr[language] + ":",
-              EDStatic.magAxisYAr[language] + ":",
-              EDStatic.magAxisVectorXAr[language] + ":",
-              EDStatic.magAxisVectorYAr[language] + ":"
+              EDStatic.messages.magAxisXAr[language] + ":",
+              EDStatic.messages.magAxisYAr[language] + ":",
+              EDStatic.messages.magAxisVectorXAr[language] + ":",
+              EDStatic.messages.magAxisVectorYAr[language] + ":"
             };
         varHelp =
             new String[] {
-              EDStatic.magAxisHelpMapXAr[language], EDStatic.magAxisHelpMapYAr[language],
-              EDStatic.magAxisHelpVectorXAr[language], EDStatic.magAxisHelpVectorYAr[language]
+              EDStatic.messages.magAxisHelpMapXAr[language],
+                  EDStatic.messages.magAxisHelpMapYAr[language],
+              EDStatic.messages.magAxisHelpVectorXAr[language],
+                  EDStatic.messages.magAxisHelpVectorYAr[language]
             };
         varOptions =
             new String[][] {
@@ -11687,7 +11754,9 @@ public abstract class EDDTable extends EDD {
           resultsVariables.add(nonAxis[sameUnits1]);
           resultsVariables.add(nonAxis[sameUnits1 + 1]);
         }
-      } else throw new SimpleException(EDStatic.errorInternalAr[0] + "No drawXxx value was set.");
+      } else
+        throw new SimpleException(
+            EDStatic.messages.errorInternalAr[0] + "No drawXxx value was set.");
       if (debugMode) String2.log("respondToGraphQuery 4");
       if (reallyVerbose)
         String2.log("post set draw-related; resultsVariables=" + resultsVariables.toString());
@@ -11713,7 +11782,7 @@ public abstract class EDDTable extends EDD {
         writer.write(
             widgets.select(
                 paramName,
-                MessageFormat.format(EDStatic.magAxisVarHelpAr[language], varHelp[v]),
+                MessageFormat.format(EDStatic.messages.magAxisVarHelpAr[language], varHelp[v]),
                 v >= variablesShowPM ? HtmlWidgets.BUTTONS_1 : 1, // was 1
                 tDvNames,
                 vi,
@@ -11740,29 +11809,29 @@ public abstract class EDDTable extends EDD {
       writer.write(
           "<tr>\n"
               + "  <th>"
-              + EDStatic.EDDTableConstraintsAr[language]
+              + EDStatic.messages.EDDTableConstraintsAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
-                  language, loggedInAs, EDStatic.magConstraintHelpAr[language])
+                  language, loggedInAs, EDStatic.messages.magConstraintHelpAr[language])
               + "</th>\n"
               + "  <th style=\"text-align:center;\" colspan=\"2\">"
-              + EDStatic.EDDTableOptConstraint1HtmlAr[language]
+              + EDStatic.messages.EDDTableOptConstraint1HtmlAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
                   "<div class=\"narrow_max_width\">"
-                      + EDStatic.EDDTableConstraintTooltipAr[language]
+                      + EDStatic.messages.EDDTableConstraintTooltipAr[language]
                       + "</div>")
               + "</th>\n"
               + "  <th style=\"text-align:center;\" colspan=\"2\">"
-              + EDStatic.EDDTableOptConstraint2HtmlAr[language]
+              + EDStatic.messages.EDDTableOptConstraint2HtmlAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
                   language,
                   loggedInAs,
                   "<div class=\"narrow_max_width\">"
-                      + EDStatic.EDDTableConstraintTooltipAr[language]
+                      + EDStatic.messages.EDDTableConstraintTooltipAr[language]
                       + "</div>")
               + "</th>\n"
               + "</tr>\n");
@@ -11924,7 +11993,7 @@ public abstract class EDDTable extends EDD {
             writer.write(
                 widgets.select(
                     "cVar" + cv,
-                    EDStatic.EDDTableOptConstraintVarAr[language],
+                    EDStatic.messages.EDDTableOptConstraintVarAr[language],
                     1,
                     dvNames0,
                     conVar[cv],
@@ -11934,13 +12003,13 @@ public abstract class EDDTable extends EDD {
 
           // make the constraintTooltip
           // ConstraintHtml below is worded in generic way so works with number and time, too
-          String constraintTooltip = EDStatic.EDDTableStringConstraintTooltipAr[language];
+          String constraintTooltip = EDStatic.messages.EDDTableStringConstraintTooltipAr[language];
           // String2.log("cv=" + cv + " conVar[cv]=" + conVar[cv]);
           if (conEdv != null && conEdv.destinationMinString().length() > 0) {
             constraintTooltip +=
                 "<br>&nbsp;<br>"
                     + MessageFormat.format(
-                        EDStatic.rangesFromToAr[language],
+                        EDStatic.messages.rangesFromToAr[language],
                         conEdv.destinationName(),
                         conEdv.destinationMinString(),
                         conEdv.destinationMaxString().length() > 0
@@ -11954,7 +12023,7 @@ public abstract class EDDTable extends EDD {
           writer.write(
               widgets.select(
                   "cOp" + cv + ab,
-                  EDStatic.EDDTableSelectAnOperatorAr[language],
+                  EDStatic.messages.EDDTableSelectAnOperatorAr[language],
                   1,
                   OPERATORS,
                   PPE_OPERATORS,
@@ -12026,7 +12095,7 @@ public abstract class EDDTable extends EDD {
               widgets.select(
                   "dis" + cv,
                   "<div class=\"narrow_max_width\">"
-                      + EDStatic.EDDTableSelectConstraintTooltipAr[language]
+                      + EDStatic.messages.EDDTableSelectConstraintTooltipAr[language]
                       + "</div>",
                   1,
                   whichSV < 0 ? new String[] {""} : distinctOptions[whichSV],
@@ -12073,7 +12142,7 @@ public abstract class EDDTable extends EDD {
                   + widgets.imageDirUrl
                   + "minus.gif\" "
                   + // vertical-align: 'b'ottom
-                  widgets.completeTooltip(EDStatic.magItemPreviousAr[language])
+                  widgets.completeTooltip(EDStatic.messages.magItemPreviousAr[language])
                   + "  alt=\"-\"\n"
                   +
                   // onMouseUp works much better than onClick and onDblClick
@@ -12099,7 +12168,7 @@ public abstract class EDDTable extends EDD {
                   + widgets.imageDirUrl
                   + "plus.gif\" "
                   + // vertical-align: 'b'ottom
-                  widgets.completeTooltip(EDStatic.magItemNextAr[language])
+                  widgets.completeTooltip(EDStatic.messages.magItemNextAr[language])
                   + "  alt=\"+\"\n"
                   +
                   // onMouseUp works much better than onClick and onDblClick
@@ -12216,7 +12285,9 @@ public abstract class EDDTable extends EDD {
       writer.write("&nbsp;\n"); // necessary for the blank line before the table (not <p>)
       writer.write(widgets.beginTable("class=\"compact nowrap\""));
       writer.write(
-          "  <tr><th class=\"L\" colspan=\"6\">" + EDStatic.magGSAr[language] + "</th></tr>\n");
+          "  <tr><th class=\"L\" colspan=\"6\">"
+              + EDStatic.messages.magGSAr[language]
+              + "</th></tr>\n");
 
       // get Marker settings
       int mType = -1, mSize = -1;
@@ -12242,7 +12313,7 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSMarkerTypeAr[language]
+                + EDStatic.messages.magGSMarkerTypeAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.select(paramName, "", 1, GraphDataLayer.MARKER_TYPES, mType, "")
@@ -12255,7 +12326,7 @@ public abstract class EDDTable extends EDD {
         if (mSize < 0) mSize = String2.indexOf(mSizes, "" + GraphDataLayer.MARKER_SIZE_SMALL);
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSSizeAr[language]
+                + EDStatic.messages.magGSSizeAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.select(paramName, "", 1, mSizes, mSize, "")
@@ -12282,7 +12353,7 @@ public abstract class EDDTable extends EDD {
       writer.write(
           "  <tr>\n"
               + "    <td>"
-              + EDStatic.magGSColorAr[language]
+              + EDStatic.messages.magGSColorAr[language]
               + ":&nbsp;</td>\n"
               + "    <td colspan=\"5\">"
               + widgets.color17("", paramName, "", colori, "")
@@ -12311,18 +12382,18 @@ public abstract class EDDTable extends EDD {
             Math.max(
                 0,
                 String2.indexOf(
-                    EDStatic.palettes0, pParts.length > 0 ? pParts[0] : defaultPalette));
+                    EDStatic.messages.palettes0, pParts.length > 0 ? pParts[0] : defaultPalette));
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSColorBarAr[language]
+                + EDStatic.messages.magGSColorBarAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.select(
                     paramName,
-                    EDStatic.magGSColorBarTooltipAr[language],
+                    EDStatic.messages.magGSColorBarTooltipAr[language],
                     1,
-                    EDStatic.palettes0,
+                    EDStatic.messages.palettes0,
                     palette,
                     "")
                 + "</td>\n");
@@ -12333,12 +12404,12 @@ public abstract class EDDTable extends EDD {
             pParts.length > 1 ? (pParts[1].equals("D") ? 2 : pParts[1].equals("C") ? 1 : 0) : 0;
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSContinuityAr[language]
+                + EDStatic.messages.magGSContinuityAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.select(
                     paramName,
-                    EDStatic.magGSContinuityTooltipAr[language],
+                    EDStatic.messages.magGSContinuityTooltipAr[language],
                     1,
                     conDisAr,
                     continuous,
@@ -12351,12 +12422,12 @@ public abstract class EDDTable extends EDD {
             Math.max(0, EDV.VALID_SCALES0.indexOf(pParts.length > 2 ? pParts[2] : defaultScale));
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSScaleAr[language]
+                + EDStatic.messages.magGSScaleAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.select(
                     paramName,
-                    EDStatic.magGSScaleTooltipAr[language],
+                    EDStatic.messages.magGSScaleTooltipAr[language],
                     1,
                     EDV.VALID_SCALES0,
                     scale,
@@ -12372,11 +12443,11 @@ public abstract class EDDTable extends EDD {
             "  <tr>\n"
                 + "    <td>"
                 + gap
-                + EDStatic.magGSMinAr[language]
+                + EDStatic.messages.magGSMinAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.textField(
-                    paramName, EDStatic.magGSMinTooltipAr[language], 10, 60, palMin, "")
+                    paramName, EDStatic.messages.magGSMinTooltipAr[language], 10, 60, palMin, "")
                 + "</td>\n");
 
         paramName = "pMax";
@@ -12384,11 +12455,11 @@ public abstract class EDDTable extends EDD {
         palMax = pParts.length > 4 ? pParts[4] : defaultMax;
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSMaxAr[language]
+                + EDStatic.messages.magGSMaxAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.textField(
-                    paramName, EDStatic.magGSMaxTooltipAr[language], 10, 60, palMax, "")
+                    paramName, EDStatic.messages.magGSMaxTooltipAr[language], 10, 60, palMax, "")
                 + "</td>\n");
 
         paramName = "pSec";
@@ -12396,12 +12467,12 @@ public abstract class EDDTable extends EDD {
             Math.max(0, EDStatic.paletteSections.indexOf(pParts.length > 5 ? pParts[5] : ""));
         writer.write(
             "    <td>&nbsp;"
-                + EDStatic.magGSNSectionsAr[language]
+                + EDStatic.messages.magGSNSectionsAr[language]
                 + ":&nbsp;</td>"
                 + "    <td>"
                 + widgets.select(
                     paramName,
-                    EDStatic.magGSNSectionsTooltipAr[language],
+                    EDStatic.messages.magGSNSectionsTooltipAr[language],
                     1,
                     EDStatic.paletteSections,
                     pSections,
@@ -12413,7 +12484,7 @@ public abstract class EDDTable extends EDD {
         String tq =
             "&.colorBar="
                 + SSR.minimalPercentEncode(
-                    EDStatic.palettes0[palette]
+                    EDStatic.messages.palettes0[palette]
                         + "|"
                         + (conDisAr[continuous].length() == 0 ? "" : conDisAr[continuous].charAt(0))
                         + "|"
@@ -12445,12 +12516,12 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSLandMaskAr[language]
+                + EDStatic.messages.magGSLandMaskAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.select(
                     "land",
-                    EDStatic.magGSLandMaskTooltipTableAr[language],
+                    EDStatic.messages.magGSLandMaskTooltipTableAr[language],
                     1,
                     String2.immutableListToArray(SgtMap.drawLandMask_OPTIONS),
                     tLand,
@@ -12488,11 +12559,16 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSVectorStandardAr[language]
+                + EDStatic.messages.magGSVectorStandardAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.textField(
-                    paramName, EDStatic.magGSVectorStandardTooltipAr[language], 10, 30, vec, "")
+                    paramName,
+                    EDStatic.messages.magGSVectorStandardTooltipAr[language],
+                    10,
+                    30,
+                    vec,
+                    "")
                 + "</td>\n"
                 + "    <td></td>\n"
                 + "    <td></td>\n"
@@ -12551,14 +12627,14 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "  <tr>\n"
                 + "    <td>"
-                + EDStatic.magGSYAxisMinAr[language]
+                + EDStatic.messages.magGSYAxisMinAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.textField(
                     "yRangeMin",
                     "<div class=\"narrow_max_width\">"
-                        + EDStatic.magGSYRangeMinTooltipAr[language]
-                        + EDStatic.magGSYRangeTooltipAr[language]
+                        + EDStatic.messages.magGSYRangeMinTooltipAr[language]
+                        + EDStatic.messages.magGSYRangeTooltipAr[language]
                         + "</div>",
                     10,
                     30,
@@ -12566,14 +12642,14 @@ public abstract class EDDTable extends EDD {
                     "")
                 + "</td>\n"
                 + "    <td>&nbsp;"
-                + EDStatic.magGSYAxisMaxAr[language]
+                + EDStatic.messages.magGSYAxisMaxAr[language]
                 + ":&nbsp;</td>\n"
                 + "    <td>"
                 + widgets.textField(
                     "yRangeMax",
                     "<div class=\"narrow_max_width\">"
-                        + EDStatic.magGSYRangeMaxTooltipAr[language]
-                        + EDStatic.magGSYRangeTooltipAr[language]
+                        + EDStatic.messages.magGSYRangeMaxTooltipAr[language]
+                        + EDStatic.messages.magGSYRangeTooltipAr[language]
                         + "</div>",
                     10,
                     30,
@@ -12583,7 +12659,7 @@ public abstract class EDDTable extends EDD {
                 + "    <td>&nbsp;"
                 + widgets.select(
                     "yRangeAscending",
-                    EDStatic.magGSYAscendingTooltipAr[language],
+                    EDStatic.messages.magGSYAscendingTooltipAr[language],
                     1,
                     new String[] {"Ascending", "Descending"},
                     yAscending ? 0 : 1,
@@ -12592,7 +12668,7 @@ public abstract class EDDTable extends EDD {
                 + "    <td>"
                 + widgets.select(
                     "yScale",
-                    EDStatic.magGSYScaleTooltipAr[language],
+                    EDStatic.messages.magGSYScaleTooltipAr[language],
                     1,
                     new String[] {"", "Linear", "Log"},
                     yAxisScale.equals("Linear") ? 1 : yAxisScale.equals("Log") ? 2 : 0,
@@ -12752,20 +12828,20 @@ public abstract class EDDTable extends EDD {
               "button",
               "",
               "",
-              EDStatic.magRedrawTooltipAr[language],
+              EDStatic.messages.magRedrawTooltipAr[language],
               "<span style=\"font-size:large;\"><strong>"
-                  + EDStatic.magRedrawAr[language]
+                  + EDStatic.messages.magRedrawAr[language]
                   + "</strong></span>",
               "onMouseUp='mySubmit(true);'"));
-      writer.write(" " + EDStatic.patientDataAr[language] + "\n" + "</td></tr>\n");
+      writer.write(" " + EDStatic.messages.patientDataAr[language] + "\n" + "</td></tr>\n");
 
       // Download the Data
       writer.write(
           "<tr><td>&nbsp;<br>"
-              + EDStatic.optionalAr[language]
+              + EDStatic.messages.optionalAr[language]
               + ":"
               + "<br>"
-              + EDStatic.magFileTypeAr[language]
+              + EDStatic.messages.magFileTypeAr[language]
               + ":\n");
       paramName = "fType";
       String htmlEncodedGraphQuery = XML.encodeAsHTMLAttribute(graphQuery.toString());
@@ -12773,7 +12849,7 @@ public abstract class EDDTable extends EDD {
       writer.write(
           widgets.select(
               paramName,
-              EDStatic.EDDSelectFileTypeAr[language],
+              EDStatic.messages.EDDSelectFileTypeAr[language],
               1,
               tAccessibleTo ? allFileTypeNames : publicGraphFileTypeNames,
               tAccessibleTo ? defaultFileTypeOption : defaultPublicGraphFileTypeOption,
@@ -12789,15 +12865,17 @@ public abstract class EDDTable extends EDD {
           " (<a rel=\"help\" href=\""
               + tErddapUrl
               + "/tabledap/documentation.html#fileType\">"
-              + EDStatic.EDDFileTypeInformationAr[language]
+              + EDStatic.messages.EDDFileTypeInformationAr[language]
               + "</a>)\n");
       writer.write("<br>and\n");
       writer.write(
           widgets.button(
               "button",
               "",
-              EDStatic.magDownloadTooltipAr[language] + "<br>" + EDStatic.patientDataAr[language],
-              EDStatic.magDownloadAr[language],
+              EDStatic.messages.magDownloadTooltipAr[language]
+                  + "<br>"
+                  + EDStatic.messages.patientDataAr[language],
+              EDStatic.messages.magDownloadAr[language],
               // "class=\"skinny\" " + //only IE needs it but only IE ignores it
               "onMouseUp='window.location=\""
                   + tErddapUrl
@@ -12813,11 +12891,11 @@ public abstract class EDDTable extends EDD {
       writer.write("</td></tr>\n");
 
       // view the url
-      writer.write("<tr><td>" + EDStatic.magViewUrlAr[language] + ":\n");
+      writer.write("<tr><td>" + EDStatic.messages.magViewUrlAr[language] + ":\n");
       String genViewHtml =
           String2.replaceAll(
               "<div class=\"standard_max_width\">"
-                  + EDStatic.justGenerateAndViewGraphUrlTooltipAr[language]
+                  + EDStatic.messages.justGenerateAndViewGraphUrlTooltipAr[language]
                   + "</div>",
               "&protocolName;",
               dapProtocol);
@@ -12841,7 +12919,7 @@ public abstract class EDDTable extends EDD {
               + tErddapUrl
               + "/tabledap/documentation.html\" "
               + "title=\"tabledap documentation\">"
-              + EDStatic.magDocumentationAr[language]
+              + EDStatic.messages.magDocumentationAr[language]
               + "</a>\n"
               + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml)
               + ")\n");
@@ -12885,12 +12963,12 @@ public abstract class EDDTable extends EDD {
                 + XML.encodeAsHTMLAttribute(graphQueryNoLatLon.toString());
 
         writer.write(
-            EDStatic.magZoomCenterAr[language]
+            EDStatic.messages.magZoomCenterAr[language]
                 + "\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.magZoomCenterTooltipAr[language])
+                    language, loggedInAs, EDStatic.messages.magZoomCenterTooltipAr[language])
                 + "<br><strong>"
-                + EDStatic.magZoomAr[language]
+                + EDStatic.messages.magZoomAr[language]
                 + ":&nbsp;</strong>\n");
 
         // zoom out?
@@ -12909,16 +12987,16 @@ public abstract class EDDTable extends EDD {
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomOutTooltipAr[language], "8x"),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutTooltipAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "8x"),
                 "class=\"skinny\" " + (disableZoomOut ? "disabled" : gqz + "out8\";'")));
 
         writer.write(
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomOutTooltipAr[language], "2x"),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutTooltipAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "2x"),
                 "class=\"skinny\" " + (disableZoomOut ? "disabled" : gqz + "out2\";'")));
 
         writer.write(
@@ -12926,8 +13004,9 @@ public abstract class EDDTable extends EDD {
                 "button",
                 "",
                 MessageFormat.format(
-                    EDStatic.magZoomOutTooltipAr[language], EDStatic.magZoomALittleAr[language]),
-                MessageFormat.format(EDStatic.magZoomOutAr[language], "").trim(),
+                    EDStatic.messages.magZoomOutTooltipAr[language],
+                    EDStatic.messages.magZoomALittleAr[language]),
+                MessageFormat.format(EDStatic.messages.magZoomOutAr[language], "").trim(),
                 "class=\"skinny\" " + (disableZoomOut ? "disabled" : gqz + "out\";'")));
 
         // zoom data
@@ -12936,8 +13015,9 @@ public abstract class EDDTable extends EDD {
                 "button",
                 "",
                 MessageFormat.format(
-                    EDStatic.magZoomOutTooltipAr[language], EDStatic.magZoomOutDataAr[language]),
-                EDStatic.magZoomDataAr[language],
+                    EDStatic.messages.magZoomOutTooltipAr[language],
+                    EDStatic.messages.magZoomOutDataAr[language]),
+                EDStatic.messages.magZoomDataAr[language],
                 "class=\"skinny\" " + gqnll + "\";'"));
 
         // zoom in
@@ -12946,24 +13026,25 @@ public abstract class EDDTable extends EDD {
                 "button",
                 "",
                 MessageFormat.format(
-                    EDStatic.magZoomInTooltipAr[language], EDStatic.magZoomALittleAr[language]),
-                MessageFormat.format(EDStatic.magZoomInAr[language], "").trim(),
+                    EDStatic.messages.magZoomInTooltipAr[language],
+                    EDStatic.messages.magZoomALittleAr[language]),
+                MessageFormat.format(EDStatic.messages.magZoomInAr[language], "").trim(),
                 "class=\"skinny\" " + gqz + "in\";'"));
 
         writer.write(
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomInTooltipAr[language], "2x"),
-                MessageFormat.format(EDStatic.magZoomInAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomInTooltipAr[language], "2x"),
+                MessageFormat.format(EDStatic.messages.magZoomInAr[language], "2x"),
                 "class=\"skinny\" " + gqz + "in2\";'"));
 
         writer.write(
             widgets.button(
                 "button",
                 "",
-                MessageFormat.format(EDStatic.magZoomInTooltipAr[language], "8x"),
-                MessageFormat.format(EDStatic.magZoomInAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomInTooltipAr[language], "8x"),
+                MessageFormat.format(EDStatic.messages.magZoomInAr[language], "8x"),
                 "class=\"skinny\" " + gqz + "in8\";'"));
 
         // trailing <br>
@@ -13007,8 +13088,8 @@ public abstract class EDDTable extends EDD {
                   "button",
                   "zoomXzoomIn",
                   "", // value
-                  EDStatic.zoomInAr[language],
-                  EDStatic.zoomInAr[language], // tooltip, labelHtml
+                  EDStatic.messages.zoomInAr[language],
+                  EDStatic.messages.zoomInAr[language], // tooltip, labelHtml
                   "onMouseUp='"
                       + formTextField
                       + "a.value=\""
@@ -13030,8 +13111,8 @@ public abstract class EDDTable extends EDD {
                       "button",
                       "zoomXzoomOut",
                       "", // value
-                      EDStatic.zoomOutAr[language],
-                      EDStatic.zoomOutAr[language], // tooltip, labelHtml
+                      EDStatic.messages.zoomOutAr[language],
+                      EDStatic.messages.zoomOutAr[language], // tooltip, labelHtml
                       "onMouseUp='"
                           + formTextField
                           + "a.value=\""
@@ -13052,7 +13133,7 @@ public abstract class EDDTable extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
                       "|<",
-                      EDStatic.shiftXAllTheWayLeftAr[language],
+                      EDStatic.messages.shiftXAllTheWayLeftAr[language],
                       "class=\"B\" "
                           + // vertical-align: 'b'ottom
                           "onMouseUp='"
@@ -13076,7 +13157,7 @@ public abstract class EDDTable extends EDD {
             HtmlWidgets.htmlTooltipImage(
                     EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
                     "-",
-                    EDStatic.shiftXLeftAr[language],
+                    EDStatic.messages.shiftXLeftAr[language],
                     "class=\"B\" "
                         + // vertical-align: 'b'ottom
                         "onMouseUp='"
@@ -13097,7 +13178,7 @@ public abstract class EDDTable extends EDD {
             HtmlWidgets.htmlTooltipImage(
                     EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
                     "+",
-                    EDStatic.shiftXRightAr[language],
+                    EDStatic.messages.shiftXRightAr[language],
                     "class=\"B\" "
                         + // vertical-align: 'b'ottom
                         "onMouseUp='"
@@ -13119,7 +13200,7 @@ public abstract class EDDTable extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
                       ">|",
-                      EDStatic.shiftXAllTheWayRightAr[language],
+                      EDStatic.messages.shiftXAllTheWayRightAr[language],
                       "class=\"B\" "
                           + // vertical-align: 'b'ottom
                           "onMouseUp='"
@@ -13218,7 +13299,7 @@ public abstract class EDDTable extends EDD {
         // beginning of row in controls table
         writer.write(
             "<tr><td><strong>"
-                + EDStatic.magTimeRangeAr[language]
+                + EDStatic.messages.magTimeRangeAr[language]
                 + "</strong>&nbsp;</td>\n"
                 + "<td>");
 
@@ -13234,7 +13315,7 @@ public abstract class EDDTable extends EDD {
         writer.write(
             widgets.select(
                 "timeN", // keep using widgets even though this isn't part of f1 form
-                EDStatic.magTimeRangeTooltipAr[language],
+                EDStatic.messages.magTimeRangeTooltipAr[language],
                 1,
                 Calendar2.IDEAL_N_OPTIONS,
                 idealTimeN - 1, // -1 so index=0 .. 99
@@ -13252,7 +13333,7 @@ public abstract class EDDTable extends EDD {
         writer.write(
             widgets.select(
                 "timeUnits", // keep using widgets even though this isn't part of f1 form
-                EDStatic.magTimeRangeTooltipAr[language],
+                EDStatic.messages.magTimeRangeTooltipAr[language],
                 1,
                 Calendar2.IDEAL_UNITS_OPTIONS,
                 idealTimeUnits,
@@ -13292,7 +13373,7 @@ public abstract class EDDTable extends EDD {
                         EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
                         "|<",
                         MessageFormat.format(
-                            EDStatic.magTimeRangeFirstAr[language], timeRangeString),
+                            EDStatic.messages.magTimeRangeFirstAr[language], timeRangeString),
                         "class=\"B\" onMouseUp='"
                             + gqnt
                             + // vertical-align: 'b'ottom
@@ -13321,7 +13402,8 @@ public abstract class EDDTable extends EDD {
               HtmlWidgets.htmlTooltipImage(
                       EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
                       "-",
-                      MessageFormat.format(EDStatic.magTimeRangeBackAr[language], timeRangeString),
+                      MessageFormat.format(
+                          EDStatic.messages.magTimeRangeBackAr[language], timeRangeString),
                       "class=\"B\" onMouseUp='"
                           + gqnt
                           + // vertical-align: 'b'ottom
@@ -13355,7 +13437,7 @@ public abstract class EDDTable extends EDD {
                       EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
                       "+",
                       MessageFormat.format(
-                          EDStatic.magTimeRangeForwardAr[language], timeRangeString),
+                          EDStatic.messages.magTimeRangeForwardAr[language], timeRangeString),
                       "class=\"B\" onMouseUp='"
                           + gqnt
                           + // vertical-align: 'b'ottom
@@ -13397,7 +13479,8 @@ public abstract class EDDTable extends EDD {
                 HtmlWidgets.htmlTooltipImage(
                     EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
                     ">|",
-                    MessageFormat.format(EDStatic.magTimeRangeLastAr[language], timeRangeString),
+                    MessageFormat.format(
+                        EDStatic.messages.magTimeRangeLastAr[language], timeRangeString),
                     "class=\"B\" onMouseUp='"
                         + gqnt
                         + // vertical-align: 'b'ottom
@@ -13437,12 +13520,12 @@ public abstract class EDDTable extends EDD {
           "<img "
               + (zoomLatLon ? "ismap " : "")
               + "width=\""
-              + EDStatic.imageWidths[1]
+              + EDStatic.messages.imageWidths[1]
               + "\" height=\""
-              + EDStatic.imageHeights[1]
+              + EDStatic.messages.imageHeights[1]
               + "\" "
               + "alt=\""
-              + EDStatic.patientYourGraphAr[language]
+              + EDStatic.messages.patientYourGraphAr[language]
               + "\" "
               + "src=\""
               + tErddapUrl
@@ -13463,7 +13546,7 @@ public abstract class EDDTable extends EDD {
       // do things with graphs
       writer.write(
           String2.replaceAll(
-              MessageFormat.format(EDStatic.doWithGraphsAr[language], tErddapUrl),
+              MessageFormat.format(EDStatic.messages.doWithGraphsAr[language], tErddapUrl),
               "&erddapUrl;",
               tErddapUrl));
       writer.write("\n\n");
@@ -13472,7 +13555,7 @@ public abstract class EDDTable extends EDD {
       writer.write(
           "<hr>\n"
               + "<h2><a class=\"selfLink\" id=\"DAS\" href=\"#DAS\" rel=\"bookmark\">"
-              + EDStatic.dasTitleAr[language]
+              + EDStatic.messages.dasTitleAr[language]
               + "</a></h2>\n"
               + "<pre style=\"white-space:pre-wrap;\">\n");
       Table table =
@@ -13595,7 +13678,8 @@ public abstract class EDDTable extends EDD {
     // insures that subsetVariables has been created.
     if (subsetVariables().length == 0 || accessibleViaSubset().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaSubset());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + accessibleViaSubset());
     String subsetVariablesCSV = String2.toSVString(subsetVariables, ",", false);
 
     // if present, the lastP parameter is not used for bigTable, but is used for smallTable
@@ -13935,7 +14019,7 @@ public abstract class EDDTable extends EDD {
     try {
       writer.write(
           EDStatic.startHeadHtml(
-              language, tErddapUrl, title() + " - " + EDStatic.subsetAr[language]));
+              language, tErddapUrl, title() + " - " + EDStatic.messages.subsetAr[language]));
       writer.write("\n" + rssHeadLink());
       writer.write("\n</head>\n");
       writer.write(
@@ -13955,8 +14039,10 @@ public abstract class EDDTable extends EDD {
               language,
               loggedInAs,
               dapProtocol,
-              EDStatic.subsetAr[language],
-              "<div class=\"narrow_max_width\">" + EDStatic.subsetTooltipAr[language] + "</div>"));
+              EDStatic.messages.subsetAr[language],
+              "<div class=\"narrow_max_width\">"
+                  + EDStatic.messages.subsetTooltipAr[language]
+                  + "</div>"));
 
       StringBuilder diQuery = new StringBuilder();
       for (int qpi = 1; qpi < queryParts.length; qpi++) { // 1 because part0 is var names
@@ -13993,7 +14079,7 @@ public abstract class EDDTable extends EDD {
             "<span class=\"warningColor\">"
                 + MustBe.THERE_IS_NO_DATA
                 + " "
-                + EDStatic.resetTheFormWasAr[language]
+                + EDStatic.messages.resetTheFormWasAr[language]
                 + "</span>\n");
 
         // reset all
@@ -14009,14 +14095,15 @@ public abstract class EDDTable extends EDD {
           widgets.beginForm("f1", "GET", subsetUrl, "")
               + "\n"
               + "<p><strong>"
-              + EDStatic.subsetSelectAr[language]
+              + EDStatic.messages.subsetSelectAr[language]
               + ":</strong>\n"
               + "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class=\"subduedColor\">"
               + "("
-              + MessageFormat.format(EDStatic.subsetNMatchingAr[language], "" + subsetTable.nRows())
+              + MessageFormat.format(
+                  EDStatic.messages.subsetNMatchingAr[language], "" + subsetTable.nRows())
               + ")</span>\n"
               + "  <br>"
-              + EDStatic.subsetInstructionsAr[language]
+              + EDStatic.messages.subsetInstructionsAr[language]
               + "\n"
               + widgets.beginTable("class=\"compact nowrap\""));
 
@@ -14139,7 +14226,7 @@ public abstract class EDDTable extends EDD {
                   + "minus.gif\"\n"
                   + // vertical-align: 'b'ottom
                   "  "
-                  + widgets.completeTooltip(EDStatic.selectPreviousAr[language])
+                  + widgets.completeTooltip(EDStatic.messages.selectPreviousAr[language])
                   + "  alt=\"-\" "
                   +
                   // onMouseUp works much better than onClick and onDblClick
@@ -14161,7 +14248,7 @@ public abstract class EDDTable extends EDD {
                   + "plus.gif\"\n"
                   + // vertical-align: 'b'ottom
                   "  "
-                  + widgets.completeTooltip(EDStatic.selectNextAr[language])
+                  + widgets.completeTooltip(EDStatic.messages.selectNextAr[language])
                   + "  alt=\"+\" "
                   +
                   // onMouseUp works much better than onClick and onDblClick
@@ -14203,12 +14290,12 @@ public abstract class EDDTable extends EDD {
                         + (pa.size() - 1)
                         + " "
                         + (pa.size() == 2
-                            ? EDStatic.subsetOptionAr[language]
+                            ? EDStatic.messages.subsetOptionAr[language]
                                 + ": "
                                 +
                                 // encodeSpaces so only option displays nicely
                                 XML.minimalEncodeSpaces(XML.encodeAsHTML(pa.getString(1)))
-                            : EDStatic.subsetOptionsAr[language])
+                            : EDStatic.messages.subsetOptionsAr[language])
                         + "</span></td>\n"
                     : "")
                 + "</tr>\n");
@@ -14222,7 +14309,7 @@ public abstract class EDDTable extends EDD {
       // View the graph and/or data?
       writer.write(
           "<p><a class=\"selfLink\" id=\"View\" href=\"#View\" rel=\"bookmark\"><strong>"
-              + EDStatic.subsetViewAr[language]
+              + EDStatic.messages.subsetViewAr[language]
               + ":</strong></a>\n");
       // !!! If changing these, change DEFAULT_SUBSET_VIEWS above.
       String viewParam[] = {
@@ -14234,20 +14321,24 @@ public abstract class EDDTable extends EDD {
         "viewRelatedData"
       };
       String viewTitle[] = {
-        EDStatic.subsetViewDistinctMapAr[language],
-        EDStatic.subsetViewRelatedMapAr[language],
-        EDStatic.subsetViewDistinctDataCountsAr[language],
-        EDStatic.subsetViewDistinctDataAr[language],
-        EDStatic.subsetViewRelatedDataCountsAr[language],
-        EDStatic.subsetViewRelatedDataAr[language]
+        EDStatic.messages.subsetViewDistinctMapAr[language],
+        EDStatic.messages.subsetViewRelatedMapAr[language],
+        EDStatic.messages.subsetViewDistinctDataCountsAr[language],
+        EDStatic.messages.subsetViewDistinctDataAr[language],
+        EDStatic.messages.subsetViewRelatedDataCountsAr[language],
+        EDStatic.messages.subsetViewRelatedDataAr[language]
       };
       String viewTooltip[] = {
-        EDStatic.subsetViewDistinctMapTooltipAr[language],
-        EDStatic.subsetViewRelatedMapTooltipAr[language] + EDStatic.subsetWarnAr[language],
-        EDStatic.subsetViewDistinctDataCountsTooltipAr[language],
-        EDStatic.subsetViewDistinctDataTooltipAr[language] + EDStatic.subsetWarn10000Ar[language],
-        EDStatic.subsetViewRelatedDataCountsTooltipAr[language] + EDStatic.subsetWarnAr[language],
-        EDStatic.subsetViewRelatedDataTooltipAr[language] + EDStatic.subsetWarn10000Ar[language]
+        EDStatic.messages.subsetViewDistinctMapTooltipAr[language],
+        EDStatic.messages.subsetViewRelatedMapTooltipAr[language]
+            + EDStatic.messages.subsetWarnAr[language],
+        EDStatic.messages.subsetViewDistinctDataCountsTooltipAr[language],
+        EDStatic.messages.subsetViewDistinctDataTooltipAr[language]
+            + EDStatic.messages.subsetWarn10000Ar[language],
+        EDStatic.messages.subsetViewRelatedDataCountsTooltipAr[language]
+            + EDStatic.messages.subsetWarnAr[language],
+        EDStatic.messages.subsetViewRelatedDataTooltipAr[language]
+            + EDStatic.messages.subsetWarn10000Ar[language]
       };
 
       boolean useCheckbox[] = {true, true, true, false, true, false};
@@ -14436,7 +14527,7 @@ public abstract class EDDTable extends EDD {
                 + ".graph?"
                 + XML.encodeAsHTML(graphDapQuery)
                 + "\">"
-                + EDStatic.subsetRefineMapDownloadAr[language]
+                + EDStatic.messages.subsetRefineMapDownloadAr[language]
                 + "</a>)\n"
                 + "<br>");
 
@@ -14456,9 +14547,9 @@ public abstract class EDDTable extends EDD {
                             + // &.view marks end of graphDapQuery
                             "&distinct()")
                     + "\">"
-                    + MessageFormat.format(EDStatic.subsetClickResetLLAr[language], ANY)
+                    + MessageFormat.format(EDStatic.messages.subsetClickResetLLAr[language], ANY)
                     + "</a>)\n");
-          else writer.write(EDStatic.subsetClickResetClosestAr[language] + "\n");
+          else writer.write(EDStatic.messages.subsetClickResetClosestAr[language] + "\n");
           // EDStatic.htmlTooltipImage(language, loggedInAs,
           //    "Unfortunately, after you click, some data sources respond with" +
           //    "<br><kbd>" + MustBe.THERE_IS_NO_DATA + "</kbd>" +
@@ -14480,9 +14571,9 @@ public abstract class EDDTable extends EDD {
                   + // if user clicks on image, browser adds "?x,y" to url
                   "<img ismap "
                   + "width=\""
-                  + EDStatic.imageWidths[1]
+                  + EDStatic.messages.imageWidths[1]
                   + "\" height=\""
-                  + EDStatic.imageHeights[1]
+                  + EDStatic.messages.imageHeights[1]
                   + "\" "
                   + "alt=\""
                   + XML.encodeAsHTML(viewTitle[current])
@@ -14496,9 +14587,9 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<p><span class=\"subduedColor\">"
                   + MessageFormat.format(
-                      EDStatic.subsetViewCheckAr[language],
+                      EDStatic.messages.subsetViewCheckAr[language],
                       "<kbd>"
-                          + EDStatic.subsetViewAr[language]
+                          + EDStatic.messages.subsetViewAr[language]
                           + " : "
                           + viewTitle[current]
                           + "</kbd>")
@@ -14530,7 +14621,7 @@ public abstract class EDDTable extends EDD {
                 + ".graph?"
                 + XML.encodeAsHTMLAttribute(graphDapQuery)
                 + "\">"
-                + EDStatic.subsetRefineMapDownloadAr[language]
+                + EDStatic.messages.subsetRefineMapDownloadAr[language]
                 + "</a>)\n");
 
         if (viewValue[current] == 1) {
@@ -14538,17 +14629,17 @@ public abstract class EDDTable extends EDD {
             writer.write(
                 "\n<p><span class=\"subduedColor\">"
                     + MessageFormat.format(
-                        EDStatic.subsetViewCheck1Ar[language], viewTitle[current], ANY)
+                        EDStatic.messages.subsetViewCheck1Ar[language], viewTitle[current], ANY)
                     + "</span>\n");
           } else {
             writer.write(
                 "<br><img width=\""
-                    + EDStatic.imageWidths[1]
+                    + EDStatic.messages.imageWidths[1]
                     + "\" height=\""
-                    + EDStatic.imageHeights[1]
+                    + EDStatic.messages.imageHeights[1]
                     + "\" "
                     + "alt=\""
-                    + EDStatic.patientYourGraphAr[language]
+                    + EDStatic.messages.patientYourGraphAr[language]
                     + "\" "
                     + "src=\""
                     + XML.encodeAsHTMLAttribute(
@@ -14559,14 +14650,14 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<p><span class=\"subduedColor\">"
                   + MessageFormat.format(
-                      EDStatic.subsetViewCheckAr[language],
+                      EDStatic.messages.subsetViewCheckAr[language],
                       "<kbd>"
-                          + EDStatic.subsetViewAr[language]
+                          + EDStatic.messages.subsetViewAr[language]
                           + " : "
                           + viewTitle[current]
                           + "</kbd>")
                   + "</span>\n"
-                  + String2.replaceAll(EDStatic.subsetWarnAr[language], "<br>", " ")
+                  + String2.replaceAll(EDStatic.messages.subsetWarnAr[language], "<br>", " ")
                   + "\n");
         }
       }
@@ -14591,7 +14682,7 @@ public abstract class EDDTable extends EDD {
                 + XML.encodeAsHTMLAttribute(
                     countsVariables.toString() + newConstraintsNLP.toString() + "&distinct()")
                 + "\">"
-                + EDStatic.subsetRefineSubsetDownloadAr[language]
+                + EDStatic.messages.subsetRefineSubsetDownloadAr[language]
                 + "</a>)\n");
 
         try {
@@ -14605,7 +14696,7 @@ public abstract class EDDTable extends EDD {
           // sort, count, remove duplicates
           varPA.sortIgnoreCase();
           IntArray countPA = new IntArray(n, false);
-          countTable.addColumn(EDStatic.subsetCountAr[language], countPA);
+          countTable.addColumn(EDStatic.messages.subsetCountAr[language], countPA);
           int lastCount = 1;
           countPA.add(lastCount);
           keep = new BitSet(n);
@@ -14626,7 +14717,7 @@ public abstract class EDDTable extends EDD {
           double total = stats[PrimitiveArray.STATS_SUM];
           n = countPA.size();
           DoubleArray percentPA = new DoubleArray(n, false);
-          countTable.addColumn(EDStatic.subsetPercentAr[language], percentPA);
+          countTable.addColumn(EDStatic.messages.subsetPercentAr[language], percentPA);
           for (int i = 0; i < n; i++) percentPA.add(Math2.roundTo(countPA.get(i) * 100 / total, 2));
 
           // write results
@@ -14634,13 +14725,13 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<br>"
                   + (countsCon.length() == 0
-                      ? EDStatic.subsetWhenNoConstraintsAr[language]
+                      ? EDStatic.messages.subsetWhenNoConstraintsAr[language]
                       : MessageFormat.format(
-                          EDStatic.subsetWhenAr[language], XML.encodeAsHTML(countsCon)))
+                          EDStatic.messages.subsetWhenAr[language], XML.encodeAsHTML(countsCon)))
                   + (countsCon.length() < 40 ? " " : "\n<br>")
                   + MessageFormat.format(
-                      EDStatic.subsetWhenCountsAr[language],
-                      EDStatic.subsetViewSelectDistinctCombosAr[language],
+                      EDStatic.messages.subsetWhenCountsAr[language],
+                      EDStatic.messages.subsetViewSelectDistinctCombosAr[language],
                       "" + countTable.nRows(),
                       XML.encodeAsHTML(lastPName))
                   + "\n");
@@ -14666,7 +14757,7 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<p>"
                   + MessageFormat.format(
-                      EDStatic.subsetTotalCountAr[language], "" + Math2.roundToLong(total))
+                      EDStatic.messages.subsetTotalCountAr[language], "" + Math2.roundToLong(total))
                   + "\n");
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
@@ -14684,9 +14775,9 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "<p><span class=\"subduedColor\">"
                 + MessageFormat.format(
-                    EDStatic.subsetViewSelectAr[language],
-                    EDStatic.subsetViewSelectDistinctCombosAr[language],
-                    EDStatic.subsetViewAr[language],
+                    EDStatic.messages.subsetViewSelectAr[language],
+                    EDStatic.messages.subsetViewSelectDistinctCombosAr[language],
+                    EDStatic.messages.subsetViewAr[language],
                     viewTitle[current])
                 + "</span>\n");
       }
@@ -14705,7 +14796,7 @@ public abstract class EDDTable extends EDD {
               + "/tabledap/"
               + datasetID
               + ".das\">"
-              + EDStatic.subsetMetadataAr[language]
+              + EDStatic.messages.subsetMetadataAr[language]
               + "</a>)\n");
       writer.write(
           "&nbsp;&nbsp;\n"
@@ -14717,7 +14808,7 @@ public abstract class EDDTable extends EDD {
               + XML.encodeAsHTMLAttribute(
                   subsetVariablesCSV + newConstraints.toString() + "&distinct()")
               + "\">"
-              + EDStatic.subsetRefineSubsetDownloadAr[language]
+              + EDStatic.messages.subsetRefineSubsetDownloadAr[language]
               + "</a>)\n");
       int onRows = subsetTable.nRows();
       if (viewValue[current] > 0) {
@@ -14746,22 +14837,27 @@ public abstract class EDDTable extends EDD {
 
       writer.write(
           "<p>"
-              + MessageFormat.format(EDStatic.subsetNVariableCombosAr[language], "" + onRows)
+              + MessageFormat.format(
+                  EDStatic.messages.subsetNVariableCombosAr[language], "" + onRows)
               + "\n");
       if (onRows > viewValue[current])
         writer.write(
             "<br><span class=\"warningColor\">"
                 + MessageFormat.format(
-                    EDStatic.subsetShowingNRowsAr[language],
+                    EDStatic.messages.subsetShowingNRowsAr[language],
                     "" + Math.min(onRows, viewValue[current]),
                     "" + (onRows - viewValue[current]))
                 + "</span>\n");
-      else writer.write(EDStatic.subsetShowingAllRowsAr[language] + "\n");
+      else writer.write(EDStatic.messages.subsetShowingAllRowsAr[language] + "\n");
       writer.write(
           "<br>"
               + MessageFormat.format(
-                  EDStatic.subsetChangeShowingAr[language],
-                  "<kbd>" + EDStatic.subsetViewAr[language] + " : " + viewTitle[current] + "</kbd>")
+                  EDStatic.messages.subsetChangeShowingAr[language],
+                  "<kbd>"
+                      + EDStatic.messages.subsetViewAr[language]
+                      + " : "
+                      + viewTitle[current]
+                      + "</kbd>")
               + "\n");
 
       // 4 = viewRelatedDataCounts
@@ -14784,7 +14880,7 @@ public abstract class EDDTable extends EDD {
                 + XML.encodeAsHTMLAttribute(newConstraintsNLP.toString())
                 + // no vars, not distinct
                 "\">"
-                + EDStatic.subsetRefineSubsetDownloadAr[language]
+                + EDStatic.messages.subsetRefineSubsetDownloadAr[language]
                 + "</a>)\n");
 
         TableWriterAll twa = null;
@@ -14813,7 +14909,7 @@ public abstract class EDDTable extends EDD {
           varPA.sortIgnoreCase();
           int n = varPA.size();
           IntArray countPA = new IntArray(n, false);
-          countTable.addColumn(EDStatic.subsetCountAr[language], countPA);
+          countTable.addColumn(EDStatic.messages.subsetCountAr[language], countPA);
           int lastCount = 1;
           countPA.add(lastCount);
           keep = new BitSet(n);
@@ -14834,7 +14930,7 @@ public abstract class EDDTable extends EDD {
           double total = stats[PrimitiveArray.STATS_SUM];
           n = countPA.size();
           DoubleArray percentPA = new DoubleArray(n, false);
-          countTable.addColumn(EDStatic.subsetPercentAr[language], percentPA);
+          countTable.addColumn(EDStatic.messages.subsetPercentAr[language], percentPA);
           for (int i = 0; i < n; i++) percentPA.add(Math2.roundTo(countPA.get(i) * 100 / total, 2));
 
           // write results
@@ -14842,13 +14938,13 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<br>"
                   + (countsConNLP.length() == 0
-                      ? EDStatic.subsetWhenNoConstraintsAr[language]
+                      ? EDStatic.messages.subsetWhenNoConstraintsAr[language]
                       : MessageFormat.format(
-                          EDStatic.subsetWhenAr[language], XML.encodeAsHTML(countsConNLP)))
+                          EDStatic.messages.subsetWhenAr[language], XML.encodeAsHTML(countsConNLP)))
                   + (countsConNLP.length() < 40 ? " " : "\n<br>")
                   + MessageFormat.format(
-                      EDStatic.subsetWhenCountsAr[language],
-                      EDStatic.subsetViewSelectRelatedCountsAr[language],
+                      EDStatic.messages.subsetWhenCountsAr[language],
+                      EDStatic.messages.subsetViewSelectRelatedCountsAr[language],
                       "" + countTable.nRows(),
                       XML.encodeAsHTML(lastPName))
                   + "\n");
@@ -14874,7 +14970,7 @@ public abstract class EDDTable extends EDD {
           writer.write(
               "<p>"
                   + MessageFormat.format(
-                      EDStatic.subsetTotalCountAr[language], "" + Math2.roundToLong(total))
+                      EDStatic.messages.subsetTotalCountAr[language], "" + Math2.roundToLong(total))
                   + "\n");
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
@@ -14896,12 +14992,12 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "<p><span class=\"subduedColor\">"
                 + MessageFormat.format(
-                    EDStatic.subsetViewSelectAr[language],
-                    EDStatic.subsetViewSelectRelatedCountsAr[language],
-                    EDStatic.subsetViewAr[language],
+                    EDStatic.messages.subsetViewSelectAr[language],
+                    EDStatic.messages.subsetViewSelectRelatedCountsAr[language],
+                    EDStatic.messages.subsetViewAr[language],
                     viewTitle[current])
                 + "</span>\n"
-                + String2.replaceAll(EDStatic.subsetWarnAr[language], "<br>", " ")
+                + String2.replaceAll(EDStatic.messages.subsetWarnAr[language], "<br>", " ")
                 + "\n");
       }
 
@@ -14919,7 +15015,7 @@ public abstract class EDDTable extends EDD {
               + "/tabledap/"
               + datasetID
               + ".das\">"
-              + EDStatic.subsetMetadataAr[language]
+              + EDStatic.messages.subsetMetadataAr[language]
               + "</a>)\n"
               + "&nbsp;&nbsp;\n"
               + "(<a href=\""
@@ -14932,14 +15028,14 @@ public abstract class EDDTable extends EDD {
                   : "?" + XML.encodeAsHTMLAttribute(newConstraints.toString()))
               + // no vars specified, and not distinct()
               "\">"
-              + EDStatic.subsetRefineSubsetDownloadAr[language]
+              + EDStatic.messages.subsetRefineSubsetDownloadAr[language]
               + "</a>)\n");
       if (viewValue[current] > 0) {
         if (allData) {
           writer.write(
               "\n<p><span class=\"subduedColor\">"
                   + MessageFormat.format(
-                      EDStatic.subsetViewCheck1Ar[language], viewTitle[current], ANY)
+                      EDStatic.messages.subsetViewCheck1Ar[language], viewTitle[current], ANY)
                   + "</span>\n");
 
         } else {
@@ -14964,7 +15060,8 @@ public abstract class EDDTable extends EDD {
                     true,
                     true,
                     viewValue[current],
-                    EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile);
+                    EDStatic.imageDirUrl(loggedInAs, language)
+                        + EDStatic.messages.questionMarkImageFile);
             if (handleViaFixedOrSubsetVariables(
                 language,
                 loggedInAs,
@@ -14983,23 +15080,23 @@ public abstract class EDDTable extends EDD {
             writer.write(
                 "<p>"
                     + MessageFormat.format(
-                        EDStatic.subsetNRowsRelatedDataAr[language], "" + twht.totalRows())
+                        EDStatic.messages.subsetNRowsRelatedDataAr[language], "" + twht.totalRows())
                     + "\n");
             if (twht.totalRows() > viewValue[current])
               writer.write(
                   "<br><span class=\"warningColor\">"
                       + MessageFormat.format(
-                          EDStatic.subsetShowingNRowsAr[language],
+                          EDStatic.messages.subsetShowingNRowsAr[language],
                           "" + Math.min(twht.totalRows(), viewValue[current]),
                           "" + (twht.totalRows() - viewValue[current]))
                       + "</span>\n");
-            else writer.write(EDStatic.subsetShowingAllRowsAr[language] + "\n");
+            else writer.write(EDStatic.messages.subsetShowingAllRowsAr[language] + "\n");
             writer.write(
                 "<br>"
                     + MessageFormat.format(
-                        EDStatic.subsetChangeShowingAr[language],
+                        EDStatic.messages.subsetChangeShowingAr[language],
                         "<kbd>"
-                            + EDStatic.subsetViewAr[language]
+                            + EDStatic.messages.subsetViewAr[language]
                             + " : "
                             + viewTitle[current]
                             + "</kbd>")
@@ -15062,14 +15159,14 @@ public abstract class EDDTable extends EDD {
         writer.write(
             "<p><span class=\"subduedColor\">"
                 + MessageFormat.format(
-                    EDStatic.subsetViewRelatedChangeAr[language],
+                    EDStatic.messages.subsetViewRelatedChangeAr[language],
                     "<kbd>"
-                        + EDStatic.subsetViewAr[language]
+                        + EDStatic.messages.subsetViewAr[language]
                         + " : "
                         + viewTitle[current]
                         + "</kbd>")
                 + "</span>\n"
-                + String2.replaceAll(EDStatic.subsetWarnAr[language], "<br>", " ")
+                + String2.replaceAll(EDStatic.messages.subsetWarnAr[language], "<br>", " ")
                 + "\n");
       }
 
@@ -15129,7 +15226,8 @@ public abstract class EDDTable extends EDD {
     // is this dataset accessibleViaSubset?
     if (accessibleViaSubset().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaSubset());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + accessibleViaSubset());
 
     // Make the subsetVariablesDataTable.
     // If this fails, dataset won't load.  Locally, throws exception if failure.
@@ -15165,7 +15263,7 @@ public abstract class EDDTable extends EDD {
         int tCol = table.findColumnNumber(tSubsetVars[col]);
         if (tCol < 0)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "subsetVariable="
                   + tSubsetVars[col]
                   + " wasn't found in "
@@ -15395,7 +15493,8 @@ public abstract class EDDTable extends EDD {
     String tSubsetVars[] = subsetVariables();
     if (tSubsetVars.length == 0 || accessibleViaSubset().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaSubset());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
+              + accessibleViaSubset());
 
     // create the table and store it in the file
     // **** NOTE: the columns are unrelated!  Each column is sorted separately!
@@ -15585,7 +15684,7 @@ public abstract class EDDTable extends EDD {
           sa.justKeep(bitset);
           if (bitset.nextClearBit(0)
               < n) // if don't keep 1 or more... (nextClearBit returns n if none)
-          sa.add(EDStatic.subsetLongNotShownAr[language]);
+          sa.add(EDStatic.messages.subsetLongNotShownAr[language]);
           n = sa.size();
         }
 
@@ -15827,7 +15926,8 @@ public abstract class EDDTable extends EDD {
           }
         }
       }
-      if (tSubsetVariables.length == 0) tAccessibleViaSubset = EDStatic.subsetNotSetUpAr[0];
+      if (tSubsetVariables.length == 0)
+        tAccessibleViaSubset = EDStatic.messages.subsetNotSetUpAr[0];
 
       if ((className.equals("EDDTableFromDapSequence") || className.equals("EDDTableFromErddap"))
           && EDStatic.quickRestart
@@ -15918,17 +16018,17 @@ public abstract class EDDTable extends EDD {
         accessibleViaMAG =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[
-                        0], // language=0 because only 1 value of accessibleViaMAG
-                    EDStatic.magAr[0],
-                    EDStatic.noXxxNoNonStringAr[0]));
+                    EDStatic.messages
+                        .noXxxBecause2Ar[0], // language=0 because only 1 value of accessibleViaMAG
+                    EDStatic.messages.magAr[0],
+                    EDStatic.messages.noXxxNoNonStringAr[0]));
       else if (nNumeric == 1)
         accessibleViaMAG =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[0],
-                    EDStatic.magAr[0],
-                    EDStatic.noXxxNo2NonStringAr[0]));
+                    EDStatic.messages.noXxxBecause2Ar[0],
+                    EDStatic.messages.magAr[0],
+                    EDStatic.messages.noXxxNo2NonStringAr[0]));
       else accessibleViaMAG = String2.canonical("");
     }
     return accessibleViaMAG;
@@ -15964,26 +16064,28 @@ public abstract class EDDTable extends EDD {
     if (!EDStatic.sosActive)
       return String2.canonical(
           MessageFormat.format(
-              EDStatic.noXxxBecauseAr[0],
+              EDStatic.messages.noXxxBecauseAr[0],
               "SOS",
-              MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "SOS")));
+              MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "SOS")));
 
     if (lonIndex < 0 || latIndex < 0 || timeIndex < 0)
       return String2.canonical(
-          MessageFormat.format(EDStatic.noXxxBecauseAr[0], "SOS", EDStatic.noXxxNoLLTAr[0]));
+          MessageFormat.format(
+              EDStatic.messages.noXxxBecauseAr[0], "SOS", EDStatic.messages.noXxxNoLLTAr[0]));
 
     String cdt = combinedGlobalAttributes().getString("cdm_data_type");
     int type = sosCdmDataTypes.indexOf(cdt);
     if (type < 0)
       return String2.canonical(
           MessageFormat.format(
-              EDStatic.noXxxBecauseAr[0],
+              EDStatic.messages.noXxxBecauseAr[0],
               "SOS",
-              MessageFormat.format(EDStatic.noXxxNoCdmDataTypeAr[0], cdt)));
+              MessageFormat.format(EDStatic.messages.noXxxNoCdmDataTypeAr[0], cdt)));
 
     if (!setSosOfferingTypeAndIndex())
       return String2.canonical(
-          MessageFormat.format(EDStatic.noXxxBecauseAr[0], "SOS", EDStatic.noXxxNoStationIDAr[0]));
+          MessageFormat.format(
+              EDStatic.messages.noXxxBecauseAr[0], "SOS", EDStatic.messages.noXxxNoStationIDAr[0]));
 
     // this just doesn't check that sosOfferings, sosMinLat, sosMaxLat, ... were all set.
 
@@ -16023,9 +16125,9 @@ public abstract class EDDTable extends EDD {
     if (subsetVariables == null || subsetVariables.length == 0)
       return String2.canonical(
           MessageFormat.format(
-              EDStatic.noXxxBecauseAr[0],
+              EDStatic.messages.noXxxBecauseAr[0],
               "SOS", // language=0 in this method because only 1 version of accessibleViaSOS
-              EDStatic.noXxxNoSubsetVariablesAr[0]));
+              EDStatic.messages.noXxxNoSubsetVariablesAr[0]));
 
     // are sosOfferingIndex, lon, lat in subsetVariablesDataTable?
     // This will only be true if lon and lat are point per offering.
@@ -16035,7 +16137,9 @@ public abstract class EDDTable extends EDD {
         || String2.indexOf(subsetVariables, "latitude") < 0)
       return String2.canonical(
           MessageFormat.format(
-              EDStatic.noXxxBecauseAr[0], "SOS", EDStatic.noXxxNoOLLSubsetVariablesAr[0]));
+              EDStatic.messages.noXxxBecauseAr[0],
+              "SOS",
+              EDStatic.messages.noXxxNoOLLSubsetVariablesAr[0]));
 
     // Request the distinct() offerings (station names), lon, lat data
     //  from the subsetVariables data table.
@@ -16054,7 +16158,7 @@ public abstract class EDDTable extends EDD {
     if (table.getColumn(0).removeDuplicates() > 0)
       return String2.canonical(
           MessageFormat.format(
-              EDStatic.noXxxBecauseAr[0],
+              EDStatic.messages.noXxxBecauseAr[0],
               "SOS",
               "In the subsetVariables table, some offerings (stations) have "
                   + ">1 longitude,latitude."));
@@ -16084,14 +16188,17 @@ public abstract class EDDTable extends EDD {
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "GeoServicesRest", // language=0 here because only 1 value of accessibleVia...
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "GeoServicesRest")));
+                    MessageFormat.format(
+                        EDStatic.messages.noXxxNotActiveAr[0], "GeoServicesRest")));
       else
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0], "GeoServicesRest", EDStatic.noXxxItsTabularAr[0]));
+                    EDStatic.messages.noXxxBecauseAr[0],
+                    "GeoServicesRest",
+                    EDStatic.messages.noXxxItsTabularAr[0]));
     }
     return accessibleViaGeoServicesRest;
   }
@@ -16105,14 +16212,16 @@ public abstract class EDDTable extends EDD {
         accessibleViaWCS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "WCS", // language=0 here because only 1 value of accessibleVia...
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "WCS")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "WCS")));
       else
         accessibleViaWCS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0], "WCS", EDStatic.noXxxItsTabularAr[0]));
+                    EDStatic.messages.noXxxBecauseAr[0],
+                    "WCS",
+                    EDStatic.messages.noXxxItsTabularAr[0]));
     }
     return accessibleViaWCS;
   }
@@ -16125,14 +16234,16 @@ public abstract class EDDTable extends EDD {
         accessibleViaWMS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0],
+                    EDStatic.messages.noXxxBecauseAr[0],
                     "WMS", // language=0 here because only 1 value of accessibleVia...
-                    MessageFormat.format(EDStatic.noXxxNotActiveAr[0], "WMS")));
+                    MessageFormat.format(EDStatic.messages.noXxxNotActiveAr[0], "WMS")));
       else
         accessibleViaWMS =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecauseAr[0], "WMS", EDStatic.noXxxItsTabularAr[0]));
+                    EDStatic.messages.noXxxBecauseAr[0],
+                    "WMS",
+                    EDStatic.messages.noXxxItsTabularAr[0]));
     return accessibleViaWMS;
   }
 
@@ -16413,9 +16524,9 @@ public abstract class EDDTable extends EDD {
         accessibleViaNcCF =
             String2.canonical(
                 MessageFormat.format(
-                    EDStatic.noXxxBecause2Ar[0],
+                    EDStatic.messages.noXxxBecause2Ar[0],
                     ".ncCF/.ncCFMA",
-                    MessageFormat.format(EDStatic.noXxxNoCdmDataTypeAr[0], cdmType)));
+                    MessageFormat.format(EDStatic.messages.noXxxNoCdmDataTypeAr[0], cdmType)));
       }
 
       // no errors so far
@@ -16495,7 +16606,7 @@ public abstract class EDDTable extends EDD {
 
     if (accessibleViaSOS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaSOS());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaSOS());
 
     // validate section=    values are case-sensitive
     String section_ServiceIdentification = "ServiceIdentification";
@@ -17077,7 +17188,8 @@ public abstract class EDDTable extends EDD {
   public void sosPhenomenaDictionary(Writer writer) throws Throwable {
 
     // if (accessibleViaSOS().length() > 0)
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
     // String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
@@ -17216,10 +17328,11 @@ public abstract class EDDTable extends EDD {
       offeringType = sosOfferingType;
       int which = sosOfferings.indexOf(shortName);
       if (which < 0)
-        // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal
+        // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+        // "deal
         // with SOS error"
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "procedure="
                 + shortName
                 + " isn't a valid sensor name.");
@@ -17692,10 +17805,11 @@ public abstract class EDDTable extends EDD {
   public static boolean isIoosSosXmlResponseFormat(int language, String responseFormat) {
     String tabledapType = sosResponseFormatToFileTypeName(responseFormat);
     if (tabledapType == null)
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "responseFormat="
               + responseFormat
               + " is invalid.");
@@ -17749,7 +17863,7 @@ public abstract class EDDTable extends EDD {
 
     if (accessibleViaSOS().length() > 0)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + accessibleViaSOS());
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaSOS());
 
     // parse the sosQuery
     String dapQueryAr[] = sosQueryToDapQuery(language, loggedInAs, sosQuery);
@@ -17874,10 +17988,11 @@ public abstract class EDDTable extends EDD {
     // service   required
     String service = sosQueryMap.get("service"); // test name.toLowerCase()
     if (service == null || !service.equals("SOS"))
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "service="
               + service
               + " should have been \"SOS\".");
@@ -17885,10 +18000,11 @@ public abstract class EDDTable extends EDD {
     // version    required
     String version = sosQueryMap.get("version"); // test name.toLowerCase()
     if (version == null || !version.equals(sosVersion))
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "version="
               + version
               + " should have been \""
@@ -17898,10 +18014,11 @@ public abstract class EDDTable extends EDD {
     // request    required
     String request = sosQueryMap.get("request"); // test name.toLowerCase()
     if (request == null || !request.equals("GetObservation"))
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "request="
               + request
               + " should have been \"GetObservation\".");
@@ -17909,10 +18026,11 @@ public abstract class EDDTable extends EDD {
     // srsName  SOS required; erddap optional (default=4326, the only one supported)
     String srsName = sosQueryMap.get("srsname"); // test name.toLowerCase()
     if (srsName != null && !srsName.endsWith(":4326"))
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "srsName="
               + srsName
               + " should have been \"urn:ogc:def:crs:epsg::4326\".");
@@ -17941,7 +18059,7 @@ public abstract class EDDTable extends EDD {
             || dv == timeIndex
             || dv == sosOfferingIndex)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "observedProperty="
                   + property
                   + " is invalid.");
@@ -17977,10 +18095,11 @@ public abstract class EDDTable extends EDD {
 
       whichOffering = sosOfferings.indexOf(requestShortOfferingName);
       if (whichOffering < 0)
-        // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal
+        // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+        // "deal
         // with SOS error"
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "offering="
                 + requestOffering
                 + " is invalid.");
@@ -17995,14 +18114,14 @@ public abstract class EDDTable extends EDD {
     String procedure = sosQueryMap.get("procedure"); // test name.toLowerCase()
     if (procedure != null)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "\"procedure\" is not supported.");
 
     // result    forbidden
     String result = sosQueryMap.get("result"); // test name.toLowerCase()
     if (result != null)
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "\"result\" is not supported.");
 
     // responseMode  SOS & erddap optional (default="inline")
@@ -18010,24 +18129,27 @@ public abstract class EDDTable extends EDD {
     // if (responseMode == null)
     //    responseMode = "inline";
     // if (!responseMode.equals("inline") && !responseMode.equals("out-of-band"))
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        "responseMode=" + responseMode + " should have been \"inline\" or \"out-of-band\".");
 
     // responseFormat
     String responseFormat = sosQueryMap.get("responseformat"); // test name.toLowerCase()
     String fileTypeName = sosResponseFormatToFileTypeName(responseFormat);
     if (fileTypeName == null)
-      // this format EDStatic.queryErrorAr[language] + "xxx=" is parsed by Erddap section "deal with
+      // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
+      // "deal with
       // SOS error"
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "responseFormat="
               + responseFormat
               + " is invalid.");
     // if ((isIoosSosXmlResponseFormat(responseFormat) ||
     //     isOostethysSosXmlResponseFormat(responseFormat)) &&
     //    responseMode.equals("out-of-band"))
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        "For responseFormat=" + responseFormat + ", responseMode=" + responseMode + " must be
     // \"inline\".");
 
@@ -18035,7 +18157,7 @@ public abstract class EDDTable extends EDD {
     String resultModel = sosQueryMap.get("resultmodel"); // test name.toLowerCase()
     if (resultModel != null && !resultModel.equals("om:Observation"))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "resultModel="
               + resultModel
               + " should have been \"om:Observation\".");
@@ -18061,7 +18183,7 @@ public abstract class EDDTable extends EDD {
         int lpo = eventTime.lastIndexOf('/');
         if (lpo != spo)
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "ERDDAP doesn't support '/resolution' in eventTime=beginTime/endTime/resolution.");
         dapQuery.append(
             "&time>=" + eventTime.substring(0, spo) + "&time<=" + eventTime.substring(spo + 1));
@@ -18076,7 +18198,7 @@ public abstract class EDDTable extends EDD {
       String bboxSA[] = String2.split(foi.substring(5), ',');
       if (bboxSA.length != 4)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "featureOfInterest=BBOX must have 4 comma-separated values.");
 
       double d1 = String2.parseDouble(bboxSA[0]);
@@ -18098,7 +18220,7 @@ public abstract class EDDTable extends EDD {
       }
     } else {
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "featureOfInterest="
               + foi
               + " is invalid. Only BBOX is allowed.");
@@ -18118,7 +18240,7 @@ public abstract class EDDTable extends EDD {
       // responseFormat is an image type
       if (requestedVars.size() == 0) {
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "For image responseFormats (e.g., "
                 + responseFormat
                 + "), observedProperty must list one or more simple observedProperties.");
@@ -18128,7 +18250,7 @@ public abstract class EDDTable extends EDD {
         EDV edv1 = findDataVariableByDestinationName(requestedVars.get(0));
         if (edv1.destinationDataPAType().equals(PAType.STRING))
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For image responseFormats, observedProperty="
                   + requestedVars.get(0)
                   + " can't be a String phenomena.");
@@ -18149,13 +18271,13 @@ public abstract class EDDTable extends EDD {
         EDV edv2 = findDataVariableByDestinationName(requestedVars.get(1));
         if (edv1.destinationDataPAType().equals(PAType.STRING))
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For image responseFormats, observedProperty="
                   + requestedVars.get(0)
                   + " can't be a String phenomena.");
         if (edv2.destinationDataPAType().equals(PAType.STRING))
           throw new SimpleException(
-              EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                   + "For image responseFormats, observedProperty="
                   + requestedVars.get(1)
                   + " can't be a String phenomena.");
@@ -18253,7 +18375,8 @@ public abstract class EDDTable extends EDD {
       throws Throwable {
 
     // if (accessibleViaSOS().length() > 0)
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
@@ -18630,7 +18753,8 @@ public abstract class EDDTable extends EDD {
       throws Throwable {
 
     // if (accessibleViaSOS().length() > 0)
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
@@ -18654,22 +18778,22 @@ public abstract class EDDTable extends EDD {
     int tIdIndex = table.findColumnNumber(idName);
     if (tLonIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'longitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'longitude' isn't in the response table.");
     if (tLatIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'latitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'latitude' isn't in the response table.");
     if (altIndex >= 0 && tAltIndex < 0) // yes, first one is alt, not tAlt
     throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'altitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'altitude' isn't in the response table.");
     if (depthIndex >= 0 && tDepthIndex < 0) // yes, first one is depth, not tDepth
     throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'depth' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'depth' isn't in the response table.");
     if (tTimeIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'time' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'time' isn't in the response table.");
     if (tIdIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'" + idName + "' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'" + idName + "' isn't in the response table.");
 
     // Ensure it is sorted by tIdIndex, tTimeIndex, [tAltIndex|tDepthIndex] (it usually is, but make
     // sure; it is assumed below)
@@ -19100,7 +19224,7 @@ public abstract class EDDTable extends EDD {
               // withinTimeIndex may not be tAltIndex or tDepthIndex,
               // so ensure there is an tAltIndex or tDepthIndex
               throw new SimpleException(
-                  EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                  EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                       + "This dataset is not suitable for SOS: there are multiple values for one time, but there is no altitude or depth variable.");
             } else {
               // withinTimeIndex may not be tAltIndex or tDepthIndex,
@@ -19109,7 +19233,7 @@ public abstract class EDDTable extends EDD {
               String val = table.getStringData(tAltDepthIndex, timeRow);
               if (val.equals(lastAltVal))
                 throw new SimpleException(
-                    EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                    EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                         + "This dataset is not suitable for SOS: there are multiple values for one time, but not because of the altitude or depth variable.");
               lastAltVal = val;
 
@@ -19195,7 +19319,7 @@ public abstract class EDDTable extends EDD {
                 // withinTimeIndex may not be tAltIndex or tDepthIndex,
                 // so ensure there is an tAltIndex or tDepthIndex
                 throw new SimpleException(
-                    EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                    EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                         + "This dataset is not suitable for SOS: there are multiple values for one time, but there is no altitude variable.");
               } else {
                 // withinTimeIndex may not be tAltIndex or tDepthIndex,
@@ -19204,7 +19328,7 @@ public abstract class EDDTable extends EDD {
                 String val = table.getStringData(tAltDepthIndex, timeRow);
                 if (val.equals(lastAltVal))
                   throw new SimpleException(
-                      EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                      EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                           + "This dataset is not suitable for SOS: there are multiple values for one time, but not because of the altitude or depth variable.");
                 lastAltVal = val;
 
@@ -19326,7 +19450,8 @@ public abstract class EDDTable extends EDD {
       throws Throwable {
 
     // if (accessibleViaSOS().length() > 0)
-    //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) +
+    //    throw new SimpleException(EDStatic.simpleBilingual(language,
+    // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
     String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
@@ -19350,22 +19475,22 @@ public abstract class EDDTable extends EDD {
     int tIdIndex = table.findColumnNumber(idName);
     if (tLonIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'longitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'longitude' isn't in the response table.");
     if (tLatIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'latitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'latitude' isn't in the response table.");
     if (altIndex >= 0 && tAltIndex < 0) // yes, first one is alt, not tAlt
     throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'altitude' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'altitude' isn't in the response table.");
     if (depthIndex >= 0 && tDepthIndex < 0) // yes, first one is depth, not tDepth
     throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'depth' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'depth' isn't in the response table.");
     if (tTimeIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'time' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'time' isn't in the response table.");
     if (tIdIndex < 0)
       throw new RuntimeException(
-          EDStatic.errorInternalAr[0] + "'" + idName + "' isn't in the response table.");
+          EDStatic.messages.errorInternalAr[0] + "'" + idName + "' isn't in the response table.");
 
     // Ensure it is sorted by tIdIndex, tTimeIndex, [tAltIndex|tDepthIndex] (it usually is, but make
     // sure; it is assumed below)
@@ -19942,14 +20067,14 @@ public abstract class EDDTable extends EDD {
         "<br>The parameters may be in any order in the URL, separated by '&amp;' .\n"
             + "<br>Parameter values are case sensitive and must be\n"
             + "  <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "<br>all characters in query values (the parts after the '=' signs) other than A-Za-z0-9_-!.~'()* must be\n"
             + "<br>encoded as %HH, where HH is the 2 digit hexadecimal value of the character, for example, space becomes %20.\n"
             + "<br>Characters above #127 must be converted to UTF-8 bytes, then each UTF-8 byte must be percent encoded\n"
             + "<br>(ask a programmer for help). There are\n"
             + "<a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "\n";
 
@@ -20029,7 +20154,7 @@ public abstract class EDDTable extends EDD {
     writer.write(
         "<h2><a class=\"selfLink\" id=\"description\" href=\"#description\" rel=\"bookmark\">What</a> is SOS?</h2>\n"
             + String2.replaceAll(
-                EDStatic.sosLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
+                EDStatic.messages.sosLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
             + "\n"
             + datasetListRef
             + "\n"
@@ -20065,7 +20190,7 @@ public abstract class EDDTable extends EDD {
             + "  <br>Some of the information you need to write such software is below. Good luck.\n"
             + "<li>For additional information, please see the\n"
             + "  <a rel=\"help\" href=\"https://www.opengeospatial.org/standards/sos\">OGC's SOS Specification"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "</ul>\n"
             + "\n");
@@ -20074,7 +20199,7 @@ public abstract class EDDTable extends EDD {
     writer.write(
         "<h2>Sample SOS Requests for this Dataset and Details from the \n"
             + "<a rel=\"help\" href=\"https://www.opengeospatial.org/standards/sos\">SOS Specification"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a></h2>\n"
             + "SOS requests are specially formed URLs with queries.\n"
             + "<br>You can create these URLs yourself or write software to do it for you.\n"
@@ -20193,7 +20318,7 @@ public abstract class EDDTable extends EDD {
             + "</td>\n"
             + "    <td>The only valid value (in\n"
             + "      <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>\n"
             + "      form) is"
             + "       <br>\""
@@ -20520,7 +20645,7 @@ public abstract class EDDTable extends EDD {
             + "    <br>eventTime=<i>beginTime/endTime</i></td>\n"
             + "    <td>The beginTime and endTime must be in\n"
             + "      <a rel=\"help\" href=\"https://en.wikipedia.org/wiki/ISO_8601\">ISO 8601:2004 \"extended\" format\n"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>,\n"
             + "      <br>for example, \"1985-01-02T00:00:00Z\".\n"
             + "      <br>This parameter is optional for the SOS standard and ERDDAP.\n"
@@ -20578,14 +20703,14 @@ public abstract class EDDTable extends EDD {
             + "    <td>responseFormat=<i>mimeType</i></td>\n"
             + "    <td>In ERDDAP, this can be any one of several response formats.\n"
             + "      <br>The value must be <a class=\"N\" rel=\"help\" href=\"https://en.wikipedia.org/wiki/Percent-encoding\">percent encoded"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>:\n"
             + "      <br>all characters in query values (the parts after the '=' signs) other than A-Za-z0-9_-!.~'()* must be\n"
             + "      <br>encoded as %HH, where HH is the 2 digit hexadecimal value of the character, for example, space becomes %20.\n"
             + "      <br>Characters above #127 must be converted to UTF-8 bytes, then each UTF-8 byte must be percent encoded\n"
             + "      <br>(ask a programmer for help). There are\n"
             + "<a class=\"N\" rel=\"help\" href=\"https://www.url-encode-decode.com\">websites that percent encode/decode for you"
-            + EDStatic.externalLinkHtml(language, tErddapUrl)
+            + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a>.\n"
             + "      <br>The data responseFormats are:<br>");
     charsWritten = 0;
@@ -20710,7 +20835,8 @@ public abstract class EDDTable extends EDD {
           if (gVisQueryLC.startsWith("'", start)) {
             // 'colName'
             int po = gVisQueryLC.indexOf("'", start + 1);
-            if (po < 0) return EDStatic.queryErrorAr[0] + "missing \"'\" after position=" + start;
+            if (po < 0)
+              return EDStatic.messages.queryErrorAr[0] + "missing \"'\" after position=" + start;
             name = gVisQuery.substring(start + 1, po);
             start = po + 1;
           } else {
@@ -20723,7 +20849,7 @@ public abstract class EDDTable extends EDD {
             start = po;
           }
           if (String2.indexOf(dataVariableDestinationNames, name) < 0)
-            return EDStatic.queryErrorAr[0]
+            return EDStatic.messages.queryErrorAr[0]
                 + "unrecognized column name=\""
                 + name
                 + "\" at position="
@@ -20780,8 +20906,8 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + EDStatic.noXxxNoLLAr[0],
-              EDStatic.queryErrorAr[language] + EDStatic.noXxxNoLLAr[language]));
+              EDStatic.messages.queryErrorAr[0] + EDStatic.messages.noXxxNoLLAr[0],
+              EDStatic.messages.queryErrorAr[language] + EDStatic.messages.noXxxNoLLAr[language]));
 
     String tErddapUrl = EDStatic.preferredErddapUrl;
     String datasetUrl = tErddapUrl + "/" + dapProtocol + "/" + datasetID();
@@ -21732,8 +21858,8 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + EDStatic.noXxxNoLLAr[0],
-              EDStatic.queryErrorAr[language] + EDStatic.noXxxNoLLAr[language]));
+              EDStatic.messages.queryErrorAr[0] + EDStatic.messages.noXxxNoLLAr[0],
+              EDStatic.messages.queryErrorAr[language] + EDStatic.messages.noXxxNoLLAr[language]));
 
     String tErddapUrl = EDStatic.preferredErddapUrl;
     String datasetUrl = tErddapUrl + "/tabledap/" + datasetID;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
@@ -1620,8 +1620,8 @@ public abstract class EDDTable extends EDD {
    * (which has access to all the data).
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery the OPeNDAP DAP-style query from the user, after the '?', still
    *     percentEncoded (shouldn't be null). (e.g., var1,var2&var3&lt;40) referring to variable's
    *     destinationNames (e.g., LAT), instead of the sourceNames. Presumably, getSourceDapQuery has
@@ -1935,8 +1935,8 @@ public abstract class EDDTable extends EDD {
    *     is included, this method does NOT check if loggedInAs has access to this dataset. The
    *     exceptions are fromPOST datasets, where loggedInAs is used to determine access to each row
    *     of data.
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery the OPeNDAP DAP-style query from the user after the '?', still
    *     percentEncoded (may be null). (e.g., var1,var2&var3%3C=40) referring to destination
    *     variable names. See parseUserDapQuery.
@@ -1961,9 +1961,9 @@ public abstract class EDDTable extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but in unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata. Use "" if not important (e.g., for
-   *     tests).
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata. Use "" if not important (e.g.,
+   *     for tests).
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded
    *     (shouldn't be null).
    * @return twawm with all of the data already read. twawm always adds a randomInt to the temporary
@@ -2018,8 +2018,8 @@ public abstract class EDDTable extends EDD {
    * This calls standardizeResultsTable.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery after the '?', still percentEncoded (shouldn't be null).
    * @param table with a chunk of the total source data.
    * @param tableWriter to which the table's data will be written
@@ -2041,7 +2041,7 @@ public abstract class EDDTable extends EDD {
     // write to tableWriter?
     // String2.log("writeChunkToTableWriter table.nRows=" + table.nRows());
     if (table.nRows() > 1000
-        || (table.nRows() * (long) table.nColumns() > EDStatic.partialRequestMaxCells)
+        || (table.nRows() * (long) table.nColumns() > EDStatic.config.partialRequestMaxCells)
         || finish) {
 
       if (table.nRows() == 0 && finish) {
@@ -3229,8 +3229,8 @@ public abstract class EDDTable extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but in unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded
    *     (shouldn't be null).
    * @param outputStreamSource the source of an outputStream that receives the results, usually
@@ -3315,7 +3315,7 @@ public abstract class EDDTable extends EDD {
     // special EDDTableFromHttpGet file types
     if (this instanceof EDDTableFromHttpGet etfhg
         && (fileTypeName.equals(".insert") || fileTypeName.equals(".delete"))) {
-      if (!EDStatic.developmentMode && loggedInAs == null)
+      if (!EDStatic.config.developmentMode && loggedInAs == null)
         throw new SimpleException(
             EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + fileTypeName
@@ -3867,10 +3867,10 @@ public abstract class EDDTable extends EDD {
         twawm.close();
       } else if (fileTypeName.equals(".nc4") || fileTypeName.equals(".nc4Header")) {
 
-        if (EDStatic.accessibleViaNC4.length() > 0)
+        if (EDStatic.config.accessibleViaNC4.length() > 0)
           throw new SimpleException(
               EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
-                  + EDStatic.accessibleViaNC4);
+                  + EDStatic.config.accessibleViaNC4);
 
         // if .nc4Header, make sure the .nc4 file exists
         // (and it is the better file to cache)
@@ -4005,7 +4005,8 @@ public abstract class EDDTable extends EDD {
         File2.rename(cacheFullName + random, cacheFullName); // make available in an instant
         if (!ok) // make eligible to be removed from cache in 5 minutes
         File2.touch(
-              cacheFullName, Math.max(0, EDStatic.cacheMillis - 5 * Calendar2.MILLIS_PER_MINUTE));
+              cacheFullName,
+              Math.max(0, EDStatic.config.cacheMillis - 5 * Calendar2.MILLIS_PER_MINUTE));
 
         File2.isFile(
             cacheFullName,
@@ -4049,7 +4050,7 @@ public abstract class EDDTable extends EDD {
     }
 
     // copy file to ...
-    if (EDStatic.awsS3OutputBucketUrl == null) {
+    if (EDStatic.config.awsS3OutputBucketUrl == null) {
 
       // copy file to outputStream
       // (I delayed getting actual outputStream as long as possible.)
@@ -4069,8 +4070,10 @@ public abstract class EDDTable extends EDD {
       // copy file to AWS and redirect user
       String contentType =
           OutputStreamFromHttpResponse.getFileContentType(request, fileTypeName, fileTypeExtension);
-      String fullAwsUrl = EDStatic.awsS3OutputBucketUrl + File2.getNameAndExtension(fullName);
-      SSR.uploadFileToAwsS3(EDStatic.awsS3OutputTransferManager, fullName, fullAwsUrl, contentType);
+      String fullAwsUrl =
+          EDStatic.config.awsS3OutputBucketUrl + File2.getNameAndExtension(fullName);
+      SSR.uploadFileToAwsS3(
+          EDStatic.config.awsS3OutputTransferManager, fullName, fullAwsUrl, contentType);
       response.sendRedirect(fullAwsUrl);
     }
 
@@ -4376,7 +4379,7 @@ public abstract class EDDTable extends EDD {
           }
         }
       } else if (p.startsWith("units(\"") && p.endsWith("\")")) {
-        String fromUnits = EDStatic.units_standard;
+        String fromUnits = EDStatic.config.units_standard;
         String toUnits = p.substring(7, p.length() - 2);
         TableWriterUnits.checkFromToUnits(language, fromUnits, toUnits);
         if (!fromUnits.equals(toUnits)) {
@@ -4400,8 +4403,8 @@ public abstract class EDDTable extends EDD {
    * request.
    *
    * @param language the index of the selected language
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery the part after the '?', still percentEncoded (shouldn't be null).
    * @param withAttributes
    * @return an empty table (with columns, but without rows) corresponding to the request
@@ -4437,7 +4440,7 @@ public abstract class EDDTable extends EDD {
       //// fix up global attributes  (always to a local COPY of global attributes)
       // EDD.addToHistory(table.globalAttributes(), publicSourceUrl());
       // EDD.addToHistory(table.globalAttributes(),
-      //    EDStatic.baseUrl + requestUrl); //userDapQuery is irrelevant
+      //    EDStatic.config.baseUrl + requestUrl); //userDapQuery is irrelevant
     }
 
     // add the columns
@@ -5167,7 +5170,7 @@ public abstract class EDDTable extends EDD {
       double fontScale = 1, vectorStandard = Double.NaN;
       String currentDrawLandMask = null; // not yet set
       StringBuilder title2 = new StringBuilder();
-      Color bgColor = EDStatic.graphBackgroundColor;
+      Color bgColor = EDStatic.config.graphBackgroundColor;
       String ampParts[] =
           Table.getDapQueryParts(userDapQuery); // decoded.  always at least 1 part (may be "")
       for (int ap = 0; ap < ampParts.length; ap++) {
@@ -5479,25 +5482,25 @@ public abstract class EDDTable extends EDD {
           if (zVar instanceof EDVTimeStamp)
             colorMap =
                 new CompoundColorMap(
-                    EDStatic.fullPaletteDirectory,
+                    EDStatic.config.fullPaletteDirectory,
                     palette,
                     false, // false= data is seconds
                     paletteMin,
                     paletteMax,
                     nSections,
                     continuous,
-                    EDStatic.fullCptCacheDirectory);
+                    EDStatic.config.fullCptCacheDirectory);
           else
             colorMap =
                 new CompoundColorMap(
-                    EDStatic.fullPaletteDirectory,
+                    EDStatic.config.fullPaletteDirectory,
                     palette,
                     scale,
                     paletteMin,
                     paletteMax,
                     nSections,
                     continuous,
-                    EDStatic.fullCptCacheDirectory);
+                    EDStatic.config.fullCptCacheDirectory);
         }
       }
 
@@ -5617,7 +5620,7 @@ public abstract class EDDTable extends EDD {
       // setup graphics2D
       String logoImageFile;
       if (pdf) {
-        logoImageFile = EDStatic.highResLogoImageFile;
+        logoImageFile = EDStatic.config.highResLogoImageFile;
         fontScale *= 1.4; // SgtMap.PDF_FONTSCALE=1.5 is too big
         // getting the outputStream was delayed as long as possible to allow errors
         // to be detected and handled before committing to sending results to client
@@ -5630,7 +5633,9 @@ public abstract class EDDTable extends EDD {
         g2 = (Graphics2D) pdfInfo[0];
       } else {
         logoImageFile =
-            sizeIndex <= 1 ? EDStatic.lowResLogoImageFile : EDStatic.highResLogoImageFile;
+            sizeIndex <= 1
+                ? EDStatic.config.lowResLogoImageFile
+                : EDStatic.config.highResLogoImageFile;
         fontScale *= imageWidth < 500 ? 1 : 1.25;
         bufferedImage = SgtUtil.getBufferedImage(imageWidth, imageHeight);
         g2 = (Graphics2D) bufferedImage.getGraphics();
@@ -5768,7 +5773,7 @@ public abstract class EDDTable extends EDD {
                     || table.nRows() == 0
                 ? null
                 : SgtMap.createTopographyGrid(
-                    EDStatic.fullSgtMapTopographyCacheDirectory,
+                    EDStatic.config.fullSgtMapTopographyCacheDirectory,
                     xMin,
                     xMax,
                     yMin,
@@ -5800,7 +5805,7 @@ public abstract class EDDTable extends EDD {
                 SgtUtil.LEGEND_BELOW,
                 EDStatic.messages.legendTitle1,
                 EDStatic.messages.legendTitle2,
-                EDStatic.imageDir,
+                EDStatic.config.imageDir,
                 logoImageFile,
                 xMin,
                 xMax,
@@ -5863,7 +5868,7 @@ public abstract class EDDTable extends EDD {
                 SgtUtil.LEGEND_BELOW,
                 EDStatic.messages.legendTitle1,
                 EDStatic.messages.legendTitle2,
-                EDStatic.imageDir,
+                EDStatic.config.imageDir,
                 logoImageFile,
                 xMin,
                 xMax,
@@ -5944,7 +5949,7 @@ public abstract class EDDTable extends EDD {
             msg = String2.noLongLines(msg, (imageWidth * 10 / 6) / tHeight, "    ");
             String lines[] = msg.split("\\n"); // not String2.split which trims
             g2.setColor(Color.black);
-            g2.setFont(new Font(EDStatic.fontFamily, Font.PLAIN, tHeight));
+            g2.setFont(new Font(EDStatic.config.fontFamily, Font.PLAIN, tHeight));
             int ty = tHeight * 2;
             for (String line : lines) {
               g2.drawString(line, tHeight, ty);
@@ -6468,7 +6473,7 @@ public abstract class EDDTable extends EDD {
         // missing values are already destinationMissingValues or destinationFillValues
         int nToGo = nRows;
         int ncOffset = 0;
-        int bufferSize = EDStatic.partialRequestMaxCells;
+        int bufferSize = EDStatic.config.partialRequestMaxCells;
         PrimitiveArray pa = null;
         try (DataInputStream dis = twawm.dataInputStream(col)) {
           PAType colType = twawm.columnType(col);
@@ -7964,7 +7969,7 @@ public abstract class EDDTable extends EDD {
     twawm.releaseResources();
     String parquetTempFileName =
         Path.of(
-                EDStatic.fullTestCacheDirectory,
+                EDStatic.config.fullTestCacheDirectory,
                 datasetID + Math2.random(Integer.MAX_VALUE) + ".parquet")
             .toString();
     table.writeParquet(parquetTempFileName, fullMetadata);
@@ -10156,7 +10161,7 @@ public abstract class EDDTable extends EDD {
             + "</a>\n"
             + "      (e.g., <kbd>2002-08-03T12:30:00Z</kbd>, but some time variables in some datasets include\n"
             + "      milliseconds, e.g., <kbd>2002-08-03T12:30:00.123Z</kbd>).\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "      <br>ERDDAP has a utility to\n"
                     + "        <a rel=\"bookmark\" href=\""
                     + tErddapUrl
@@ -10199,7 +10204,7 @@ public abstract class EDDTable extends EDD {
             + "      And this is consistent with some other places in ERDDAP that try to repair\n"
             + "      invalid input when the intention is clear, instead of just returning an error\n"
             + "      message.)\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "      <br>ERDDAP has a utility to\n"
                     + "        <a rel=\"bookmark\" href=\""
                     + tErddapUrl
@@ -10542,9 +10547,9 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.externalLinkHtml(language, tErddapUrl)
             + "</a> standard (for example, <kbd>Cel</kbd>).\n"
             + "      <br>On this ERDDAP, the default for most/all datasets is "
-            + EDStatic.units_standard
+            + EDStatic.config.units_standard
             + ".\n"
-            + (EDStatic.convertersActive
+            + (EDStatic.config.convertersActive
                 ? "      <br>See also ERDDAP's <a rel=\"bookmark\" href=\""
                     + tErddapUrl
                     + "/convert/units.html\"\n"
@@ -10587,7 +10592,7 @@ public abstract class EDDTable extends EDD {
             + "       For example, a fully opaque (ff) greenish-blue color with red=22, green=88, blue=ee\n"
             + "       would be 0xff2288ee. Opaque white is 0xffffffff. Opaque light blue is 0xffccccff.\n"
             + "       The default on this ERDDAP is "
-            + String2.to0xHexString(EDStatic.graphBackgroundColor.getRGB(), 8)
+            + String2.to0xHexString(EDStatic.config.graphBackgroundColor.getRGB(), 8)
             + ".\n"
             + "    <li><kbd>&amp;.colorBar=<i>palette</i>|<i>continuous</i>|<i>scale</i>|<i>min</i>|<i>max</i>|<i>nSections</i></kbd> \n"
             + "      <br>This specifies the settings for a color bar.  The sub-values are:\n"
@@ -10976,8 +10981,8 @@ public abstract class EDDTable extends EDD {
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
    *     (EDDTableFromPost?) it could be. Normally, this is just used to determine which erddapUrl
    *     to use (http vs https).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery after the '?', still percentEncoded (shouldn't be null). If the query has
    *     missing or invalid parameters, defaults will be used. If the query has irrelevant
    *     parameters, they will be ignored.
@@ -12585,7 +12590,7 @@ public abstract class EDDTable extends EDD {
       }
 
       // bgColor
-      Color bgColor = EDStatic.graphBackgroundColor;
+      Color bgColor = EDStatic.config.graphBackgroundColor;
       String tBGColor = String2.stringStartsWith(queryParts, partName = ".bgColor=");
       if (tBGColor != null) {
         String tBGColorAr[] = String2.split(tBGColor.substring(partName.length()), '|');
@@ -15241,7 +15246,7 @@ public abstract class EDDTable extends EDD {
 
     // are the combinations available in a .json or .csv file created by ERDDAP admin?
     // <contentDir>subset/datasetID.json
-    String adminSubsetFileName = EDStatic.contentDirectory + "subset/" + datasetID;
+    String adminSubsetFileName = EDStatic.config.contentDirectory + "subset/" + datasetID;
     if (File2.isFile(adminSubsetFileName + ".json")) {
       // json
       if (reallyVerbose)
@@ -15591,7 +15596,7 @@ public abstract class EDDTable extends EDD {
       String subject = "WARNING: datasetID=" + datasetID + " has carriageReturns or newlines";
       String2.log(subject);
       String2.log(results.toString());
-      // EDStatic.email(EDStatic.emailEverythingToCsv, subject,
+      // EDStatic.email(EDStatic.config.emailEverythingToCsv, subject,
       //    results.toString());
     }
 
@@ -15731,8 +15736,8 @@ public abstract class EDDTable extends EDD {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. I think
-   *     it's currently just used to add to "history" metadata.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'. I
+   *     think it's currently just used to add to "history" metadata.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter
@@ -15930,7 +15935,7 @@ public abstract class EDDTable extends EDD {
         tAccessibleViaSubset = EDStatic.messages.subsetNotSetUpAr[0];
 
       if ((className.equals("EDDTableFromDapSequence") || className.equals("EDDTableFromErddap"))
-          && EDStatic.quickRestart
+          && EDStatic.config.quickRestart
           && EDStatic.initialLoadDatasets()
           && File2.isFile(quickRestartFullFileName())) {
 
@@ -15938,7 +15943,7 @@ public abstract class EDDTable extends EDD {
         if (verbose) String2.log("  quickRestart: reusing subset and distinct files");
 
       } else if ((this instanceof EDDTableFromFiles)
-          && EDStatic.quickRestart
+          && EDStatic.config.quickRestart
           && EDStatic.initialLoadDatasets()) {
 
         // 2022-07-26 don't delete subset and distinct files  (to reuse them)
@@ -16061,7 +16066,7 @@ public abstract class EDDTable extends EDD {
   public String preliminaryAccessibleViaSOS() {
 
     // easy tests make for a better error message
-    if (!EDStatic.sosActive)
+    if (!EDStatic.config.sosActive)
       return String2.canonical(
           MessageFormat.format(
               EDStatic.messages.noXxxBecauseAr[0],
@@ -16184,7 +16189,7 @@ public abstract class EDDTable extends EDD {
   public String accessibleViaGeoServicesRest() {
     if (accessibleViaGeoServicesRest == null) {
 
-      if (!EDStatic.geoServicesRestActive)
+      if (!EDStatic.config.geoServicesRestActive)
         accessibleViaGeoServicesRest =
             String2.canonical(
                 MessageFormat.format(
@@ -16208,7 +16213,7 @@ public abstract class EDDTable extends EDD {
   public String accessibleViaWCS() {
     if (accessibleViaWCS == null) {
 
-      if (!EDStatic.wcsActive)
+      if (!EDStatic.config.wcsActive)
         accessibleViaWCS =
             String2.canonical(
                 MessageFormat.format(
@@ -16230,7 +16235,7 @@ public abstract class EDDTable extends EDD {
   @Override
   public String accessibleViaWMS() {
     if (accessibleViaWMS == null)
-      if (!EDStatic.wmsActive)
+      if (!EDStatic.config.wmsActive)
         accessibleViaWMS =
             String2.canonical(
                 MessageFormat.format(
@@ -16574,7 +16579,7 @@ public abstract class EDDTable extends EDD {
         + ":"
         + tSosOfferingType
         + ":"
-        + EDStatic.sosBaseGmlName
+        + EDStatic.config.sosBaseGmlName
         + "."
         + datasetID
         + ":"; // + shortOffering
@@ -16729,39 +16734,39 @@ public abstract class EDDTable extends EDD {
       writer.write(
           "  <ows:ServiceProvider>\n"
               + "    <ows:ProviderName>"
-              + XML.encodeAsXML(EDStatic.adminInstitution)
+              + XML.encodeAsXML(EDStatic.config.adminInstitution)
               + "</ows:ProviderName>\n"
               + "    <ows:ProviderSite xlink:href=\""
               + XML.encodeAsXML(tErddapUrl)
               + "\"/>\n"
               + "    <ows:ServiceContact>\n"
               + "      <ows:IndividualName>"
-              + XML.encodeAsXML(EDStatic.adminIndividualName)
+              + XML.encodeAsXML(EDStatic.config.adminIndividualName)
               + "</ows:IndividualName>\n"
               + "      <ows:ContactInfo>\n"
               + "        <ows:Phone>\n"
               + "          <ows:Voice>"
-              + XML.encodeAsXML(EDStatic.adminPhone)
+              + XML.encodeAsXML(EDStatic.config.adminPhone)
               + "</ows:Voice>\n"
               + "        </ows:Phone>\n"
               + "        <ows:Address>\n"
               + "          <ows:DeliveryPoint>"
-              + XML.encodeAsXML(EDStatic.adminAddress)
+              + XML.encodeAsXML(EDStatic.config.adminAddress)
               + "</ows:DeliveryPoint>\n"
               + "          <ows:City>"
-              + XML.encodeAsXML(EDStatic.adminCity)
+              + XML.encodeAsXML(EDStatic.config.adminCity)
               + "</ows:City>\n"
               + "          <ows:AdministrativeArea>"
-              + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+              + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
               + "</ows:AdministrativeArea>\n"
               + "          <ows:PostalCode>"
-              + XML.encodeAsXML(EDStatic.adminPostalCode)
+              + XML.encodeAsXML(EDStatic.config.adminPostalCode)
               + "</ows:PostalCode>\n"
               + "          <ows:Country>"
-              + XML.encodeAsXML(EDStatic.adminCountry)
+              + XML.encodeAsXML(EDStatic.config.adminCountry)
               + "</ows:Country>\n"
               + "          <ows:ElectronicMailAddress>"
-              + XML.encodeAsXML(EDStatic.adminEmail)
+              + XML.encodeAsXML(EDStatic.config.adminEmail)
               + "</ows:ElectronicMailAddress>\n"
               + "        </ows:Address>\n"
               + "      </ows:ContactInfo>\n"
@@ -17490,37 +17495,37 @@ public abstract class EDDTable extends EDD {
             +
             // bob added:
             "          <sml:individualName>"
-            + XML.encodeAsXML(EDStatic.adminIndividualName)
+            + XML.encodeAsXML(EDStatic.config.adminIndividualName)
             + "</sml:individualName>\n"
             + "          <sml:organizationName>"
-            + XML.encodeAsXML(EDStatic.adminInstitution)
+            + XML.encodeAsXML(EDStatic.config.adminInstitution)
             + "</sml:organizationName>\n"
             + "          <sml:contactInfo>\n"
             + "            <sml:phone>\n"
             + "              <sml:voice>"
-            + XML.encodeAsXML(EDStatic.adminPhone)
+            + XML.encodeAsXML(EDStatic.config.adminPhone)
             + "</sml:voice>\n"
             + "            </sml:phone>\n"
             + "            <sml:address>\n"
             + "              <sml:deliveryPoint>"
-            + XML.encodeAsXML(EDStatic.adminAddress)
+            + XML.encodeAsXML(EDStatic.config.adminAddress)
             + "</sml:deliveryPoint>\n"
             + "              <sml:city>"
-            + XML.encodeAsXML(EDStatic.adminCity)
+            + XML.encodeAsXML(EDStatic.config.adminCity)
             + "</sml:city>\n"
             + "              <sml:administrativeArea>"
-            + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+            + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
             + "</sml:administrativeArea>\n"
             + "              <sml:postalCode>"
-            + XML.encodeAsXML(EDStatic.adminPostalCode)
+            + XML.encodeAsXML(EDStatic.config.adminPostalCode)
             + "</sml:postalCode>\n"
             + "              <sml:country>"
-            + XML.encodeAsXML(EDStatic.adminCountry)
+            + XML.encodeAsXML(EDStatic.config.adminCountry)
             + "</sml:country>\n"
             +
             // bob added:
             "              <sml:electronicMailAddress>"
-            + XML.encodeAsXML(EDStatic.adminEmail)
+            + XML.encodeAsXML(EDStatic.config.adminEmail)
             + "</sml:electronicMailAddress>\n"
             + "            </sml:address>\n"
             + "            <sml:onlineResource xlink:href=\""
@@ -17892,7 +17897,7 @@ public abstract class EDDTable extends EDD {
             throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (from source)");
 
           // convert UDUNITS to UCUM units  (before direct use of twawm or get cumulativeTable)
-          if (EDStatic.units_standard.equals("UDUNITS")) {
+          if (EDStatic.config.units_standard.equals("UDUNITS")) {
             int nColumns = twawm.nColumns();
             for (int col = 0; col < nColumns; col++) {
               Attributes atts = twawm.columnAttributes(col);
@@ -17927,7 +17932,7 @@ public abstract class EDDTable extends EDD {
       } else {
         // *** handle all other file types
         // add the units function to dapQuery?
-        if (!EDStatic.units_standard.equals("UCUM")) dapQuery += "&units(%22UCUM%22)";
+        if (!EDStatic.config.units_standard.equals("UCUM")) dapQuery += "&units(%22UCUM%22)";
 
         respondToDapQuery(
             language,
@@ -20913,7 +20918,7 @@ public abstract class EDDTable extends EDD {
     String datasetUrl = tErddapUrl + "/" + dapProtocol + "/" + datasetID();
     String sosUrl = tErddapUrl + "/sos/" + datasetID() + "/" + sosServer; // "?" at end?
     String wmsUrl = tErddapUrl + "/wms/" + datasetID() + "/" + WMS_SERVER; // "?" at end?
-    String domain = EDStatic.baseUrl;
+    String domain = EDStatic.config.baseUrl;
     if (domain.startsWith("http://")) domain = domain.substring(7);
     else if (domain.startsWith("https://")) domain = domain.substring(8);
     String eddCreationDate =
@@ -20950,7 +20955,7 @@ public abstract class EDDTable extends EDD {
     String keywords = combinedGlobalAttributes.getString("keywords");
     String keywordsVocabulary = combinedGlobalAttributes.getString("keywords_vocabulary");
     if (keywords == null) { // use the crude, ERDDAP keywords
-      keywords = EDStatic.keywords;
+      keywords = EDStatic.config.keywords;
       keywordsVocabulary = null;
     }
     String license = combinedGlobalAttributes.getString("license");
@@ -20963,18 +20968,24 @@ public abstract class EDDTable extends EDD {
     String standardNameVocabulary = combinedGlobalAttributes.getString("standard_name_vocabulary");
 
     String adminInstitution =
-        EDStatic.adminInstitution == null ? unknown : EDStatic.adminInstitution;
+        EDStatic.config.adminInstitution == null ? unknown : EDStatic.config.adminInstitution;
     String adminIndividualName =
-        EDStatic.adminIndividualName == null ? unknown : EDStatic.adminIndividualName;
-    String adminPosition = EDStatic.adminPosition == null ? unknown : EDStatic.adminPosition;
-    String adminPhone = EDStatic.adminPhone == null ? unknown : EDStatic.adminPhone;
-    String adminAddress = EDStatic.adminAddress == null ? unknown : EDStatic.adminAddress;
-    String adminCity = EDStatic.adminCity == null ? unknown : EDStatic.adminCity;
+        EDStatic.config.adminIndividualName == null ? unknown : EDStatic.config.adminIndividualName;
+    String adminPosition =
+        EDStatic.config.adminPosition == null ? unknown : EDStatic.config.adminPosition;
+    String adminPhone = EDStatic.config.adminPhone == null ? unknown : EDStatic.config.adminPhone;
+    String adminAddress =
+        EDStatic.config.adminAddress == null ? unknown : EDStatic.config.adminAddress;
+    String adminCity = EDStatic.config.adminCity == null ? unknown : EDStatic.config.adminCity;
     String adminStateOrProvince =
-        EDStatic.adminStateOrProvince == null ? unknown : EDStatic.adminStateOrProvince;
-    String adminPostalCode = EDStatic.adminPostalCode == null ? unknown : EDStatic.adminPostalCode;
-    String adminCountry = EDStatic.adminCountry == null ? unknown : EDStatic.adminCountry;
-    String adminEmail = EDStatic.adminEmail == null ? unknown : EDStatic.adminEmail;
+        EDStatic.config.adminStateOrProvince == null
+            ? unknown
+            : EDStatic.config.adminStateOrProvince;
+    String adminPostalCode =
+        EDStatic.config.adminPostalCode == null ? unknown : EDStatic.config.adminPostalCode;
+    String adminCountry =
+        EDStatic.config.adminCountry == null ? unknown : EDStatic.config.adminCountry;
+    String adminEmail = EDStatic.config.adminEmail == null ? unknown : EDStatic.config.adminEmail;
 
     // testMinimalMetadata is useful for Bob doing tests of validity of FGDC results
     //  when a dataset has minimal metadata
@@ -21865,7 +21876,7 @@ public abstract class EDDTable extends EDD {
     String datasetUrl = tErddapUrl + "/tabledap/" + datasetID;
     // String wcsUrl     = tErddapUrl + "/wcs/"     + datasetID() + "/" + wcsServer;  // "?" at end?
     String wmsUrl = tErddapUrl + "/wms/" + datasetID() + "/" + WMS_SERVER; // "?" at end?
-    String domain = EDStatic.baseUrl;
+    String domain = EDStatic.config.baseUrl;
     if (domain.startsWith("http://")) domain = domain.substring(7);
     else if (domain.startsWith("https://")) domain = domain.substring(8);
     String eddCreationDate = Calendar2.millisToIsoDateString(creationTimeMillis());
@@ -21900,7 +21911,7 @@ public abstract class EDDTable extends EDD {
     String institution = combinedGlobalAttributes.getString("institution");
     String keywords = combinedGlobalAttributes.getString("keywords");
     if (keywords == null) { // use the crude, ERDDAP keywords
-      keywords = EDStatic.keywords;
+      keywords = EDStatic.config.keywords;
     }
     String license = combinedGlobalAttributes.getString("license");
     String project = combinedGlobalAttributes.getString("project");
@@ -22050,12 +22061,12 @@ public abstract class EDDTable extends EDD {
             + "    <gmd:CI_ResponsibleParty>\n"
             + "      <gmd:individualName>\n"
             + "        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminIndividualName)
+            + XML.encodeAsXML(EDStatic.config.adminIndividualName)
             + "</gco:CharacterString>\n"
             + "      </gmd:individualName>\n"
             + "      <gmd:organisationName>\n"
             + "        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminInstitution)
+            + XML.encodeAsXML(EDStatic.config.adminInstitution)
             + "</gco:CharacterString>\n"
             + "      </gmd:organisationName>\n"
             + "      <gmd:contactInfo>\n"
@@ -22064,7 +22075,7 @@ public abstract class EDDTable extends EDD {
             + "            <gmd:CI_Telephone>\n"
             + "              <gmd:voice>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPhone)
+            + XML.encodeAsXML(EDStatic.config.adminPhone)
             + "</gco:CharacterString>\n"
             + "              </gmd:voice>\n"
             + "            </gmd:CI_Telephone>\n"
@@ -22073,32 +22084,32 @@ public abstract class EDDTable extends EDD {
             + "            <gmd:CI_Address>\n"
             + "              <gmd:deliveryPoint>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminAddress)
+            + XML.encodeAsXML(EDStatic.config.adminAddress)
             + "</gco:CharacterString>\n"
             + "              </gmd:deliveryPoint>\n"
             + "              <gmd:city>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCity)
+            + XML.encodeAsXML(EDStatic.config.adminCity)
             + "</gco:CharacterString>\n"
             + "              </gmd:city>\n"
             + "              <gmd:administrativeArea>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+            + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
             + "</gco:CharacterString>\n"
             + "              </gmd:administrativeArea>\n"
             + "              <gmd:postalCode>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPostalCode)
+            + XML.encodeAsXML(EDStatic.config.adminPostalCode)
             + "</gco:CharacterString>\n"
             + "              </gmd:postalCode>\n"
             + "              <gmd:country>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCountry)
+            + XML.encodeAsXML(EDStatic.config.adminCountry)
             + "</gco:CharacterString>\n"
             + "              </gmd:country>\n"
             + "              <gmd:electronicMailAddress>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminEmail)
+            + XML.encodeAsXML(EDStatic.config.adminEmail)
             + "</gco:CharacterString>\n"
             + "              </gmd:electronicMailAddress>\n"
             + "            </gmd:CI_Address>\n"
@@ -23170,12 +23181,12 @@ public abstract class EDDTable extends EDD {
             "            <gmd:CI_ResponsibleParty>\n"
             + "              <gmd:individualName>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminIndividualName)
+            + XML.encodeAsXML(EDStatic.config.adminIndividualName)
             + "</gco:CharacterString>\n"
             + "              </gmd:individualName>\n"
             + "              <gmd:organisationName>\n"
             + "                <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminInstitution)
+            + XML.encodeAsXML(EDStatic.config.adminInstitution)
             + "</gco:CharacterString>\n"
             + "              </gmd:organisationName>\n"
             + "              <gmd:contactInfo>\n"
@@ -23184,7 +23195,7 @@ public abstract class EDDTable extends EDD {
             + "                    <gmd:CI_Telephone>\n"
             + "                      <gmd:voice>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPhone)
+            + XML.encodeAsXML(EDStatic.config.adminPhone)
             + "</gco:CharacterString>\n"
             + "                      </gmd:voice>\n"
             + "                    </gmd:CI_Telephone>\n"
@@ -23193,32 +23204,32 @@ public abstract class EDDTable extends EDD {
             + "                    <gmd:CI_Address>\n"
             + "                      <gmd:deliveryPoint>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminAddress)
+            + XML.encodeAsXML(EDStatic.config.adminAddress)
             + "</gco:CharacterString>\n"
             + "                      </gmd:deliveryPoint>\n"
             + "                      <gmd:city>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCity)
+            + XML.encodeAsXML(EDStatic.config.adminCity)
             + "</gco:CharacterString>\n"
             + "                      </gmd:city>\n"
             + "                      <gmd:administrativeArea>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminStateOrProvince)
+            + XML.encodeAsXML(EDStatic.config.adminStateOrProvince)
             + "</gco:CharacterString>\n"
             + "                      </gmd:administrativeArea>\n"
             + "                      <gmd:postalCode>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminPostalCode)
+            + XML.encodeAsXML(EDStatic.config.adminPostalCode)
             + "</gco:CharacterString>\n"
             + "                      </gmd:postalCode>\n"
             + "                      <gmd:country>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminCountry)
+            + XML.encodeAsXML(EDStatic.config.adminCountry)
             + "</gco:CharacterString>\n"
             + "                      </gmd:country>\n"
             + "                      <gmd:electronicMailAddress>\n"
             + "                        <gco:CharacterString>"
-            + XML.encodeAsXML(EDStatic.adminEmail)
+            + XML.encodeAsXML(EDStatic.config.adminEmail)
             + "</gco:CharacterString>\n"
             + "                      </gmd:electronicMailAddress>\n"
             + "                    </gmd:CI_Address>\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
@@ -552,7 +552,7 @@ public class EDDTableAggregateRows extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRows.java
@@ -280,7 +280,7 @@ public class EDDTableAggregateRows extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // specify what sourceCanConstrain
@@ -535,7 +535,7 @@ public class EDDTableAggregateRows extends EDDTable {
       if (tChild == null) {
         EDD.requestReloadASAP(localChildrenID[c]);
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\n(underlying local child["
                 + c
                 + "] datasetID="

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopy.java
@@ -83,7 +83,7 @@ public class EDDTableCopy extends EDDTable {
     String tDefaultDataQuery = null;
     String tDefaultGraphQuery = null;
     String tAddVariablesWhere = null;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     int tStandardizeWhat = Integer.MAX_VALUE; // not specified by user
     int tnThreads = -1; // interpret invalid values (like -1) as EDStatic.nTableThreads
 
@@ -282,7 +282,7 @@ public class EDDTableCopy extends EDDTable {
         tStandardizeWhat < 0 || tStandardizeWhat == Integer.MAX_VALUE
             ? defaultStandardizeWhat()
             : tStandardizeWhat;
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles;
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles;
     nThreads = tnThreads; // interpret invalid values (like -1) as EDStatic.nTableThreads
 
     // check some things
@@ -314,7 +314,7 @@ public class EDDTableCopy extends EDDTable {
     if (reallyVerbose) String2.log("orderExtractBy=" + orderExtractBy);
 
     // ensure copyDatasetDir exists
-    String copyDatasetDir = EDStatic.fullCopyDirectory + datasetID + "/";
+    String copyDatasetDir = EDStatic.config.fullCopyDirectory + datasetID + "/";
     File2.makeDirectory(copyDatasetDir);
 
     // assign copy tasks to taskThread
@@ -466,7 +466,7 @@ public class EDDTableCopy extends EDDTable {
             .ensureTaskThreadIsRunningIfNeeded(); // clients (like this class) are responsible for
         // checking on it
 
-        if (EDStatic.forceSynchronousLoading) {
+        if (EDStatic.config.forceSynchronousLoading) {
           while (EDStatic.lastFinishedTask.get() < taskNumber) {
             Thread.sleep(2000);
           }
@@ -750,7 +750,7 @@ public class EDDTableCopy extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopyPost.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableCopyPost.javaINACTIVE
@@ -321,9 +321,9 @@ public class EDDTableCopyPost extends EDDTableCopy {
             EDDTable tedd = (EDDTable)oneFromDatasetsXml(null, "cPostSurg3"); 
 /* */
             //das
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_cps3_Data", ".das"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 //data changes so it is hard to test all
 "Attributes {\n" +
@@ -344,9 +344,9 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 "\nresults=\n" + results);
 
             //.dds 
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_cps3_Data", ".dds"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -403,8 +403,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1role", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1role", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -419,8 +419,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleLIOD", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleLIOD", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //same expected
             Test.ensureEqual(results.substring(0, expected.length()), expected, 
                 "\nresults=\n" + results.substring(0, 3000));
@@ -432,8 +432,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 String2.log("\nUnexpected results:\n" + results);
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
@@ -451,8 +451,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, "WELCH_DAVID", tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleWP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleWP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
                 if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -465,8 +465,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleL", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleL", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -481,8 +481,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "&orderBy(\"unique_tag_id\")"; //without this, data is ordered by pi, so different order
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1rolePDLI", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1rolePDLI", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -498,8 +498,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "longitude,latitude,time&time>=2007-05-01&time<2007-09-01";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_LLT", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_LLT", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //String2.log("results=\n" + results.substring(0, Math.min(results.length(), 10000)));
             po = results.indexOf("NaN");
             String2.log("\nresults.length()=" + results.length() + "  NaN po=" + po);
@@ -510,8 +510,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "role&distinct()";
             tName = tedd.makeNewFileForDapQuery(language, null, EDStatic.loggedInAsSuperuser, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_roles", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_roles", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "role\n" +
 "\n" +
@@ -531,8 +531,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             eTime = System.currentTimeMillis();
             tQuery = "unique_tag_id,pi,longitude,latitude,time,tagger&tagger=\"\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "noTagger", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_noTagger", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_noTagger", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, tagger, date_public, role\n" +
 ", , degrees_east, degrees_north, UTC, , UTC, \n" +
@@ -547,8 +547,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
             Test.ensureTrue(String2.max("", "ADRIAN LADOUCEUR").equals("ADRIAN LADOUCEUR"), "\"\" doesn't sort first!");
             tQuery = "unique_tag_id,pi,longitude,latitude,time,tagger&tagger=%22ADRIAN%20LADOUCEUR%22";
             tName = tedd.makeNewFileForDapQuery(language, null, "tagAL", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_tagAL", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_tagAL", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, tagger, date_public, role\n" +
 ", , degrees_east, degrees_north, UTC, , UTC, \n" +
@@ -630,9 +630,9 @@ public class EDDTableCopyPost extends EDDTableCopy {
             EDDTable tedd = (EDDTable)oneFromDatasetsXml(null, "cPostDet3"); 
 /* 
             //das
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_cpd3_Data", ".das"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
             expected = 
 "Attributes {\n" +
 " s {\n" +
@@ -649,9 +649,9 @@ public class EDDTableCopyPost extends EDDTableCopy {
             Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
   
             //.dds 
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_cpd3_Data", ".dds"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
             expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -684,8 +684,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 eTime = System.currentTimeMillis();
                 tQuery = "&unique_tag_id=\"224_A69-1206-AF_4003\"";
                 tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1tag", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1tag", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 expected =   
     "unique_tag_id, pi, longitude, latitude, time, bottom_depth, common_name, date_public, position_on_subarray, project, riser_height, role, scientific_name, stock, surgery_time, surgery_location, tagger\n" +
     ", , degrees_east, degrees_north, UTC, m, , UTC, , , m, , , , UTC, , \n" +
@@ -700,8 +700,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 eTime = System.currentTimeMillis();
                 tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
                 tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1role", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1role", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 //same expected
                 Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
                 String2.log("*** testCopyPostDet3 c1role FINISHED.  TIME=" + (System.currentTimeMillis() - eTime) + "ms"); 
@@ -710,8 +710,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 eTime = System.currentTimeMillis();
                 tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
                 tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleLIOD", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleLIOD", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 //same expected
                 Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
                 String2.log("*** testCopyPostDet3 c1roleLIOD FINISHED.  TIME=" + (System.currentTimeMillis() - eTime) + "ms"); 
@@ -722,8 +722,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
                 try {
                     tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                        EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleP", ".csv"); 
-                    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                        EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleP", ".csv"); 
+                    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                     throw new Exception("Shouldn't get here.");
                 } catch (Throwable t) {
                     if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -737,8 +737,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
                 try {
                     tName = tedd.makeNewFileForDapQuery(language, null, "WELCH_DAVID", tQuery, 
-                        EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleWP", ".csv"); 
-                    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                        EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleWP", ".csv"); 
+                    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                     throw new Exception("Shouldn't get here.");
                 } catch (Throwable t) {
                     if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -751,8 +751,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 eTime = System.currentTimeMillis();
                 tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
                 tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleL", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleL", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
     String2.log("\n" + results.substring(0, 4000) + "\n");
                 expected =   
     "unique_tag_id, pi, longitude, latitude, time, bottom_depth, common_name, date_public, position_on_subarray, project, riser_height, role, scientific_name, stock, surgery_time, surgery_location, tagger\n" +
@@ -768,8 +768,8 @@ public class EDDTableCopyPost extends EDDTableCopy {
                 eTime = System.currentTimeMillis();
                 tQuery = "role&distinct()";
                 tName = tedd.makeNewFileForDapQuery(language, null, EDStatic.loggedInAsSuperuser, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_roles", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_roles", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 expected =   
     "role\n" +
     "\n" +
@@ -1480,7 +1480,7 @@ public class EDDTableCopyPost extends EDDTableCopy {
         boolean showHtmlTable) throws Throwable {
         String2.log("\n*** EDDTableCopyPost.testOneDetectionMap()\n");
         defaultCheckSourceData = false;
-        String tDir = EDStatic.fullTestCacheDirectory;
+        String tDir = EDStatic.config.fullTestCacheDirectory;
         String tName = postDetections.makeNewFileForDapQuery(language, null, EDStatic.loggedInAsSuperuser, 
             "longitude,latitude,time&unique_tag_id=%22" + 
             SSR.minimalPercentEncode(unique_tag_id) + "%22&.draw=markers&.colorBar=BlueWhiteRed|D||||", 
@@ -1501,7 +1501,7 @@ public class EDDTableCopyPost extends EDDTableCopy {
         String2.log("\n*** EDDTableCopyPost.printOneSurgery()\n");
         defaultCheckSourceData = false;
         EDDTable postSurgery3 = (EDDTable)oneFromDatasetsXml(null, "cPostSurg3"); 
-        String tDir = EDStatic.fullTestCacheDirectory;
+        String tDir = EDStatic.config.fullTestCacheDirectory;
         String tName = postSurgery3.makeNewFileForDapQuery(language, null, EDStatic.loggedInAsSuperuser, 
             "&unique_tag_id=%22" + SSR.minimalPercentEncode(unique_tag_id) + "%22", 
             tDir, "cPostSurg3_1Surgery_" + String2.modifyToBeFileNameSafe(unique_tag_id), ".csv"); 
@@ -1567,7 +1567,7 @@ public class EDDTableCopyPost extends EDDTableCopy {
 
         //surgery  
         EDDTable postSurgery = (EDDTable)oneFromDatasetsXml(null, "cPostSurg3"); 
-        tDir = EDStatic.fullTestCacheDirectory;
+        tDir = EDStatic.config.fullTestCacheDirectory;
 
         tag = "19190_A69-1303_1037589";
         query = "&unique_tag_id=\"" + tag + "\"";
@@ -1980,7 +1980,7 @@ public class EDDTableCopyPost extends EDDTableCopy {
         String2.log("\n*** EDDTableCopyPost.run(" + which + ")\n");
         testVerbose(reallyVerbose);
 
-        String resultsFileName = EDStatic.fullTestCacheDirectory + "runPOST.log";
+        String resultsFileName = EDStatic.config.fullTestCacheDirectory + "runPOST.log";
         File2.delete(resultsFileName);
         
         int firstTest = which < 0? 0 : which;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
@@ -227,13 +227,13 @@ public class EDDTableFromAllDatasets extends EDDTable {
         .add("creator_url", tErddapUrl)
         .add("infoUrl", tErddapUrl)
         .add("institution", EDStatic.adminInstitution)
-        .add("keywords", EDStatic.admKeywords)
-        .add("license", EDStatic.standardLicense)
+        .add("keywords", EDStatic.messages.admKeywords)
+        .add("license", EDStatic.messages.standardLicense)
         .add("sourceUrl", publicSourceUrl)
-        .add("subsetVariables", EDStatic.admSubsetVariables)
-        .add("summary", EDStatic.admSummaryAr[language])
+        .add("subsetVariables", EDStatic.messages.admSubsetVariables)
+        .add("summary", EDStatic.messages.admSummaryAr[language])
         // "* " is distinctive and almost ensures it will be sorted first (or close)
-        .add("title", "* " + EDStatic.admTitleAr[language] + " *");
+        .add("title", "* " + EDStatic.messages.admTitleAr[language] + " *");
 
     // order here is not important
     StringArray idCol = new StringArray();
@@ -287,214 +287,214 @@ public class EDDTableFromAllDatasets extends EDDTable {
             tErddapUrl + "/info/") // can't be griddap|tabledap because not same for all datasets
         .add("fileAccessSuffix", "/index.html")
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_datasetID);
+        .add("long_name", EDStatic.messages.advl_datasetID);
     col = table.addColumn("accessible", accessCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_accessibleAr[language])
+        .add("comment", EDStatic.messages.advc_accessibleAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_accessibleAr[language]);
+        .add("long_name", EDStatic.messages.advl_accessibleAr[language]);
     col = table.addColumn("institution", institutionCol); // Institution
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_institutionAr[language]);
+        .add("long_name", EDStatic.messages.advl_institutionAr[language]);
     col = table.addColumn("dataStructure", dataStructureCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_dataStructureAr[language])
+        .add("comment", EDStatic.messages.advc_dataStructureAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_dataStructureAr[language])
-        .add("references", EDStatic.advr_dataStructure);
+        .add("long_name", EDStatic.messages.advl_dataStructureAr[language])
+        .add("references", EDStatic.messages.advr_dataStructure);
     col = table.addColumn("cdm_data_type", cdmCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_cdm_data_typeAr[language])
-        .add("references", EDStatic.advr_cdm_data_type);
+        .add("long_name", EDStatic.messages.advl_cdm_data_typeAr[language])
+        .add("references", EDStatic.messages.advr_cdm_data_type);
     col = table.addColumn("class", classCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_classAr[language])
-        .add("references", EDStatic.advr_class);
+        .add("long_name", EDStatic.messages.advl_classAr[language])
+        .add("references", EDStatic.messages.advr_class);
     col = table.addColumn("title", titleCol); // Title
     int titleColNumber = col;
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_titleAr[language]);
+        .add("long_name", EDStatic.messages.advl_titleAr[language]);
 
     col = table.addColumn("minLongitude", minLongitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_minLongitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_minLongitudeAr[language])
         .add("units", EDV.LON_UNITS);
     col = table.addColumn("maxLongitude", maxLongitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_maxLongitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_maxLongitudeAr[language])
         .add("units", EDV.LON_UNITS);
     col = table.addColumn("longitudeSpacing", longitudeSpacing);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_longitudeSpacingAr[language])
+        .add("long_name", EDStatic.messages.advl_longitudeSpacingAr[language])
         .add("units", EDV.LON_UNITS);
     col = table.addColumn("minLatitude", minLatitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_minLatitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_minLatitudeAr[language])
         .add("units", EDV.LAT_UNITS);
     col = table.addColumn("maxLatitude", maxLatitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_maxLatitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_maxLatitudeAr[language])
         .add("units", EDV.LAT_UNITS);
     col = table.addColumn("latitudeSpacing", latitudeSpacing);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_latitudeSpacingAr[language])
+        .add("long_name", EDStatic.messages.advl_latitudeSpacingAr[language])
         .add("units", EDV.LAT_UNITS);
     col = table.addColumn("minAltitude", minAltitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_minAltitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_minAltitudeAr[language])
         .add("positive", "up")
         .add("units", "m");
     col = table.addColumn("maxAltitude", maxAltitude);
     table
         .columnAttributes(col)
         .add("ioos_category", "Location")
-        .add("long_name", EDStatic.advl_maxAltitudeAr[language])
+        .add("long_name", EDStatic.messages.advl_maxAltitudeAr[language])
         .add("positive", "up")
         .add("units", "m");
     col = table.addColumn("minTime", minTime);
     table
         .columnAttributes(col)
         .add("ioos_category", "Time")
-        .add("long_name", EDStatic.advl_minTimeAr[language])
+        .add("long_name", EDStatic.messages.advl_minTimeAr[language])
         .add("units", Calendar2.SECONDS_SINCE_1970);
     col = table.addColumn("maxTime", maxTime);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_maxTimeAr[language])
+        .add("comment", EDStatic.messages.advc_maxTimeAr[language])
         .add("ioos_category", "Time")
-        .add("long_name", EDStatic.advl_maxTimeAr[language])
+        .add("long_name", EDStatic.messages.advl_maxTimeAr[language])
         .add("units", Calendar2.SECONDS_SINCE_1970);
     col = table.addColumn("timeSpacing", timeSpacing);
     table
         .columnAttributes(col)
         .add("ioos_category", "Time")
-        .add("long_name", EDStatic.advl_timeSpacingAr[language])
+        .add("long_name", EDStatic.messages.advl_timeSpacingAr[language])
         .add("units", "seconds");
     // other columns
     col = table.addColumn("griddap", gdCol); // just protocol name
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_griddapAr[language])
+        .add("comment", EDStatic.messages.advc_griddapAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_griddapAr[language]);
+        .add("long_name", EDStatic.messages.advl_griddapAr[language]);
     col = table.addColumn("subset", subCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_subsetAr[language]);
+        .add("long_name", EDStatic.messages.advl_subsetAr[language]);
     col = table.addColumn("tabledap", tdCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_tabledapAr[language])
+        .add("comment", EDStatic.messages.advc_tabledapAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_tabledapAr[language]);
+        .add("long_name", EDStatic.messages.advl_tabledapAr[language]);
     col = table.addColumn("MakeAGraph", magCol); // Make A Graph
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_MakeAGraphAr[language]);
+        .add("long_name", EDStatic.messages.advl_MakeAGraphAr[language]);
     col = table.addColumn("sos", sosCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_sosAr[language])
+        .add("comment", EDStatic.messages.advc_sosAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_sosAr[language]);
+        .add("long_name", EDStatic.messages.advl_sosAr[language]);
     col = table.addColumn("wcs", wcsCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_wcsAr[language]);
+        .add("long_name", EDStatic.messages.advl_wcsAr[language]);
     col = table.addColumn("wms", wmsCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_wmsAr[language]);
+        .add("long_name", EDStatic.messages.advl_wmsAr[language]);
     col = table.addColumn("files", filesCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_filesAr[language])
+        .add("comment", EDStatic.messages.advc_filesAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_filesAr[language]);
+        .add("long_name", EDStatic.messages.advl_filesAr[language]);
     col = table.addColumn("fgdc", fgdcCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_fgdcAr[language])
+        .add("comment", EDStatic.messages.advc_fgdcAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_fgdcAr[language]);
+        .add("long_name", EDStatic.messages.advl_fgdcAr[language]);
     col = table.addColumn("iso19115", iso19115Col);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_iso19115Ar[language])
+        .add("comment", EDStatic.messages.advc_iso19115Ar[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_iso19115Ar[language]);
+        .add("long_name", EDStatic.messages.advl_iso19115Ar[language]);
     col = table.addColumn("metadata", metadataCol); // Info
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_metadataAr[language])
+        .add("comment", EDStatic.messages.advc_metadataAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_metadataAr[language]);
+        .add("long_name", EDStatic.messages.advl_metadataAr[language]);
     col = table.addColumn("sourceUrl", sourceCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_sourceUrlAr[language]);
+        .add("long_name", EDStatic.messages.advl_sourceUrlAr[language]);
     col = table.addColumn("infoUrl", infoUrlCol); // Background Info
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_infoUrlAr[language]);
+        .add("long_name", EDStatic.messages.advl_infoUrlAr[language]);
     col = table.addColumn("rss", rssCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_rssAr[language]);
+        .add("long_name", EDStatic.messages.advl_rssAr[language]);
     col = table.addColumn("email", emailCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_emailAr[language])
+        .add("comment", EDStatic.messages.advc_emailAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_emailAr[language]);
+        .add("long_name", EDStatic.messages.advl_emailAr[language]);
     col = table.addColumn("testOutOfDate", testOutOfDateCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_testOutOfDateAr[language])
+        .add("comment", EDStatic.messages.advc_testOutOfDateAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_testOutOfDateAr[language]);
+        .add("long_name", EDStatic.messages.advl_testOutOfDateAr[language]);
     col = table.addColumn("outOfDate", outOfDateCol);
     table
         .columnAttributes(col)
-        .add("comment", EDStatic.advc_outOfDateAr[language])
+        .add("comment", EDStatic.messages.advc_outOfDateAr[language])
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_outOfDateAr[language]);
+        .add("long_name", EDStatic.messages.advl_outOfDateAr[language]);
     col = table.addColumn("summary", summaryCol);
     table
         .columnAttributes(col)
         .add("ioos_category", "Other")
-        .add("long_name", EDStatic.advl_summaryAr[language]);
+        .add("long_name", EDStatic.messages.advl_summaryAr[language]);
 
     // add each dataset's information
     // only title, summary, institution, id are always accessible if !listPrivateDatasets

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
@@ -13,6 +13,7 @@ import com.cohort.util.Calendar2;
 import com.cohort.util.Math2;
 import com.cohort.util.String2;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
+import gov.noaa.pfel.erddap.util.EDConfig;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.util.Subscriptions;
 import gov.noaa.pfel.erddap.variable.*;
@@ -222,11 +223,11 @@ public class EDDTableFromAllDatasets extends EDDTable {
         .globalAttributes()
         .add("cdm_data_type", CDM_OTHER)
         .add("Conventions", "COARDS, CF-1.6, ACDD-1.3")
-        .add("creator_name", EDStatic.adminIndividualName)
-        .add("creator_email", EDStatic.adminEmail)
+        .add("creator_name", EDStatic.config.adminIndividualName)
+        .add("creator_email", EDStatic.config.adminEmail)
         .add("creator_url", tErddapUrl)
         .add("infoUrl", tErddapUrl)
-        .add("institution", EDStatic.adminInstitution)
+        .add("institution", EDStatic.config.adminInstitution)
         .add("keywords", EDStatic.messages.admKeywords)
         .add("license", EDStatic.messages.standardLicense)
         .add("sourceUrl", publicSourceUrl)
@@ -515,7 +516,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
       continue;
       boolean isAccessible = edd.isAccessibleTo(roles);
       boolean graphsAccessible = isAccessible || edd.graphsAccessibleToPublic();
-      if (!EDStatic.listPrivateDatasets && !isAccessible && !graphsAccessible) continue;
+      if (!EDStatic.config.listPrivateDatasets && !isAccessible && !graphsAccessible) continue;
 
       // add this dataset's value to each column   (order is not important)
       idCol.add(tId);
@@ -652,7 +653,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
           graphsAccessible && edd.accessibleViaFGDC().length() == 0
               ? tErddapUrl
                   + "/"
-                  + EDStatic.fgdcXmlDirectory
+                  + EDConfig.fgdcXmlDirectory
                   + edd.datasetID()
                   + EDD.fgdcSuffix
                   + ".xml"
@@ -661,7 +662,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
           graphsAccessible && edd.accessibleViaISO19115().length() == 0
               ? tErddapUrl
                   + "/"
-                  + EDStatic.iso19115XmlDirectory
+                  + EDConfig.iso19115XmlDirectory
                   + edd.datasetID()
                   + EDD.iso19115Suffix
                   + ".xml"
@@ -674,7 +675,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
               ? EDStatic.erddapUrl + "/rss/" + edd.datasetID() + ".rss"
               : ""); // never https url
       emailCol.add(
-          graphsAccessible && EDStatic.subscriptionSystemActive
+          graphsAccessible && EDStatic.config.subscriptionSystemActive
               ? tErddapUrl
                   + "/"
                   + Subscriptions.ADD_HTML
@@ -697,7 +698,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
@@ -214,7 +214,7 @@ public abstract class EDDTableFromAsciiService extends EDDTable {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense.
+   *     be converted to the EDStatic.messages.standardLicense.
    * @param tDataVariables is an Object[nDataVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source, without the
    *     outer or inner sequence name), <br>
@@ -299,7 +299,7 @@ public abstract class EDDTableFromAsciiService extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // create structures to hold the sourceAttributes temporarily

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiService.java
@@ -480,7 +480,7 @@ public abstract class EDDTableFromAsciiService extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOS.java
@@ -231,22 +231,23 @@ public class EDDTableFromAsciiServiceNOS extends EDDTableFromAsciiService {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + "For this dataset, all queries must include a \"datum=\" constraint.",
-              EDStatic.queryErrorAr[language]
+              EDStatic.messages.queryErrorAr[language]
                   + "For this dataset, all queries must include a \"datum=\" constraint."));
     if (Double.isNaN(beginSeconds))
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + "Missing time>= constraint.",
-              EDStatic.queryErrorAr[language] + "Missing time>= constraint."));
+              EDStatic.messages.queryErrorAr[0] + "Missing time>= constraint.",
+              EDStatic.messages.queryErrorAr[language] + "Missing time>= constraint."));
     if (Double.isNaN(endSeconds))
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + "If present, the time<= constraint must be valid.",
-              EDStatic.queryErrorAr[language]
+              EDStatic.messages.queryErrorAr[0]
+                  + "If present, the time<= constraint must be valid.",
+              EDStatic.messages.queryErrorAr[language]
                   + "If present, the time<= constraint must be valid."));
     String beginTime =
         Calendar2.epochSecondsToIsoStringTZ(beginSeconds).substring(0, 16); // no seconds

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOS.java
@@ -138,7 +138,7 @@ public class EDDTableFromAsciiServiceNOS extends EDDTableFromAsciiService {
     // Note that times are often too wide a range because they are for all observedProperties,
     //  not just the one used by this dataset.
     // This is not tested!
-    if (EDStatic.sosActive && stationDateEstCol >= 0) {
+    if (EDStatic.config.sosActive && stationDateEstCol >= 0) {
       sosOfferingPrefix = "urn:ioos:station:NOAA.NOS.CO-OPS:";
       sosOfferingType = "Station";
       // The index of the dataVariable with the sosOffering outer var (e.g. with
@@ -161,7 +161,7 @@ public class EDDTableFromAsciiServiceNOS extends EDDTableFromAsciiService {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAudioFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAudioFiles.java
@@ -323,7 +323,7 @@ public class EDDTableFromAudioFiles extends EDDTableFromFiles {
               destPA.elementType() != PAType.STRING, // addColorBarMinMax
               true)); // tryToFindLLAT
       if (c > 0) {
-        if (EDStatic.variablesMustHaveIoosCategory)
+        if (EDStatic.config.variablesMustHaveIoosCategory)
           dataAddTable.columnAttributes(c).set("ioos_category", "Other");
         if (sourcePA.isIntegerType()) {
           dataAddTable

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromBMDE.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromBMDE.javaINACTIVE
@@ -425,7 +425,7 @@ public class EDDTableFromBMDE extends EDDTable{
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)
@@ -575,9 +575,9 @@ public class EDDTableFromBMDE extends EDDTable{
         //if (true) System.exit(0);
 
         //.das     das isn't affected by userDapQuery
-        tName = prbo.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+        tName = prbo.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
             prbo.className(), ".das"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         expected = 
 "Attributes {\n" +
 " s {\n" +
@@ -715,9 +715,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         //        "bmde:GlobalUniqueIdentifier", "bmde:Genus", "bmde:ScientificName"});
         userDapQuery = "longitude,latitude,altitude,time,GlobalUniqueIdentifier,Genus,ScientificName,ObservationCount" +
             "&Family=\"Laridae\"&Genus=\"Uria\"&time>2007-06-01&time<2007-06-05"; 
-        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             prbo.className(), ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         String2.log(results);
         expected = 
 "longitude, latitude, altitude, time, GlobalUniqueIdentifier, Genus, ScientificName, ObservationCount\n" +
@@ -739,18 +739,18 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         //.csv     variation to test string  < >
         userDapQuery = "longitude,latitude,altitude,time,GlobalUniqueIdentifier,Genus,ScientificName,ObservationCount" +
             "&Family=\"Laridae\"&Genus>=\"Urh\"&Genus<\"Urj\"&time>2007-06-01&time<2007-06-05"; 
-        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             prbo.className() + "Compare", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         String2.log(results);
         Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
         //.csv     variation to test string  regex
         userDapQuery = "longitude,latitude,altitude,time,GlobalUniqueIdentifier,Genus,ScientificName,ObservationCount" +
             "&Family=\"Laridae\"&Genus=~\"(zztop|Uria)\"&time>2007-06-01&time<2007-06-05"; 
-        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             prbo.className() + "Compare", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         String2.log(results);
         Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -759,9 +759,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         //All I ever get for altitude is missingValue.
         userDapQuery = "longitude,latitude,altitude,time,GlobalUniqueIdentifier,Genus,ScientificName,ObservationCount" +
             "&longitude=-123.002737&latitude=37.698771&Family=\"Laridae\"&Genus=\"Uria\"&time>2007-06-01&time<2007-06-05"; 
-        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = prbo.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             prbo.className() + "LonLat", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         String2.log(results);
         expected = 
 "longitude, latitude, altitude, time, GlobalUniqueIdentifier, Genus, ScientificName, ObservationCount\n" +

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromBMDE.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromBMDE.javaINACTIVE
@@ -282,7 +282,7 @@ public class EDDTableFromBMDE extends EDDTable{
         String tLicense = combinedGlobalAttributes.getString("license");
         if (tLicense != null)
             combinedGlobalAttributes.set("license", 
-                String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+                String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
         combinedGlobalAttributes.removeValue("\"null\"");
 
         //sourceCanConstrain:

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
@@ -1149,7 +1149,7 @@ public class EDDTableFromCassandra extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter
@@ -1412,7 +1412,7 @@ public class EDDTableFromCassandra extends EDDTable {
       rvToResultsEDV[rv] = dataVariables[resultsDVI[rv]];
     }
     // triggerNRows + 1000 since lists expand, so hard to catch exactly
-    int triggerNRows = EDStatic.partialRequestMaxCells / nRv;
+    int triggerNRows = EDStatic.config.partialRequestMaxCells / nRv;
     Table table = makeEmptySourceTable(rvToResultsEDV, triggerNRows + 1000);
 
     // make a call to Cassandra for each row in pkdTable
@@ -1601,7 +1601,7 @@ public class EDDTableFromCassandra extends EDDTable {
       if (rvToResultsEDV[rv].sourceDataPAType() == PAType.STRING)
         rvToTypeCodec[rv] = CodecRegistry.DEFAULT_INSTANCE.codecFor(rvToCassDataType[rv]);
     }
-    int triggerNRows = EDStatic.partialRequestMaxCells / nRv;
+    int triggerNRows = EDStatic.config.partialRequestMaxCells / nRv;
     PrimitiveArray paArray[] = new PrimitiveArray[nRv];
     for (int rv = 0; rv < nRv; rv++) paArray[rv] = table.getColumn(rv);
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandra.java
@@ -586,7 +586,7 @@ public class EDDTableFromCassandra extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // create dataVariables[]
@@ -1422,7 +1422,7 @@ public class EDDTableFromCassandra extends EDDTable {
 
       if (Thread.currentThread().isInterrupted())
         throw new SimpleException(
-            "EDDTableFromCassandra.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+            "EDDTableFromCassandra.getDataForDapQuery" + EDStatic.messages.caughtInterruptedAr[0]);
 
       // Make the BoundStatement
       // ***!!! This method avoids CQL/SQL Injection Vulnerability !!!***

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromColumnarAsciiFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromColumnarAsciiFiles.java
@@ -654,7 +654,7 @@ public class EDDTableFromColumnarAsciiFiles extends EDDTableFromFiles {
 
     boolean pauseForErrors = false;
     String resultsFileName =
-        EDStatic.fullLogsDirectory
+        EDStatic.config.fullLogsDirectory
             + "fromEML_"
             + Calendar2.getCompactCurrentISODateTimeStringLocal()
             + ".log";
@@ -1873,7 +1873,7 @@ public class EDDTableFromColumnarAsciiFiles extends EDDTableFromFiles {
                 + "The data file and EML file have different column names.\n"
                 + "ERDDAP would like to equate these pairs of names:\n"
                 + differ;
-        if (!EDStatic.developmentMode) {
+        if (!EDStatic.config.developmentMode) {
           te =
               String2.getStringFromSystemIn(
                   "WARNING for"
@@ -2511,7 +2511,7 @@ public class EDDTableFromColumnarAsciiFiles extends EDDTableFromFiles {
         localTimeZone; // from TZ at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     StringArray names;
     String resultsFileName =
-        EDStatic.fullLogsDirectory
+        EDStatic.config.fullLogsDirectory
             + "fromEML_"
             + Calendar2.getCompactCurrentISODateTimeStringLocal()
             + ".log";

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
@@ -222,7 +222,7 @@ public class EDDTableFromDapSequence extends EDDTable {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of
-   *     value="[standard]" will be converted to the EDStatic.standardLicense.
+   *     value="[standard]" will be converted to the EDStatic.messages.standardLicense.
    * @param tDataVariables is an Object[nDataVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source, without the
    *     outer or inner sequence name), <br>
@@ -372,7 +372,7 @@ public class EDDTableFromDapSequence extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // create structures to hold the sourceAttributes temporarily
@@ -791,9 +791,9 @@ public class EDDTableFromDapSequence extends EDDTable {
       throw t instanceof WaitThenTryAgainException
           ? t
           : new WaitThenTryAgainException(
-              EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                   + "\n("
-                  + EDStatic.errorFromDataSource
+                  + EDStatic.messages.errorFromDataSource
                   + tToString
                   + ")",
               t);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
@@ -328,7 +328,7 @@ public class EDDTableFromDapSequence extends EDDTable {
 
     // quickRestart
     Attributes quickRestartAttributes = null;
-    if (EDStatic.quickRestart
+    if (EDStatic.config.quickRestart
         && EDStatic.initialLoadDatasets()
         && File2.isFile(quickRestartFullFileName())) {
       // try to do quick initialLoadDatasets()
@@ -660,7 +660,7 @@ public class EDDTableFromDapSequence extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
@@ -323,7 +323,7 @@ public class EDDTableFromDatabase extends EDDTable {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of
-   *     value="[standard]" will be converted to the EDStatic.standardLicense.
+   *     value="[standard]" will be converted to the EDStatic.messages.standardLicense.
    * @param tDataVariables is an Object[nDataVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source), <br>
    *     [1]=String destinationName (the name to be presented to the ERDDAP user, or null to use the
@@ -513,7 +513,7 @@ public class EDDTableFromDatabase extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // create dataVariables[]
@@ -826,8 +826,8 @@ public class EDDTableFromDatabase extends EDDTable {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0] + "Invalid syntax for \"" + p + "\".",
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[0] + "Invalid syntax for \"" + p + "\".",
+                    EDStatic.messages.queryErrorAr[language]
                         + "Invalid syntax for \""
                         + p
                         + "\".")); // should have been caught already
@@ -840,12 +840,13 @@ public class EDDTableFromDatabase extends EDDTable {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + MessageFormat.format(
-                              EDStatic.queryErrorUnknownVariableAr[0], tQueryOrderBy.get(oi)),
-                      EDStatic.queryErrorAr[language]
+                              EDStatic.messages.queryErrorUnknownVariableAr[0],
+                              tQueryOrderBy.get(oi)),
+                      EDStatic.messages.queryErrorAr[language]
                           + MessageFormat.format(
-                              EDStatic.queryErrorUnknownVariableAr[language],
+                              EDStatic.messages.queryErrorUnknownVariableAr[language],
                               tQueryOrderBy.get(oi))));
             String tSourceName = dataVariableSourceNames()[v];
             tQueryOrderBy.set(oi, tSourceName);
@@ -930,15 +931,15 @@ public class EDDTableFromDatabase extends EDDTable {
         throw new WaitThenTryAgainException(
             EDStatic.bilingual(
                 language,
-                EDStatic.waitThenTryAgainAr[0]
+                EDStatic.messages.waitThenTryAgainAr[0]
                     + "("
-                    + EDStatic.databaseUnableToConnectAr[0]
+                    + EDStatic.messages.databaseUnableToConnectAr[0]
                     + ": "
                     + t
                     + ")",
-                EDStatic.waitThenTryAgainAr[language]
+                EDStatic.messages.waitThenTryAgainAr[language]
                     + "("
-                    + EDStatic.databaseUnableToConnectAr[language]
+                    + EDStatic.messages.databaseUnableToConnectAr[language]
                     + ": "
                     + t
                     + ")"));
@@ -1149,7 +1150,8 @@ public class EDDTableFromDatabase extends EDDTable {
         if ((paArray[0].size() > 0 && !hasNext) || paArray[0].size() >= triggerNRows) {
           if (Thread.currentThread().isInterrupted())
             throw new SimpleException(
-                "EDDTableFromDatabase.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+                "EDDTableFromDatabase.getDataForDapQuery"
+                    + EDStatic.messages.caughtInterruptedAr[0]);
 
           // convert script columns into data columns
           if (scriptNames != null)
@@ -1200,11 +1202,11 @@ public class EDDTableFromDatabase extends EDDTable {
       // String2.log("EDDTableFromDatabase caught:\n" + msg);
 
       if (msg.indexOf(MustBe.THERE_IS_NO_DATA) >= 0
-          || msg.indexOf(EDStatic.caughtInterruptedAr[0]) >= 0) {
+          || msg.indexOf(EDStatic.messages.caughtInterruptedAr[0]) >= 0) {
         throw t;
       } else {
         // all other errors probably from database
-        throw new Throwable(EDStatic.errorFromDataSource + t, t);
+        throw new Throwable(EDStatic.messages.errorFromDataSource + t, t);
       }
     }
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabase.java
@@ -730,7 +730,7 @@ public class EDDTableFromDatabase extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter
@@ -1096,7 +1096,7 @@ public class EDDTableFromDatabase extends EDDTable {
         tableColToRsCol[rv] =
             rs.findColumn(tName); // stored as 1..    throws Throwable if not found
       }
-      int triggerNRows = EDStatic.partialRequestMaxCells / resultsEDVs.length;
+      int triggerNRows = EDStatic.config.partialRequestMaxCells / resultsEDVs.length;
       Table table = makeEmptySourceTable(resultsEDVs, triggerNRows);
       PrimitiveArray paArray[] = new PrimitiveArray[nRv];
       for (int rv = 0; rv < nRv; rv++) paArray[rv] = table.getColumn(rv);
@@ -1731,7 +1731,7 @@ public class EDDTableFromDatabase extends EDDTable {
    * @throws Throwable if trouble
    */
   public static String getCSV(int language, String datasetID) throws Throwable {
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     EDDTableFromDatabase tedd = (EDDTableFromDatabase) oneFromDatasetsXml(null, datasetID);
     String tName =
         tedd.makeNewFileForDapQuery(

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
@@ -268,7 +268,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     maxAxis0 = combinedGlobalAttributes.getInt("maxAxis0");
@@ -390,7 +390,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
       if (tChildDataset == null) {
         EDD.requestReloadASAP(localChildDatasetID);
         throw new WaitThenTryAgainException(
-            EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                 + "\n(underlying local datasetID="
                 + localChildDatasetID
                 + " not found)");
@@ -529,12 +529,13 @@ public class EDDTableFromEDDGrid extends EDDTable {
                   MustBe.THERE_IS_NO_DATA
                       + " ("
                       + MessageFormat.format(
-                          EDStatic.queryErrorNeverTrueAr[0], conVar + conOp + conValD)
+                          EDStatic.messages.queryErrorNeverTrueAr[0], conVar + conOp + conValD)
                       + ")",
                   MustBe.THERE_IS_NO_DATA
                       + " ("
                       + MessageFormat.format(
-                          EDStatic.queryErrorNeverTrueAr[language], conVar + conOp + conValD)
+                          EDStatic.messages.queryErrorNeverTrueAr[language],
+                          conVar + conOp + conValD)
                       + ")"));
       }
     }
@@ -552,7 +553,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
                 MustBe.THERE_IS_NO_DATA
                     + " "
                     + MessageFormat.format(
-                        EDStatic.queryErrorNeverTrueAr[0],
+                        EDStatic.messages.queryErrorNeverTrueAr[0],
                         edvga.destinationName()
                             + ">="
                             + avMin[av]
@@ -563,7 +564,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
                 MustBe.THERE_IS_NO_DATA
                     + " "
                     + MessageFormat.format(
-                        EDStatic.queryErrorNeverTrueAr[language],
+                        EDStatic.messages.queryErrorNeverTrueAr[language],
                         edvga.destinationName()
                             + ">="
                             + avMin[av]
@@ -669,7 +670,8 @@ public class EDDTableFromEDDGrid extends EDDTable {
             if (debugMode) String2.log(tTable.dataToString(5));
             if (Thread.currentThread().isInterrupted())
               throw new SimpleException(
-                  "EDDTableFromEDDGrid.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+                  "EDDTableFromEDDGrid.getDataForDapQuery"
+                      + EDStatic.messages.caughtInterruptedAr[0]);
 
             standardizeResultsTable(
                 language,
@@ -769,7 +771,8 @@ public class EDDTableFromEDDGrid extends EDDTable {
         if (++cumNRows >= chunkNRows) {
           if (Thread.currentThread().isInterrupted())
             throw new SimpleException(
-                "EDDTableFromDatabase.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+                "EDDTableFromDatabase.getDataForDapQuery"
+                    + EDStatic.messages.caughtInterruptedAr[0]);
 
           standardizeResultsTable(
               language,
@@ -803,8 +806,8 @@ public class EDDTableFromEDDGrid extends EDDTable {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + " No results variables?!",
-              EDStatic.queryErrorAr[language] + " No results variables?!"));
+              EDStatic.messages.queryErrorAr[0] + " No results variables?!",
+              EDStatic.messages.queryErrorAr[language] + " No results variables?!"));
     }
   }
 
@@ -899,7 +902,9 @@ public class EDDTableFromEDDGrid extends EDDTable {
       String tSummary =
           (tMaxAxis0 > 0
                   ? MessageFormat.format(
-                          EDStatic.EDDTableFromEDDGridSummaryAr[language], tDatasetID, tMaxAxis0)
+                          EDStatic.messages.EDDTableFromEDDGridSummaryAr[language],
+                          tDatasetID,
+                          tMaxAxis0)
                       + "\n"
                   : "")
               + summaryPA.getString(row);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGrid.java
@@ -67,7 +67,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
     Attributes tAddGlobalAttributes = null;
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -253,7 +253,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
     }
     // for rest of constructor, use temporary, stable tChildDataset reference.
     accessibleViaFiles =
-        EDStatic.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
+        EDStatic.config.filesActive && tAccessibleViaFiles && tChildDataset.accessibleViaFiles;
 
     // global attributes
     localSourceUrl = tChildDataset.localSourceUrl;
@@ -434,7 +434,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter
@@ -591,7 +591,9 @@ public class EDDTableFromEDDGrid extends EDDTable {
 
     StringBuilder gridDapQuery = new StringBuilder();
     String gridRequestUrl =
-        "/griddap/" + tChildDataset.datasetID() + ".dods"; // after EDStatic.baseUrl, before '?'
+        "/griddap/"
+            + tChildDataset.datasetID()
+            + ".dods"; // after EDStatic.config.baseUrl, before '?'
 
     if (resultsDvNames.size() > 0 || constraintsDvNames.size() > 0) {
       // handle a request for 1+ data variables (in results or constraint variables)
@@ -646,7 +648,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
               findDataVariableByDestinationName(queryDV[dv].destinationName());
 
         // make a table to hold a chunk of the results
-        int chunkNRows = EDStatic.partialRequestMaxCells / (childDatasetNAV + nQueryDV);
+        int chunkNRows = EDStatic.config.partialRequestMaxCells / (childDatasetNAV + nQueryDV);
         Table tTable =
             makeEmptySourceTable(
                 sourceTableVars,
@@ -750,7 +752,7 @@ public class EDDTableFromEDDGrid extends EDDTable {
       NDimensionalIndex ndIndex = new NDimensionalIndex(ndShape);
 
       // make a table to hold a chunk of the results
-      int chunkNRows = EDStatic.partialRequestMaxCells / nActiveEdvga;
+      int chunkNRows = EDStatic.config.partialRequestMaxCells / nActiveEdvga;
       Table tTable = new Table(); // source table, but source here is tChildDataset's destination
       PrimitiveArray paAr[] = new PrimitiveArray[nActiveEdvga];
       for (int aav = 0; aav < nActiveEdvga; aav++) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromErddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromErddap.java
@@ -75,9 +75,9 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
     int tReloadEveryNMinutes = Integer.MAX_VALUE;
     String tAccessibleTo = null;
     String tGraphsAccessibleTo = null;
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     StringArray tOnChange = new StringArray();
-    boolean tSubscribeToRemoteErddapDataset = EDStatic.subscribeToRemoteErddapDataset;
+    boolean tSubscribeToRemoteErddapDataset = EDStatic.config.subscribeToRemoteErddapDataset;
     boolean tRedirect = true;
     String tFgdcFile = null;
     String tIso19115File = null;
@@ -222,7 +222,7 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
     publicSourceErddapUrl = convertToPublicSourceUrl(localSourceUrl);
     subscribeToRemoteErddapDataset = tSubscribeToRemoteErddapDataset;
     redirect = tRedirect;
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles; // tentative. see below
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles; // tentative. see below
 
     // erddap support all constraints:
     sourceNeedsExpandedFP_EQ = false;
@@ -234,7 +234,7 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
     Table sourceTable = new Table();
     sourceGlobalAttributes = sourceTable.globalAttributes();
     boolean qrMode =
-        EDStatic.quickRestart
+        EDStatic.config.quickRestart
             && EDStatic.initialLoadDatasets()
             && File2.isFile(
                 quickRestartFullFileName()); // goofy: name is .nc but contents are NCCSV
@@ -357,7 +357,8 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
 
       // deal with remote not having ioos_category, but this ERDDAP requiring it
       Attributes tAddAtt = new Attributes();
-      if (EDStatic.variablesMustHaveIoosCategory && tSourceAtt.getString("ioos_category") == null) {
+      if (EDStatic.config.variablesMustHaveIoosCategory
+          && tSourceAtt.getString("ioos_category") == null) {
 
         // guess ioos_category   (alternative is always assign "Unknown")
         Attributes tAtts =
@@ -574,7 +575,7 @@ public class EDDTableFromErddap extends EDDTable implements FromErddap {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
@@ -311,7 +311,7 @@ public class EDDTableFromFileNames extends EDDTable {
     fileDir = tFileDir;
     fileNameRegex = tFileNameRegex;
     accessibleViaFiles =
-        EDStatic.filesActive; // default for this dataset is 'true' and not changeable
+        EDStatic.config.filesActive; // default for this dataset is 'true' and not changeable
 
     if (!String2.isSomething(fileDir))
       throw new IllegalArgumentException(errorInMethod + "fileDir wasn't specified.");
@@ -455,7 +455,7 @@ public class EDDTableFromFileNames extends EDDTable {
         from == fromRemoteFiles) {
       String qrName = quickRestartFullFileName();
 
-      if (EDStatic.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
+      if (EDStatic.config.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
 
         // try to do quickRestart
         // set creationTimeMillis to time of previous creation, so next time
@@ -1144,7 +1144,7 @@ public class EDDTableFromFileNames extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
@@ -243,7 +243,7 @@ public class EDDTableFromFileNames extends EDDTable {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of
-   *     value="[standard]" will be converted to the EDStatic.standardLicense.
+   *     value="[standard]" will be converted to the EDStatic.messages.standardLicense.
    * @param tDataVariables is an Object[nDataVariables][3]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source, without the
    *     outer or inner sequence name), <br>
@@ -445,7 +445,7 @@ public class EDDTableFromFileNames extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // useCachedInfo?

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
@@ -226,7 +226,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     String tFileNameRegex = ".*";
     boolean tRecursive = false;
     String tPathRegex = ".*";
-    boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+    boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
     String tMetadataFrom = MF_LAST;
     String tPreExtractRegex = "", tPostExtractRegex = "", tExtractRegex = "";
     String tColumnNameForExtract = "";
@@ -855,7 +855,9 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         String qrName = quickRestartFullFileName(tDatasetID);
         long tCreationTime = System.currentTimeMillis(); // used below
 
-        if (EDStatic.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
+        if (EDStatic.config.quickRestart
+            && EDStatic.initialLoadDatasets()
+            && File2.isFile(qrName)) {
 
           // quickRestart
           // set creationTimeMillis to time of previous creation, so next time
@@ -934,7 +936,9 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         String qrName = quickRestartFullFileName(tDatasetID);
         long tCreationTime = System.currentTimeMillis(); // used below
 
-        if (EDStatic.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
+        if (EDStatic.config.quickRestart
+            && EDStatic.initialLoadDatasets()
+            && File2.isFile(qrName)) {
 
           // quickRestart
           // set creationTimeMillis to time of previous creation, so next time
@@ -1011,11 +1015,11 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         return tEDDTable;
       }
       case "EDDTableFromWFSFiles" -> {
-        String fileDir = EDStatic.fullCopyDirectory + tDatasetID + "/";
+        String fileDir = EDStatic.config.fullCopyDirectory + tDatasetID + "/";
         String fileName = "data.tsv";
         long tCreationTime = System.currentTimeMillis(); // used below
 
-        if (EDStatic.quickRestart
+        if (EDStatic.config.quickRestart
             && EDStatic.initialLoadDatasets()
             && File2.isFile(fileDir + fileName)) {
 
@@ -1347,7 +1351,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         tStandardizeWhat < 0 || tStandardizeWhat == Integer.MAX_VALUE
             ? defaultStandardizeWhat()
             : tStandardizeWhat;
-    accessibleViaFiles = EDStatic.filesActive && tAccessibleViaFiles;
+    accessibleViaFiles = EDStatic.config.filesActive && tAccessibleViaFiles;
     nThreads = tNThreads;
 
     preExtractRegex = tPreExtractRegex;
@@ -1683,7 +1687,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     }
 
     // skip loading until after intial loadDatasets?
-    if (!EDStatic.forceSynchronousLoading
+    if (!EDStatic.config.forceSynchronousLoading
         && fileTable.nRows() == 0
         && EDStatic.initialLoadDatasets()) {
       requestReloadASAP();
@@ -1701,7 +1705,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     // set up WatchDirectory
     if (updateEveryNMillis > 0) {
       try {
-        if (EDStatic.useSharedWatchService) {
+        if (EDStatic.config.useSharedWatchService) {
           SharedWatchService.watchDirectory(fileDir, recursive, pathRegex, this, datasetID);
         } else {
           watchDirectory = WatchDirectory.watchDirectoryAll(fileDir, recursive, pathRegex);
@@ -1711,7 +1715,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         String subject = String2.ERROR + " in " + datasetID + " constructor (inotify)";
         msg = MustBe.throwableToString(t);
         if (msg.indexOf("inotify instances") >= 0) msg += EDStatic.messages.inotifyFixAr[0];
-        EDStatic.email(EDStatic.adminEmail, subject, msg);
+        EDStatic.email(EDStatic.config.adminEmail, subject, msg);
         msg = "";
       }
     }
@@ -1719,7 +1723,8 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     // doQuickRestart?
     boolean doQuickRestart =
         fileTable.nRows() > 0
-            && (testQuickRestart || (EDStatic.quickRestart && EDStatic.initialLoadDatasets()));
+            && (testQuickRestart
+                || (EDStatic.config.quickRestart && EDStatic.initialLoadDatasets()));
     if (verbose) String2.log("doQuickRestart=" + doQuickRestart);
 
     if (doQuickRestart) {
@@ -2210,7 +2215,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     // send email with bad file info
     if (!badFileMap.isEmpty()) {
       String emailSB = badFileMapToString(badFileMap, dirList) + msg + "\n\n";
-      EDStatic.email(EDStatic.emailEverythingToCsv, errorInMethod + "Bad Files", emailSB);
+      EDStatic.email(EDStatic.config.emailEverythingToCsv, errorInMethod + "Bad Files", emailSB);
     }
     // if (debugMode) String2.log(">> EDDTableFromFiles " +
     // Calendar2.getCurrentISODateTimeStringLocalTZ() + " finished sending email
@@ -2562,7 +2567,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     // if cacheFromUrl is remote ERDDAP /files/, subscribe to the dataset
     // This is like code in EDDGridFromFiles but "/tabledap/"
     if (!doQuickRestart
-        && EDStatic.subscribeToRemoteErddapDataset
+        && EDStatic.config.subscribeToRemoteErddapDataset
         && cacheFromUrl != null
         && cacheFromUrl.startsWith("http")
         && cacheFromUrl.indexOf("/erddap/files/") > 0) {
@@ -3200,13 +3205,13 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
 
     // If too many events, call for reload.
     // This method isn't as nearly as efficient as full reload.
-    if (nEvents > EDStatic.updateMaxEvents) {
+    if (nEvents > EDStatic.config.updateMaxEvents) {
       if (reallyVerbose)
         String2.log(
             msg
                 + nEvents
                 + ">"
-                + EDStatic.updateMaxEvents
+                + EDStatic.config.updateMaxEvents
                 + " file events, so I called requestReloadASAP() instead of making changes here.");
       requestReloadASAP();
       return false;
@@ -3438,7 +3443,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
       }
 
       // after changes all in place
-      if (EDStatic.updateSubsRssOnFileChanges) {
+      if (EDStatic.config.updateSubsRssOnFileChanges) {
         Erddap.tryToDoActions(datasetID(), this, "", changed(snapshot));
       }
     }
@@ -3480,7 +3485,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
   @Override
   public boolean lowUpdate(int language, String msg, long startUpdateMillis) throws Throwable {
 
-    if (EDStatic.useSharedWatchService) {
+    if (EDStatic.config.useSharedWatchService) {
       SharedWatchService.processEvents();
       return false;
     }
@@ -4300,7 +4305,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFiles.java
@@ -1181,7 +1181,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of
-   *     value="[standard]" will be converted to the EDStatic.standardLicense.
+   *     value="[standard]" will be converted to the EDStatic.messages.standardLicense.
    * @param tDataVariables is an Object[nDataVariables][3 or 4]: <br>
    *     [0]=String sourceName (the name of the data variable in the dataset source, without the
    *     outer or inner sequence name), <br>
@@ -1710,7 +1710,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         updateEveryNMillis = 0; // disable the inotify system for this instance
         String subject = String2.ERROR + " in " + datasetID + " constructor (inotify)";
         msg = MustBe.throwableToString(t);
-        if (msg.indexOf("inotify instances") >= 0) msg += EDStatic.inotifyFixAr[0];
+        if (msg.indexOf("inotify instances") >= 0) msg += EDStatic.messages.inotifyFixAr[0];
         EDStatic.email(EDStatic.adminEmail, subject, msg);
         msg = "";
       }
@@ -1901,7 +1901,8 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
       elapsedTime = System.currentTimeMillis();
       while (tFileListPo < tFileNamePA.size()) {
         if (Thread.currentThread().isInterrupted())
-          throw new SimpleException("EDDTableFromFiles.init" + EDStatic.caughtInterruptedAr[0]);
+          throw new SimpleException(
+              "EDDTableFromFiles.init" + EDStatic.messages.caughtInterruptedAr[0]);
 
         int tDirI = tFileDirIndexPA.get(tFileListPo);
         String tFileS = tFileNamePA.get(tFileListPo);
@@ -2277,7 +2278,7 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
     // if (debugMode) String2.log(">> EDDTableFromFiles " +
     // Calendar2.getCurrentISODateTimeStringLocalTZ() + " finished making
@@ -3235,7 +3236,8 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
     int nChanges = 0; // BadFiles or FileTable
     for (int evi = 0; evi < nEvents; evi++) {
       if (Thread.currentThread().isInterrupted())
-        throw new SimpleException("EDDTableFromFiles.lowUpdate" + EDStatic.caughtInterruptedAr[0]);
+        throw new SimpleException(
+            "EDDTableFromFiles.lowUpdate" + EDStatic.messages.caughtInterruptedAr[0]);
 
       String fullName = contexts.get(evi);
       String dirName = File2.getDirectory(fullName);
@@ -4962,8 +4964,8 @@ public abstract class EDDTableFromFiles extends EDDTable implements WatchUpdateH
         throw t;
         // throw t instanceof WaitThenTryAgainException? t :
         // new WaitThenTryAgainException(
-        // EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr) +
-        // "\n(" + EDStatic.errorFromDataSource + tToString + ")", t);
+        // EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr) +
+        // "\n(" + EDStatic.messages.errorFromDataSource + tToString + ")", t);
       }
 
     } finally {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromHttpGet.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromHttpGet.java
@@ -940,9 +940,9 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
               throw new SimpleException(
                   EDStatic.bilingual(
                       language,
-                      EDStatic.queryErrorAr[0]
+                      EDStatic.messages.queryErrorAr[0]
                           + "Invalid units for the string time variable. Units MUST specify the format of the time values.",
-                      EDStatic.queryErrorAr[language]
+                      EDStatic.messages.queryErrorAr[language]
                           + "Invalid units for the string time variable. Units MUST specify the format of the time values."));
             }
             timeFormat = columnUnits[col];
@@ -975,11 +975,11 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
       throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + "The \""
                     + parts[p]
                     + "\" parameter isn't in the form name=value.",
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + "The \""
                     + parts[p]
                     + "\" parameter isn't in the form name=value."));
@@ -995,15 +995,16 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + "author= must be the last parameter.",
-                  EDStatic.queryErrorAr[language] + "author= must be the last parameter."));
+                  EDStatic.messages.queryErrorAr[0] + "author= must be the last parameter.",
+                  EDStatic.messages.queryErrorAr[language]
+                      + "author= must be the last parameter."));
         if (!keys.contains(
             tValue)) // this tests validity of author_key (since checked when created)
         throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + "Invalid author_key.",
-                  EDStatic.queryErrorAr[language] + "Invalid author_key."));
+                  EDStatic.messages.queryErrorAr[0] + "Invalid author_key.",
+                  EDStatic.messages.queryErrorAr[language] + "Invalid author_key."));
         int po = Math.max(0, tValue.indexOf('_'));
         author = tValue.substring(0, po);
         columnValues[authorColumn] = new StringArray(new String[] {author});
@@ -1020,17 +1021,17 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0] + "Unknown variable name=" + tName,
-                  EDStatic.queryErrorAr[language] + "Unknown variable name=" + tName));
+                  EDStatic.messages.queryErrorAr[0] + "Unknown variable name=" + tName,
+                  EDStatic.messages.queryErrorAr[language] + "Unknown variable name=" + tName));
         } else if (whichCol == timestampColumn) {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + "An .insert or .delete request must not include "
                       + TIMESTAMP
                       + " as a parameter.",
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + "An .insert or .delete request must not include "
                       + TIMESTAMP
                       + " as a parameter."));
@@ -1038,11 +1039,11 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + "An .insert or .delete request must not include "
                       + COMMAND
                       + " as a parameter.",
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + "An .insert or .delete request must not include "
                       + COMMAND
                       + " as a parameter."));
@@ -1052,11 +1053,11 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           throw new SimpleException(
               EDStatic.bilingual(
                   language,
-                  EDStatic.queryErrorAr[0]
+                  EDStatic.messages.queryErrorAr[0]
                       + "There are two parameters with variable name="
                       + tName
                       + ".",
-                  EDStatic.queryErrorAr[language]
+                  EDStatic.messages.queryErrorAr[language]
                       + "There are two parameters with variable name="
                       + tName
                       + "."));
@@ -1079,13 +1080,13 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + "Different parameters with arrays have different sizes: "
                         + arraySize
                         + "!="
                         + columnValues[whichCol].size()
                         + ".",
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + "Different parameters with arrays have different sizes: "
                         + arraySize
                         + "!="
@@ -1103,13 +1104,13 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
             throw new SimpleException(
                 EDStatic.bilingual(
                     language,
-                    EDStatic.queryErrorAr[0]
+                    EDStatic.messages.queryErrorAr[0]
                         + "One value (not "
                         + sa.size()
                         + ") expected for columnName="
                         + tName
                         + ". (missing [ ] ?)",
-                    EDStatic.queryErrorAr[language]
+                    EDStatic.messages.queryErrorAr[language]
                         + "One value (not "
                         + sa.size()
                         + ") expected for columnName="
@@ -1124,7 +1125,8 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           //    (tValue.length() < 2 ||
           //     tValue.charAt(0) != '"' ||
           //     tValue.charAt(tValue.length() - 1) != '"'))
-          //    throw new SimpleException(EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          //    throw new SimpleException(EDStatic.simpleBilingual(language,
+          // EDStatic.messages.queryErrorAr)
           // +
           //        "The String value for columnName=" + tName + " must start and end with \"'s.");
         }
@@ -1134,7 +1136,7 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
           PrimitiveArray pa = columnValues[whichCol];
           if (pa.size() == 0 || pa.getString(0).length() == 0) // string="" number=NaN
           throw new SimpleException(
-                EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                     + "requiredVariable="
                     + tName
                     + " must have a valid value.");
@@ -1147,18 +1149,18 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + "author= was not specified.",
-              EDStatic.queryErrorAr[language] + "author= was not specified."));
+              EDStatic.messages.queryErrorAr[0] + "author= was not specified.",
+              EDStatic.messages.queryErrorAr[language] + "author= was not specified."));
     int notFound = requiredVariablesFound.nextClearBit(0);
     if (notFound < requiredVariableNames.length)
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0]
+              EDStatic.messages.queryErrorAr[0]
                   + "requiredVariableName="
                   + requiredVariableNames[notFound]
                   + " wasn't specified.",
-              EDStatic.queryErrorAr[language]
+              EDStatic.messages.queryErrorAr[language]
                   + "requiredVariableName="
                   + requiredVariableNames[notFound]
                   + " wasn't specified."));
@@ -1625,20 +1627,20 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
       } else if (colName.equals("timestamp")) {
         destAtts.add(
             "comment",
-            EDStatic.EDDTableFromHttpGetTimestampDescription
+            EDStatic.messages.EDDTableFromHttpGetTimestampDescription
                 + " "
-                + EDStatic.noteAr[0]
+                + EDStatic.messages.noteAr[0]
                 + " "
-                + EDStatic.EDDTableFromHttpGetDatasetDescription);
+                + EDStatic.messages.EDDTableFromHttpGetDatasetDescription);
         destAtts.add("units", Calendar2.SECONDS_SINCE_1970);
         destAtts.add("time_precision", "1970-01-01T00:00:00.000Z");
         destPA = new DoubleArray(sourcePA);
       } else if (colName.equals("author")) {
-        destAtts.add("comment", EDStatic.EDDTableFromHttpGetAuthorDescription);
+        destAtts.add("comment", EDStatic.messages.EDDTableFromHttpGetAuthorDescription);
         destAtts.add("ioos_category", "Identifier");
         destPA = new StringArray(sourcePA);
       } else if (colName.equals("command")) {
-        destAtts.add("comment", EDStatic.EDDTableFromHttpGetDatasetDescription);
+        destAtts.add("comment", EDStatic.messages.EDDTableFromHttpGetDatasetDescription);
         destAtts.add("flag_values", new byte[] {0, 1});
         destAtts.add("flag_meanings", "insert delete");
         destAtts.add("ioos_category", "Other");
@@ -1710,7 +1712,9 @@ public class EDDTableFromHttpGet extends EDDTableFromFiles {
         String2.ifSomethingConcat(
             ttSummary,
             "\n\n",
-            EDStatic.noteAr[0] + " " + EDStatic.EDDTableFromHttpGetDatasetDescription));
+            EDStatic.messages.noteAr[0]
+                + " "
+                + EDStatic.messages.EDDTableFromHttpGetDatasetDescription));
     if (String2.isSomething(tHttpGetRequiredVariables)) {
       StringArray sa = StringArray.fromCSV(tHttpGetRequiredVariables);
       if (sa.size() > 0) addGlobalAtts.add("subsetVariables", sa.get(0));

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromHyraxFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromHyraxFiles.java
@@ -129,7 +129,7 @@ public class EDDTableFromHyraxFiles extends EDDTableFromFiles {
         tDataVariables,
         tReloadEveryNMinutes,
         tUpdateEveryNMillis,
-        EDStatic.fullCopyDirectory + tDatasetID + "/", // force fileDir to be the copyDir
+        EDStatic.config.fullCopyDirectory + tDatasetID + "/", // force fileDir to be the copyDir
         tFileNameRegex,
         tRecursive,
         tPathRegex,
@@ -215,8 +215,8 @@ public class EDDTableFromHyraxFiles extends EDDTableFromFiles {
       int lookForLength = lookFor.length();
 
       // mimic the remote dir structure in baseDir
-      String baseDir = EDStatic.fullCopyDirectory + tDatasetID + "/";
-      // e.g. localFile EDStatic.fullCopyDirectory + tDatasetID +  /
+      String baseDir = EDStatic.config.fullCopyDirectory + tDatasetID + "/";
+      // e.g. localFile EDStatic.config.fullCopyDirectory + tDatasetID +  /
       // 1987/M07/pentad_19870710_v11l35flk.nc.gz
       File2.makeDirectory(baseDir);
 
@@ -397,7 +397,7 @@ public class EDDTableFromHyraxFiles extends EDDTableFromFiles {
       EDStatic.lastAssignedTask.put(tDatasetID, taskNumber);
       EDStatic.ensureTaskThreadIsRunningIfNeeded(); // ensure info is up-to-date
 
-      if (EDStatic.forceSynchronousLoading) {
+      if (EDStatic.config.forceSynchronousLoading) {
         boolean interrupted = false;
         while (!interrupted && EDStatic.lastFinishedTask.get() < taskNumber) {
           try {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromMWFS.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromMWFS.javaINACTIVE
@@ -205,7 +205,7 @@ public class EDDTableFromMWFS extends EDDTable{
      *   </ul>
      *   Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
      *   Special case: if combinedGlobalAttributes name="license", any instance of "[standard]"
-     *     will be converted to the EDStatic.standardLicense.
+     *     will be converted to the EDStatic.messages.standardLicense.
      * @param tLonMin in source units (use Double.NaN if not known).
      *    [I use eddTable.getEmpiricalMinMax(language, "2007-02-01", "2007-02-01", false, true); below to get it.]
      * @param tLonMax see tLonMin description.
@@ -282,7 +282,7 @@ public class EDDTableFromMWFS extends EDDTable{
         String tLicense = combinedGlobalAttributes.getString("license");
         if (tLicense != null)
             combinedGlobalAttributes.set("license", 
-                String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+                String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
         combinedGlobalAttributes.removeValue("\"null\"");
 
         //make the fixedVariables

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromMWFS.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromMWFS.javaINACTIVE
@@ -359,7 +359,7 @@ public class EDDTableFromMWFS extends EDDTable{
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)
@@ -672,8 +672,8 @@ time series data.</att>
 
         //*** test getting das for entire dataset
         String2.log("\n****************** EDDTableFromMWFS.test das dds for entire dataset\n");
-        tName = mwfs.makeNewFileForDapQuery(language, null, "", EDStatic.fullTestCacheDirectory, className + "_Entire", ".das"); 
-        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray()));
+        tName = mwfs.makeNewFileForDapQuery(language, null, "", EDStatic.config.fullTestCacheDirectory, className + "_Entire", ".das"); 
+        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray()));
         //String2.log(results);
         expected = //see OpendapHelper.EOL for comments
 "Attributes {[10]\n" +
@@ -780,8 +780,8 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
         
         //*** test getting dds for entire dataset
-        tName = mwfs.makeNewFileForDapQuery(language, null, "", EDStatic.fullTestCacheDirectory, className + "_Entire", ".dds"); 
-        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray()));
+        tName = mwfs.makeNewFileForDapQuery(language, null, "", EDStatic.config.fullTestCacheDirectory, className + "_Entire", ".dds"); 
+        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray()));
         //String2.log(results);
         expected = 
 "Dataset {[10]\n" +
@@ -809,8 +809,8 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
             "&time>=2007-05-01&time<=2007-05-08"; 
         //2007-05-01 -> 1.1779776E9
         //2007-05-08 -> 1.1785824E9
-        tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.fullTestCacheDirectory, className + "_station1", ".asc"); 
-        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray()));
+        tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, className + "_station1", ".asc"); 
+        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray()));
         //String2.log(results);
         expected = 
 "Dataset {[10]\n" +
@@ -834,8 +834,8 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         if (doLongTest) {
             userDapQuery = "longitude,latitude,station_id,time,sea_water_temperature" +
                 "&longitude=" + tLon + "&latitude=" + tLat; 
-            tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.fullTestCacheDirectory, className + "_station1", ".asc"); 
-            results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray()));
+            tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, className + "_station1", ".asc"); 
+            results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray()));
             //String2.log(results);
             expected = 
 "Dataset {[10]\n" +
@@ -861,9 +861,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
             "&time>=2007-05-01&time<=2007-05-01T00:59:00";
         //2007-05-01 -> 1.1779776E9
         //2007-05-01T00:59:00 -> 1.17798114E9
-        tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.fullTestCacheDirectory, className + "_stations", ".asc"); 
-        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray()));
-        //Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+        tName = mwfs.makeNewFileForDapQuery(language, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, className + "_stations", ".asc"); 
+        results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray()));
+        //Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 "Dataset {[10]\n" +
@@ -887,8 +887,8 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         Test.ensureTrue(results.indexOf(expected) > 0, "\nresults=\n" + results.substring(results.length() - 300));
 
         //data for mapExample
-        tName = mwfs.makeNewFileForDapQuery(language, null, "longitude,latitude&time>=2007-12-01&time<=2007-12-01T00:01:00", EDStatic.fullTestCacheDirectory, className + "Map", ".csv");
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+        tName = mwfs.makeNewFileForDapQuery(language, null, "longitude,latitude&time>=2007-12-01&time<=2007-12-01T00:01:00", EDStatic.config.fullTestCacheDirectory, className + "Map", ".csv");
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
         //String2.log(results);
         expected = 
 "longitude, latitude\n" +

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNOS.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNOS.javaINACTIVE
@@ -511,7 +511,7 @@ public class EDDTableFromNOS extends EDDTable{
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)
@@ -933,10 +933,10 @@ String2.log("\n  response=\n" + SSR.getSoapString(sourceUrl, request,
 
         //*** test getting das for entire dataset
         String2.log("\n****************** EDDTableFromNOS.test das dds for entire dataset\n");
-        tName = wind.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_Entire", ".das"); 
         results = String2.annotatedString(File2.directReadFrom88591File(
-            EDStatic.fullTestCacheDirectory + tName));
+            EDStatic.config.fullTestCacheDirectory + tName));
         //String2.log(results);
         expected = //see OpendapHelper.EOL for comments
 "Attributes {[10]\n" +
@@ -1069,10 +1069,10 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
         
         //*** test getting dds for entire dataset
-        tName = wind.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_Entire", ".dds"); 
         results = String2.annotatedString(File2.directReadFrom88591File(
-            EDStatic.fullTestCacheDirectory + tName));
+            EDStatic.config.fullTestCacheDirectory + tName));
         //String2.log(results);
         expected = 
 "Dataset {[10]\n" +
@@ -1101,9 +1101,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         //.asc test of just station data
         userDapQuery = "longitude,latitude,station_name,station_id" +
             "&longitude=" + tLon + "&latitude=" + tLat; 
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_station1", ".asc"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         //String2.log(results);
         expected = 
 "Dataset {\n" +
@@ -1123,9 +1123,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         //.asc test of just station data          REGEX
         userDapQuery = "longitude,latitude,station_name,station_id" +
             "&station_name" + PrimitiveArray.REGEX_OP + "\"P.*e.*\""; 
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_station2", ".asc"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         expected =   
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -1182,9 +1182,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
 
 
         //.asc    test 1 lon,lat point
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_Data", ".asc"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -1218,9 +1218,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
             "&longitude>=" + (tLon-0.01) + "&longitude<" + (tLon+0.01) + 
             "&wind_speed>2.2&wind_speed<3.2" +  //wind_speed
             "&latitude=" + tLat + "&time>=" + beginDate + "&time<=" + endDate;
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_Num", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "longitude, latitude, time, station_id, station_name, wind_from_direction\n" +
 "degrees_east, degrees_north, UTC, , , degrees_true\n" +
@@ -1231,9 +1231,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         userDapQuery = "longitude,latitude,time,station_id,station_name,wind_speed,wind_from_direction" + 
             "&station_name>\"Prov\"&station_name<\"Prow\"" +
             "&time>=" + beginDate + "&time<=" + endDate;
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_name", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "longitude, latitude, time, station_id, station_name, wind_speed, wind_from_direction\n" +
 "degrees_east, degrees_north, UTC, , , m s-1, degrees_true\n" +
@@ -1247,9 +1247,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         userDapQuery = "longitude,latitude,time,station_id,station_name,wind_speed,wind_from_direction" + 
             "&station_id>\"8454\"&station_id<\"8455\"" +
             "&time>=" + beginDate + "&time<=" + endDate;
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_id", ".csv"); 
-        results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "longitude, latitude, time, station_id, station_name, wind_speed, wind_from_direction\n" +
 "degrees_east, degrees_north, UTC, , , m s-1, degrees_true\n" +
@@ -1280,10 +1280,10 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
             //"&stationID=9411340&time>=1993-09-09&time<=1993-09-11"; //succeeds, including data on 9/9
             "&stationID=9411340&time>=1993-09-09&time<=1993-09-10";  //fails: no data
             //"&stationID=9411340&time=1993-09-09"; //fails: no data
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_DataLLRange", ".xhtml"); 
-        results = String2.annotatedString(File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName));
-        Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+        results = String2.annotatedString(File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName));
+        Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "Dataset {[10]\n" +
 "  Sequence {[10]\n" +
@@ -1310,10 +1310,10 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
         userDapQuery = "longitude,latitude,time,station_id,station_name," +
             "wind_speed,wind_from_direction,wind_speed_of_gust,MaxExceeded,RateExceeded" +
             "&longitude>-125&longitude<-115&latitude>30&latitude<35&time=2006-01-01";
-        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.fullTestCacheDirectory, 
+        tName = wind.makeNewFileForDapQuery(language, null, null, userDapQuery, EDStatic.config.fullTestCacheDirectory, 
             wind.className() + "_DataLLRange", ".xhtml"); 
-        results = String2.annotatedString(File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName));
-        Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+        results = String2.annotatedString(File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName));
+        Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "Dataset {[10]\n" +
 "  Sequence {[10]\n" +
@@ -1340,9 +1340,9 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
             String tUserDapQuery = "longitude,latitude,time,station_name," +
                 "wind_speed,wind_from_direction,wind_speed_of_gust" +
                 "&longitude=" + tLon + "&latitude=" + tLat + "&time>=" + beginDate + "&time<=2007-05-01"; //>366 days (their limit)
-            tName = wind.makeNewFileForDapQuery(language, null, null, tUserDapQuery, EDStatic.fullTestCacheDirectory, 
+            tName = wind.makeNewFileForDapQuery(language, null, null, tUserDapQuery, EDStatic.config.fullTestCacheDirectory, 
                 wind.className() + "_DataTime", ".asc"); 
-            results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            results = String2.annotatedString(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
             expected = 
 "Dataset {[10]\n" +
 "  Sequence {[10]\n" +
@@ -1374,8 +1374,8 @@ today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
 
         //data for mapExample
         tName = wind.makeNewFileForDapQuery(language, null, null, "longitude,latitude&time>=2007-12-01&time<=2007-12-02", 
-            EDStatic.fullTestCacheDirectory, wind.className() + "Map", ".csv");
-        results = File2.readFromFile(EDStatic.fullTestCacheDirectory + tName)[1];
+            EDStatic.config.fullTestCacheDirectory, wind.className() + "Map", ".csv");
+        results = File2.readFromFile(EDStatic.config.fullTestCacheDirectory + tName)[1];
         expected = 
 "longitude, latitude\n" +
 "degrees_east, degrees_north\n" +

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNOS.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNOS.javaINACTIVE
@@ -236,7 +236,7 @@ public class EDDTableFromNOS extends EDDTable{
      *   </ul>
      *   Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
      *   Special case: if combinedGlobalAttributes name="license", any instance of "[standard]"
-     *     will be converted to the EDStatic.standardLicense.
+     *     will be converted to the EDStatic.messages.standardLicense.
      * @param tDataVariables is an Object[nDataVariables][4]: 
      *    <br>[0]=String sourceName (the name of the data variable in the dataset source),
      *    <br>[1]=String destinationName (the name to be presented to the ERDDAP user, 
@@ -337,7 +337,7 @@ public class EDDTableFromNOS extends EDDTable{
         String tLicense = combinedGlobalAttributes.getString("license");
         if (tLicense != null)
             combinedGlobalAttributes.set("license", 
-                String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+                String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
         combinedGlobalAttributes.removeValue("\"null\"");
 
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNWISDV.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNWISDV.javaINACTIVE
@@ -557,7 +557,7 @@ public class EDDTableFromNWISDV extends EDDTable{
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)
@@ -1482,7 +1482,7 @@ public class EDDTableFromNWISDV extends EDDTable{
         String logFileName        = "c:/data/waterML/NWISDVDatasetFailures" + today + ".txt";
         Writer logFile = File2.getBufferedFileWriterUtf8(logFileName); 
         try {
-            String subsetDir   = EDStatic.contentDirectory + "subset/";
+            String subsetDir   = EDStatic.config.contentDirectory + "subset/";
             String fileNames[] = RegexFilenameFilter.list(dataStationsDir, ".*\\.json");
             StringBuilder results  = new StringBuilder();
             int nSkip = 0;
@@ -2791,7 +2791,7 @@ String2.log("\ndatasetStations=\n" + datasetStations.dataToString());
     public static void testBasic() throws Throwable {
         EDD edd = EDD.oneFromDatasetsXml(null, "usgs_waterservices_f8b2_b8b1_96dd");
         int language = 0;
-        String dir = EDStatic.fullTestCacheDirectory;
+        String dir = EDStatic.config.fullTestCacheDirectory;
         String tName, query, tRestuls, results[], expected;
         String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
         Table table;
@@ -2799,7 +2799,7 @@ String2.log("\ndatasetStations=\n" + datasetStations.dataToString());
         //dds
         tName = edd.makeNewFileForDapQuery(language, null, null, "", dir, 
             edd.className() + "_Entire", ".dds"); 
-        results = File2.readFromFile(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.readFromFile(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -2831,7 +2831,7 @@ String2.log("\ndatasetStations=\n" + datasetStations.dataToString());
         //das
         tName = edd.makeNewFileForDapQuery(language, null, null, "", dir, 
             edd.className() + "_Entire", ".das"); 
-        results = File2.readFromFile(EDStatic.fullTestCacheDirectory + tName);
+        results = File2.readFromFile(EDStatic.config.fullTestCacheDirectory + tName);
         expected = 
 "Attributes {\n" +
 " s {\n" +

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNWISDV.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNWISDV.javaINACTIVE
@@ -327,7 +327,7 @@ public class EDDTableFromNWISDV extends EDDTable{
      *   </ul>
      *   Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
      *   Special case: if combinedGlobalAttributes name="license", any instance of "[standard]"
-     *     will be converted to the EDStatic.standardLicense.
+     *     will be converted to the EDStatic.messages.standardLicense.
      * @param tDataVariables is an Object[nDataVariables][3]: 
      *    <br>[0]=String sourceName (the name of the data variable in the dataset source, 
      *         without the outer or inner sequence name),
@@ -401,7 +401,7 @@ public class EDDTableFromNWISDV extends EDDTable{
         String tLicense = combinedGlobalAttributes.getString("license");
         if (tLicense != null)
             combinedGlobalAttributes.set("license", 
-                String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+                String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
         combinedGlobalAttributes.removeValue("\"null\"");
         parameterCode = combinedGlobalAttributes.getString("parameterCode");
         statisticCode = combinedGlobalAttributes.getString("statisticCode");
@@ -744,7 +744,7 @@ public class EDDTableFromNWISDV extends EDDTable{
             } catch (Throwable t) {
                 if (!reallyVerbose)  //if reallyVerbose, it was done above
                     String2.log(encodedSourceUrl);
-                throw new Throwable(EDStatic.errorFromDataSource + t.toString(), t);
+                throw new Throwable(EDStatic.messages.errorFromDataSource + t.toString(), t);
             }
 
             int nRows = table.nRows();

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNcSequenceFiles.javaNOT_FINISHED
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromNcSequenceFiles.javaNOT_FINISHED
@@ -1148,7 +1148,7 @@ cdmSuggestion() +
         String name, tName, results, tResults, expected, userDapQuery, tQuery;
         String error = "";
         EDV edv;
-        String dir = EDStatic.fullTestCacheDirectory;
+        String dir = EDStatic.config.fullTestCacheDirectory;
         String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 14); //14 is enough to check hour. Hard to check min:sec.
 
         String id = "testTableNcSequence";

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
@@ -658,7 +658,7 @@ public class EDDTableFromOBIS extends EDDTable {
    *
    * @param language the index of the selected language
    * @param loggedInAs the user's login name if logged in (or null if not logged in).
-   * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be
    *     null.
    * @param tableWriter

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromOBIS.java
@@ -354,7 +354,8 @@ public class EDDTableFromOBIS extends EDDTable {
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     <br>
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense plus EDDTableFromOBIS OBIS_LICENSE. <br>
+   *     be converted to the EDStatic.messages.standardLicense plus EDDTableFromOBIS OBIS_LICENSE.
+   *     <br>
    *     Special case: addGlobalAttributes must have a name="creator_email" value=AnEmailAddress for
    *     users to contact regarding publications that use the data in order to comply with license.
    *     A suitable email address can be found by reading the XML response from the sourceURL. <br>
@@ -454,7 +455,7 @@ public class EDDTableFromOBIS extends EDDTable {
           String2.replaceAll(
               tLicense,
               "[standard]",
-              EDStatic.standardLicense
+              EDStatic.messages.standardLicense
                   + "\n\n"
                   + String2.replaceAll(OBIS_LICENSE, "&sourceUrl;", tLocalSourceUrl));
       tLicense = String2.replaceAll(tLicense, "&creator_email;", tCreator_email);
@@ -784,7 +785,7 @@ public class EDDTableFromOBIS extends EDDTable {
           || tToString.indexOf(Math2.memoryTooMuchData) >= 0
           || tToString.indexOf(Math2.TooManyOpenFiles) >= 0) throw t;
 
-      throw new Throwable(EDStatic.errorFromDataSource + tToString, t);
+      throw new Throwable(EDStatic.messages.errorFromDataSource + tToString, t);
     }
     // if (reallyVerbose) String2.log(table.toString());
     table.setColumnName(table.findColumnNumber("LON"), "darwin:Longitude");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromPostDatabase.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromPostDatabase.javaINACTIVE
@@ -376,7 +376,7 @@ boolean addTestPostUser = false;
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)
@@ -521,9 +521,9 @@ boolean addTestPostUser = false;
             EDDTableFromPostDatabase tedd = (EDDTableFromPostDatabase)oneFromDatasetsXml(null, "postSurg3"); 
  
             //das
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_ps3_Data", ".das"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "Attributes {\n" +
 " s {\n" +
@@ -858,9 +858,9 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             Test.ensureEqual(results, expected, "\nresults=\n" + results);
   
             //.dds 
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_ps3_Data", ".dds"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -916,8 +916,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1role", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1role", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -929,8 +929,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleLIOD", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleLIOD", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //same expected
             Test.ensureEqual(results, expected, "\nresults=\n" + results);
             String2.log("*** testPostSurg3 1roleLIOD FINISHED.  TIME=" + (System.currentTimeMillis() - eTime) + "ms"); 
@@ -941,8 +941,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
                 if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -956,8 +956,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, "WELCH_DAVID", tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleWP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleWP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
                 if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -970,8 +970,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1roleL", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1roleL", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -985,8 +985,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_1rolePDLI", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_1rolePDLI", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, activation_time, anaesthetic_conc_recirc, anaesthetic_conc_surgery, buffer_conc_anaesthetic, buffer_conc_recirc, buffer_conc_surgery, channel, code_label, comments, common_name, date_public, delay_max, delay_min, delay_start, delay_type, dna_sampled, est_tag_life, fork_length, frequency, implant_type, length_hood, length_pcl, length_standard, project, provenance, role, scientific_name, sedative_conc_surgery, stock, surgery_id, surgery_location, surgery_longitude, surgery_latitude, surgery_time, tagger, treatment_type, water_temp, weight\n" +
 ", , degrees_east, degrees_north, UTC, UTC, ppm, ppm, ppm, ppm, ppm, , , , , UTC, ms, ms, days, , , days, mm, kHz, , mm, mm, mm, , , , , ppm, , , , degrees_east, degrees_north, UTC, , , degree_C, grams\n" +
@@ -1001,8 +1001,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "longitude,latitude,time&time>=2007-05-01&time<2007-09-01";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_ps3_LLT", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_ps3_LLT", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //String2.log("results=\n" + results.substring(0, Math.min(results.length(), 10000)));
             po = results.indexOf("NaN");
             String2.log("\nresults.length()=" + results.length() + "  NaN po=" + po);
@@ -1030,9 +1030,9 @@ today + " http://localhost:8080/cwexperimental/tabledap/postSurg3.das\";\n" +
             EDDTableFromPostDatabase tedd = (EDDTableFromPostDatabase)oneFromDatasetsXml(null, "postDet3"); 
 /* */
             //das
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_pd3_Data", ".das"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "Attributes {\n" +
 " s {\n" +
@@ -1220,9 +1220,9 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             Test.ensureEqual(results, expected, "\nresults=\n" + results);
   
             //.dds 
-            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.fullTestCacheDirectory, 
+            tName = tedd.makeNewFileForDapQuery(language, null, null, "", EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_pd3_Data", ".dds"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "Dataset {\n" +
 "  Sequence {\n" +
@@ -1252,8 +1252,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&unique_tag_id=\"19835\"";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1tag", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1tag", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
 //the row from the surgery table is
 //"19835, DAVID WELCH, -121.97974, 49.07988, 2007-05-16T22:00:00Z, 2007-05-13T07:00:00Z, NaN, 70.0, 140.0, NaN, NaN, A, A69-1105-AE, , /"SOCKEYE, KOKANEE/", 2008-09-29T23:29:37Z, 90, 30, 0, RANDOM, 0, 2055.0, 204.0, 69.0, INTERNAL, NaN, NaN, NaN, KINTAMA RESEARCH, Hatchery, WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE, ONCORHYNCHUS NERKA, 1.0, CULTUS LAKE, 7991, INCH CREEK HATCHERY, -122.16152, 49.17132, 2007-05-13T07:00:00Z, ADRIAN LADOUCEUR, SHADE, 6.7, NaN\n";
             expected =   
@@ -1270,8 +1270,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1role", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1role", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //expected = same
             Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
             String2.log("*** testPostDet3 1role FINISHED.  TIME=" + (System.currentTimeMillis() - eTime) + "ms"); 
@@ -1280,8 +1280,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"WELCH_DAVID_ONCORHYNCHUSNERKA_CULTUSLAKE\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleLIOD", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleLIOD", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             //same expected
             Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
             String2.log("*** testPostDet3 1roleLIOD FINISHED.  TIME=" + (System.currentTimeMillis() - eTime) + "ms"); 
@@ -1292,8 +1292,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, null, tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
                 if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -1307,8 +1307,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             try {
                 tName = tedd.makeNewFileForDapQuery(language, null, "WELCH_DAVID", tQuery, 
-                    EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleWP", ".csv"); 
-                results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                    EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleWP", ".csv"); 
+                results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
                 throw new Exception("Shouldn't get here.");
             } catch (Throwable t) {
                 if (t.toString().indexOf(MustBe.THERE_IS_NO_DATA) < 0)
@@ -1321,8 +1321,8 @@ today + " http://localhost:8080/cwexperimental/tabledap/postDet3.das\";\n" +
             eTime = System.currentTimeMillis();
             tQuery = "&role=\"ROBICHAUD_DAVID_ACIPENSERTRANSMONTANUS_LOWERFRASER\"";
             tName = tedd.makeNewFileForDapQuery(language, null, "ROBICHAUD_DAVID", tQuery, 
-                EDStatic.fullTestCacheDirectory, tedd.className() + "_pd3_1roleL", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+                EDStatic.config.fullTestCacheDirectory, tedd.className() + "_pd3_1roleL", ".csv"); 
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
 String2.log("\n" + results.substring(0, 4000) + "\n");
             expected =   
 "unique_tag_id, pi, longitude, latitude, time, bottom_depth, common_name, date_public, position_on_subarray, project, riser_height, role, scientific_name, stock, surgery_time, surgery_location, tagger\n" +
@@ -1388,9 +1388,9 @@ String2.log("\n" + results.substring(0, 4000) + "\n");
                 //",stock,surgery_time,surgery_location,tagger" +
                 //"&unique_tag_id=\"1039490\"",
 
-                EDStatic.fullTestCacheDirectory, 
+                EDStatic.config.fullTestCacheDirectory, 
                 tedd.className() + "_pd3_tag", ".csv"); 
-            results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName)).toArray());
+            results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName)).toArray());
             expected = 
 "unique_tag_id, PI, longitude, latitude, time, bottom_depth, common_name, date_public, position_on_subarray, project, riser_height, role, scientific_name, serial_number, stock, surgery_time, surgery_location, tagger\n" +
 ", , degrees_east, degrees_north, UTC, m, , UTC, , , m, , , , , UTC, , \n" +
@@ -1411,7 +1411,7 @@ String2.log("\n" + results.substring(0, 4000) + "\n");
     public static void testPostSurg3Direct() throws Throwable {
         String2.log("\n*** EDDTableFromPostDatabase.testPostSurg3Direct");
         testVerboseOn();
-        String dir = EDStatic.fullTestCacheDirectory;
+        String dir = EDStatic.config.fullTestCacheDirectory;
         String tName, tQuery, results, expected;
         Table table;
         try {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromPostNcFiles.javaINACTIVE
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromPostNcFiles.javaINACTIVE
@@ -180,7 +180,7 @@ public class EDDTableFromPostNcFiles extends EDDTableFromNcFiles {
      *
      * @param language the index of the selected language
      * @param loggedInAs the user's login name if logged in (or null if not logged in).
-     * @param requestUrl the part of the user's request, after EDStatic.baseUrl, before '?'.
+     * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
      * @param userDapQuery the part of the user's request after the '?', still percentEncoded, may be null.
      * @param tableWriter
      * @throws Throwable if trouble (notably, WaitThenTryAgainException)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
@@ -120,7 +120,7 @@ public class EDDTableFromSOS extends EDDTable {
   protected static final int stationProcedureCol = 5;
   protected static final String defaultStationIdSourceName = "station_id";
   protected static final String stationIdDestinationName = "station_id";
-  static final String sosCopyDir = EDStatic.fullCopyDirectory + "_SOS_cache/";
+  static final String sosCopyDir = EDStatic.config.fullCopyDirectory + "_SOS_cache/";
 
   /**
    * The first nFixedVariables dataVariables are always created automatically (don't include in
@@ -666,7 +666,7 @@ public class EDDTableFromSOS extends EDDTable {
     // to test, set this to true in test method, not here.
     boolean testQuickRestart = false;
     if (quickRestartFileExists
-        && (testQuickRestart || (EDStatic.quickRestart && EDStatic.initialLoadDatasets()))) {
+        && (testQuickRestart || (EDStatic.config.quickRestart && EDStatic.initialLoadDatasets()))) {
       // use the quickRestartFile
       // Note that if this fails (any reason, e.g., damaged quickRestartFile)
       //  the dataset will reload at next majorLoadDatasets,
@@ -1774,7 +1774,7 @@ public class EDDTableFromSOS extends EDDTable {
     String grabFileName = cacheDirectory() + "grabFile" + String2.md5Hex12(kvp);
     long downloadTime = System.currentTimeMillis();
     try {
-      if (EDStatic.developmentMode && File2.isFile(grabFileName)) {
+      if (EDStatic.config.developmentMode && File2.isFile(grabFileName)) {
       } else SSR.downloadFile(localSourceUrl + kvp, grabFileName, true);
       downloadTime = System.currentTimeMillis() - downloadTime;
     } catch (Throwable t) {
@@ -2042,7 +2042,7 @@ public class EDDTableFromSOS extends EDDTable {
                 + processTime
                 + "ms");
 
-      if (!EDStatic.developmentMode)
+      if (!EDStatic.config.developmentMode)
         File2.simpleDelete(grabFileName); // don't keep in cache. SOS datasets change frequently.
 
     } catch (Throwable t) {
@@ -2052,7 +2052,7 @@ public class EDDTableFromSOS extends EDDTable {
               + " while processing response from requestUrl="
               + localSourceUrl
               + kvp);
-      if (!EDStatic.developmentMode)
+      if (!EDStatic.config.developmentMode)
         File2.simpleDelete(grabFileName); // don't keep in cache. SOS datasets change frequently.
       throw t;
     }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromSOS.java
@@ -371,7 +371,7 @@ public class EDDTableFromSOS extends EDDTable {
    *     </ul>
    *     Special case: value="null" causes that item to be removed from combinedGlobalAttributes.
    *     Special case: if combinedGlobalAttributes name="license", any instance of "[standard]" will
-   *     be converted to the EDStatic.standardLicense. Special case: if addGlobalAttributes
+   *     be converted to the EDStatic.messages.standardLicense. Special case: if addGlobalAttributes
    *     name="summary", then "[standard]" within the value will be replaced by the standardSummary
    *     (from this class).
    * @param tLonSourceName the results field name for the longitude variable (e.g., longitude). The
@@ -601,7 +601,7 @@ public class EDDTableFromSOS extends EDDTable {
     String tLicense = combinedGlobalAttributes.getString("license");
     if (tLicense != null)
       combinedGlobalAttributes.set(
-          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.standardLicense));
+          "license", String2.replaceAll(tLicense, "[standard]", EDStatic.messages.standardLicense));
     combinedGlobalAttributes.removeValue("\"null\"");
 
     // get all dv sourceObservedProperties
@@ -1471,7 +1471,7 @@ public class EDDTableFromSOS extends EDDTable {
     for (int station = 0; station < nStations; station++) {
       if (Thread.currentThread().isInterrupted())
         throw new SimpleException(
-            "EDDTableFromSOS.getDataForDapQuery" + EDStatic.caughtInterruptedAr[0]);
+            "EDDTableFromSOS.getDataForDapQuery" + EDStatic.messages.caughtInterruptedAr[0]);
 
       String tStationLonString = "",
           tStationLatString = "",
@@ -1789,7 +1789,10 @@ public class EDDTableFromSOS extends EDDTable {
       throw t instanceof WaitThenTryAgainException
           ? t
           : new WaitThenTryAgainException(
-              EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr) + "\n(" + t + ")");
+              EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
+                  + "\n("
+                  + t
+                  + ")");
     }
 
     try {
@@ -2118,7 +2121,10 @@ public class EDDTableFromSOS extends EDDTable {
       throw t instanceof WaitThenTryAgainException
           ? t
           : new WaitThenTryAgainException(
-              EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr) + "\n(" + t + ")");
+              EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
+                  + "\n("
+                  + t
+                  + ")");
     }
     try {
 
@@ -2454,7 +2460,10 @@ public class EDDTableFromSOS extends EDDTable {
       throw t instanceof WaitThenTryAgainException
           ? t
           : new WaitThenTryAgainException(
-              EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr) + "\n(" + t + ")");
+              EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
+                  + "\n("
+                  + t
+                  + ")");
     }
 
     try {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromThreddsFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromThreddsFiles.java
@@ -139,7 +139,7 @@ public class EDDTableFromThreddsFiles extends EDDTableFromFiles {
         tDataVariables,
         tReloadEveryNMinutes,
         tUpdateEveryNMillis,
-        EDStatic.fullCopyDirectory + tDatasetID + "/", // force fileDir to be the copyDir
+        EDStatic.config.fullCopyDirectory + tDatasetID + "/", // force fileDir to be the copyDir
         tFileNameRegex,
         tRecursive,
         tPathRegex,
@@ -246,8 +246,8 @@ public class EDDTableFromThreddsFiles extends EDDTableFromFiles {
       int lookForLength = lookFor.length();
 
       // mimic the remote dir structure in baseDir
-      String baseDir = EDStatic.fullCopyDirectory + tDatasetID + "/";
-      // e.g. localFile EDStatic.fullCopyDirectory + tDatasetID +  /
+      String baseDir = EDStatic.config.fullCopyDirectory + tDatasetID + "/";
+      // e.g. localFile EDStatic.config.fullCopyDirectory + tDatasetID +  /
       // WES001/2008/WES001_030MTBD029R00_20080429.nc
       File2.makeDirectory(baseDir);
 
@@ -469,7 +469,7 @@ public class EDDTableFromThreddsFiles extends EDDTableFromFiles {
       EDStatic.lastAssignedTask.put(tDatasetID, taskNumber);
       EDStatic.ensureTaskThreadIsRunningIfNeeded(); // ensure info is up-to-date
 
-      if (EDStatic.forceSynchronousLoading) {
+      if (EDStatic.config.forceSynchronousLoading) {
         boolean interrupted = false;
         while (!interrupted && EDStatic.lastFinishedTask.get() < taskNumber) {
           try {
@@ -836,7 +836,7 @@ public class EDDTableFromThreddsFiles extends EDDTableFromFiles {
 
     String tPublicDirUrl = convertToPublicSourceUrl(tLocalDirUrl);
     String tDatasetID = suggestDatasetID(tPublicDirUrl + tFileNameRegex);
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     // download the 1 file
     // URL may not have .nc at end.  I think that's okay.  Keep exact file name from URL.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromWFSFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromWFSFiles.java
@@ -158,7 +158,7 @@ public class EDDTableFromWFSFiles extends EDDTableFromAsciiFiles {
    *     examples in JavaDocs for generateDatasetsXml.
    * @param tRowElementXPath the element (XPath style) identifying a row, If null or "", the default
    *     will be used: /wfs:FeatureCollection/gml:featureMember .
-   * @param fullFileName recommended: EDStatic.fullCopyDirectory + datasetID + "/data.tsv"
+   * @param fullFileName recommended: EDStatic.config.fullCopyDirectory + datasetID + "/data.tsv"
    * @return error string ("" if no error)
    */
   public static String downloadData(
@@ -367,7 +367,7 @@ public class EDDTableFromWFSFiles extends EDDTableFromAsciiFiles {
                 dataSourceTable.globalAttributes(),
                 // another cdm_data_type could be better; this is good for now
                 hasLonLatTime(dataAddTable) ? "Point" : "Other",
-                EDStatic.fullCopyDirectory + tDatasetID + "/",
+                EDStatic.config.fullCopyDirectory + tDatasetID + "/",
                 externalAddGlobalAttributes,
                 suggestKeywords(dataSourceTable, dataAddTable)));
     dataAddTable.globalAttributes().set("rowElementXPath", tRowElementXPath);
@@ -395,7 +395,7 @@ public class EDDTableFromWFSFiles extends EDDTableFromAsciiFiles {
             // "    <fileNameRegex>.*\\.tsv</fileNameRegex>\n" + //irrelevant/overridden
             // "    <recursive>false</recursive>\n" +            //irrelevant/overridden
             // "    <pathRegex>.*</pathRegex>\n" +               //irrelevant/overridden
-            // "    <fileDir>" + EDStatic.fullCopyDirectory + tDatasetID + "/</fileDir>\n" +
+            // "    <fileDir>" + EDStatic.config.fullCopyDirectory + tDatasetID + "/</fileDir>\n" +
             "    <metadataFrom>last</metadataFrom>\n"
             + "    <standardizeWhat>"
             + tStandardizeWhat

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
@@ -629,9 +629,9 @@ public class GridDataAccessor implements AutoCloseable {
       throw t instanceof WaitThenTryAgainException
           ? t
           : new WaitThenTryAgainException(
-              EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+              EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                   + "\n("
-                  + EDStatic.errorFromDataSource
+                  + EDStatic.messages.errorFromDataSource
                   + tToString
                   + ")",
               t);
@@ -708,7 +708,7 @@ public class GridDataAccessor implements AutoCloseable {
               || !Math2.almostEqual(
                   9, pa.getDouble(0), avInDriverExpectedValues[av])) { // source values
             throw new WaitThenTryAgainException(
-                EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                     + "\n(Details: GridDataAccessor.increment: partialResults["
                     + av
                     + "]=\""
@@ -723,7 +723,7 @@ public class GridDataAccessor implements AutoCloseable {
           String tError = gda.axisValues[av].almostEqual(pa); // destination values
           if (tError.length() > 0)
             throw new WaitThenTryAgainException(
-                EDStatic.simpleBilingual(language, EDStatic.waitThenTryAgainAr)
+                EDStatic.simpleBilingual(language, EDStatic.messages.waitThenTryAgainAr)
                     + "\n(Details: GridDataAccessor.increment: partialResults["
                     + av
                     + "] was not as expected.\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
@@ -93,8 +93,8 @@ public class GridDataAccessor implements AutoCloseable {
    * This is the constructor. This constructor sets everything up, but doesn't get any grid data.
    *
    * @param tEDDGrid the data source
-   * @param tRequestUrl the part of the user's request, after EDStatic.baseUrl, before '?'. Here, it
-   *     is just used for history metadata.
+   * @param tRequestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
+   *     Here, it is just used for history metadata.
    * @param tUserDapQuery the original user DAP-style query after the '?', still percentEncoded, may
    *     be null.
    * @param tRowMajor Set this to true if you want to get the data in row major order. Set this to
@@ -151,7 +151,7 @@ public class GridDataAccessor implements AutoCloseable {
     EDD.addToHistory(globalAttributes, eddGrid.publicSourceUrl());
     EDD.addToHistory(
         globalAttributes,
-        EDStatic.baseUrl
+        EDStatic.config.baseUrl
             + tRequestUrl
             + (tUserDapQuery == null || tUserDapQuery.length() == 0 ? "" : "?" + tUserDapQuery));
 
@@ -313,7 +313,7 @@ public class GridDataAccessor implements AutoCloseable {
     Arrays.fill(avInDriver, true);
     long nBytesPerPartialRequest = nDataBytesPerRow; // long to safely avoid overflow
     int tPartialRequestMaxBytes =
-        EDStatic.partialRequestMaxBytes; // local copy so constant for this calculation
+        EDStatic.config.partialRequestMaxBytes; // local copy so constant for this calculation
     if (rowMajor) {
       // work from right
       int av = axisAttributes.length - 1;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/OutputStreamViaAwsS3.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/OutputStreamViaAwsS3.java
@@ -66,9 +66,9 @@ public class OutputStreamViaAwsS3 extends BufferedOutputStream {
     String contentType = (String) fileTypeInfo[0];
     // copy to AWS bucket
     // tell Aws about other file attributes when file accessed as from web site
-    String fullAwsUrl = EDStatic.awsS3OutputBucketUrl + parent.fileName + parent.extension;
+    String fullAwsUrl = EDStatic.config.awsS3OutputBucketUrl + parent.fileName + parent.extension;
     SSR.uploadFileToAwsS3(
-        EDStatic.awsS3OutputTransferManager, fullLocalFileName, fullAwsUrl, contentType);
+        EDStatic.config.awsS3OutputTransferManager, fullLocalFileName, fullAwsUrl, contentType);
 
     // EDStatic.awsS3OutputClient.putObject(objectRequest, localPath);
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterGeoJson.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterGeoJson.java
@@ -76,8 +76,9 @@ public class TableWriterGeoJson extends TableWriter {
       throw new SimpleException(
           EDStatic.bilingual(
               language,
-              EDStatic.queryErrorAr[0] + EDStatic.errorJsonpFunctionNameAr[0],
-              EDStatic.queryErrorAr[language] + EDStatic.errorJsonpFunctionNameAr[language]));
+              EDStatic.messages.queryErrorAr[0] + EDStatic.messages.errorJsonpFunctionNameAr[0],
+              EDStatic.messages.queryErrorAr[language]
+                  + EDStatic.messages.errorJsonpFunctionNameAr[language]));
   }
 
   /**
@@ -111,9 +112,9 @@ public class TableWriterGeoJson extends TableWriter {
         throw new SimpleException(
             EDStatic.bilingual(
                 language,
-                EDStatic.queryErrorAr[0]
+                EDStatic.messages.queryErrorAr[0]
                     + "Requests for GeoJSON data must include the longitude and latitude variables.",
-                EDStatic.queryErrorAr[language]
+                EDStatic.messages.queryErrorAr[language]
                     + "Requests for GeoJSON data must include the longitude and latitude variables."));
       // it is unclear to me if specification supports altitude in coordinates info...
       isTimeStamp = new boolean[nColumns];

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
@@ -127,7 +127,7 @@ public class TableWriterHtmlTable extends TableWriter {
     writeUnits = tWriteUnits;
     showFirstNRows = tShowFirstNRows >= 0 ? tShowFirstNRows : Integer.MAX_VALUE;
     tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
-    externalLinkHtml = EDStatic.externalLinkHtml(language, tErddapUrl);
+    externalLinkHtml = EDStatic.messages.externalLinkHtml(language, tErddapUrl);
     questionMarkImageUrl = tQuestionMarkImageUrl;
   }
 
@@ -489,7 +489,7 @@ public class TableWriterHtmlTable extends TableWriter {
     if (isMBLimited && !allDataDisplayed)
       writer.write(
           "<span class=\"warningColor\">"
-              + EDStatic.htmlTableMaxMessageAr[language]
+              + EDStatic.messages.htmlTableMaxMessageAr[language]
               + "</span>"
               + (xhtmlMode ? "<br />" : "<br>")
               + "\n");
@@ -566,7 +566,7 @@ public class TableWriterHtmlTable extends TableWriter {
             encode,
             writeUnits,
             tShowFirstNRows,
-            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.questionMarkImageFile);
+            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile);
     tw.writeAllAndFinish(table);
     tw.close();
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
@@ -350,7 +350,7 @@ public class TableWriterHtmlTable extends TableWriter {
     }
 
     // write the data
-    boolean baseHttpsUrlIsSomething = String2.isSomething(EDStatic.baseHttpsUrl);
+    boolean baseHttpsUrlIsSomething = String2.isSomething(EDStatic.config.baseHttpsUrl);
     for (int row = 0; row < showNRows; row++) {
       writer.write("<tr>\n");
       somethingWritten = false;
@@ -378,8 +378,9 @@ public class TableWriterHtmlTable extends TableWriter {
                   // display as a link
                   url = fileAccessBaseUrl[col] + s + fileAccessSuffix[col];
                   boolean isLocal =
-                      url.startsWith(EDStatic.baseUrl)
-                          || (baseHttpsUrlIsSomething && url.startsWith(EDStatic.baseHttpsUrl));
+                      url.startsWith(EDStatic.config.baseUrl)
+                          || (baseHttpsUrlIsSomething
+                              && url.startsWith(EDStatic.config.baseHttpsUrl));
                   s =
                       "<a href=\""
                           + XML.encodeAsHTMLAttribute(url)
@@ -392,8 +393,9 @@ public class TableWriterHtmlTable extends TableWriter {
                   // display as a link
                   url = s;
                   boolean isLocal =
-                      url.startsWith(EDStatic.baseUrl)
-                          || (baseHttpsUrlIsSomething && url.startsWith(EDStatic.baseHttpsUrl));
+                      url.startsWith(EDStatic.config.baseUrl)
+                          || (baseHttpsUrlIsSomething
+                              && url.startsWith(EDStatic.config.baseHttpsUrl));
                   s =
                       "<a href=\""
                           + XML.encodeAsHTMLAttribute(url)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterJson.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterJson.java
@@ -67,7 +67,10 @@ public class TableWriterJson extends TableWriter {
     jsonp = tJsonp;
     if (jsonp != null && !String2.isJsonpNameSafe(jsonp))
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.errorJsonpFunctionNameAr));
+          EDStatic.bilingual(
+              language,
+              EDStatic.messages.queryErrorAr,
+              EDStatic.messages.errorJsonpFunctionNameAr));
     writeUnits = tWriteUnits;
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterJsonl.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterJsonl.java
@@ -72,7 +72,10 @@ public class TableWriterJsonl extends TableWriter {
     jsonp = tJsonp;
     if (jsonp != null && !String2.isJsonpNameSafe(jsonp))
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.errorJsonpFunctionNameAr));
+          EDStatic.bilingual(
+              language,
+              EDStatic.messages.queryErrorAr,
+              EDStatic.messages.errorJsonpFunctionNameAr));
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderBy.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderBy.java
@@ -54,7 +54,7 @@ public class TableWriterOrderBy extends TableWriterAll {
     super(tLanguage, tEdd, tNewHistory, tDir, tFileNameNoExt);
     otherTableWriter = tOtherTableWriter;
     String err =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
             + "No column names were specified for 'orderBy'.";
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0) throw new SimpleException(err);
     orderBy = String2.split(tOrderByCsv, ',');
@@ -62,7 +62,7 @@ public class TableWriterOrderBy extends TableWriterAll {
     for (String s : orderBy)
       if (s.indexOf('/') >= 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "'orderBy' doesn't support '/' ("
                 + s
                 + ").");
@@ -115,7 +115,7 @@ public class TableWriterOrderBy extends TableWriterAll {
       ascending[ob] = true;
       if (keys[ob] < 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "'orderBy' column="
                 + orderBy[ob]
                 + " isn't in the results table.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByClosest.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByClosest.java
@@ -60,7 +60,10 @@ public class TableWriterOrderByClosest extends TableWriterAll {
     otherTableWriter = tOtherTableWriter;
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByClosestAr)
               + (language == 0 ? " " : "\n")
               + "no CSV.");
     String csv[] = String2.split(tOrderByCsv, ',');
@@ -80,7 +83,10 @@ public class TableWriterOrderByClosest extends TableWriterAll {
 
     if (csv.length < 2)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByClosestAr)
               + (language == 0 ? " " : "\n")
               + "CSV.length<2.");
 
@@ -92,7 +98,10 @@ public class TableWriterOrderByClosest extends TableWriterAll {
     numberTimeUnits = Calendar2.parseNumberTimeUnits(csv[csv.length - 1]); // throws Exception
     if (numberTimeUnits[0] <= 0)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByClosestAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByClosestAr)
               + (language == 0 ? " " : "\n")
               + "number="
               + numberTimeUnits[0]

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByDescending.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByDescending.java
@@ -55,7 +55,7 @@ public class TableWriterOrderByDescending extends TableWriterAll {
     super(tLanguage, tEdd, tNewHistory, tDir, tFileNameNoExt);
     otherTableWriter = tOtherTableWriter;
     String err =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
             + "No column names were specified for 'orderByDescending'.";
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0) throw new SimpleException(err);
     orderBy = String2.split(tOrderByCsv, ',');
@@ -63,7 +63,7 @@ public class TableWriterOrderByDescending extends TableWriterAll {
     for (String s : orderBy)
       if (s.indexOf('/') >= 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "'orderByDescending' doesn't support '/' ("
                 + s
                 + ").");
@@ -115,7 +115,7 @@ public class TableWriterOrderByDescending extends TableWriterAll {
       keys[ob] = table.findColumnNumber(orderBy[ob]);
       if (keys[ob] < 0)
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "'orderByDescending' column="
                 + orderBy[ob]
                 + " isn't in the results table.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByLimit.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByLimit.java
@@ -58,13 +58,19 @@ public class TableWriterOrderByLimit extends TableWriterAll {
     otherTableWriter = tOtherTableWriter;
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByLimitAr)
               + (language == 0 ? " " : "\n")
               + "No CSV.");
     String csv[] = String2.split(tOrderByCsv, ',');
     if (csv.length == 0)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByLimitAr)
               + (language == 0 ? " " : "\n")
               + "CSV.length=0.");
 
@@ -76,7 +82,10 @@ public class TableWriterOrderByLimit extends TableWriterAll {
     limitN = String2.parseInt(csv[csv.length - 1]);
     if (limitN <= 0 || limitN == Integer.MAX_VALUE)
       throw new SimpleException(
-          EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByLimitAr)
+          EDStatic.bilingual(
+                  language,
+                  EDStatic.messages.queryErrorAr,
+                  EDStatic.messages.queryErrorOrderByLimitAr)
               + (language == 0 ? " " : "\n")
               + "limit="
               + csv[csv.length - 1]

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMax.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMax.java
@@ -53,7 +53,7 @@ public class TableWriterOrderByMax extends TableWriterAll {
     super(tLanguage, tEdd, tNewHistory, tDir, tFileNameNoExt);
     otherTableWriter = tOtherTableWriter;
     String err =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
             + "No column names were specified for 'orderByMax'.";
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0) throw new SimpleException(err);
     orderBy = String2.split(tOrderByCsv, ',');

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMean.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMean.java
@@ -83,7 +83,7 @@ public class TableWriterOrderByMean extends TableWriterAll {
     otherTableWriter = tOtherTableWriter;
     final String[] cols =
         Table.parseOrderByColumnNamesCsvString(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "orderByMean: ",
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + "orderByMean: ",
             tOrderByCsv);
     orderBy = new String[cols.length];
 
@@ -246,7 +246,10 @@ public class TableWriterOrderByMean extends TableWriterAll {
       int col = table.findColumnNumber(orderBy[k]);
       if (col < 0)
         throw new SimpleException(
-            EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByMeanAr)
+            EDStatic.bilingual(
+                    language,
+                    EDStatic.messages.queryErrorAr,
+                    EDStatic.messages.queryErrorOrderByMeanAr)
                 + (language == 0 ? " " : "\n")
                 + "unknown orderBy column="
                 + orderBy[k]
@@ -262,7 +265,9 @@ public class TableWriterOrderByMean extends TableWriterAll {
               if (!(column.isIntegerType() || column.isFloatingPointType())) {
                 throw new SimpleException(
                     EDStatic.bilingual(
-                            language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderByMeanAr)
+                            language,
+                            EDStatic.messages.queryErrorAr,
+                            EDStatic.messages.queryErrorOrderByMeanAr)
                         + (language == 0 ? " " : "\n")
                         + "Cannot group numerically for column="
                         + columnName

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMin.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMin.java
@@ -53,7 +53,7 @@ public class TableWriterOrderByMin extends TableWriterAll {
     super(tLanguage, tEdd, tNewHistory, tDir, tFileNameNoExt);
     otherTableWriter = tOtherTableWriter;
     String err =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
             + "No column names were specified for 'orderByMin'.";
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0) throw new SimpleException(err);
     orderBy = String2.split(tOrderByCsv, ',');

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMinMax.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderByMinMax.java
@@ -54,7 +54,7 @@ public class TableWriterOrderByMinMax extends TableWriterAll {
     super(tLanguage, tEdd, tNewHistory, tDir, tFileNameNoExt);
     otherTableWriter = tOtherTableWriter;
     String err =
-        EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+        EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
             + "No column names were specified for 'orderByMinMax'.";
     if (tOrderByCsv == null || tOrderByCsv.trim().length() == 0) throw new SimpleException(err);
     orderBy = String2.split(tOrderByCsv, ',');

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderBySum.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterOrderBySum.java
@@ -76,7 +76,7 @@ public class TableWriterOrderBySum extends TableWriterAll {
     otherTableWriter = tOtherTableWriter;
     final String[] cols =
         Table.parseOrderByColumnNamesCsvString(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr) + "orderBySum: ",
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + "orderBySum: ",
             tOrderByCsv);
     orderBy = new String[cols.length];
 
@@ -229,7 +229,10 @@ public class TableWriterOrderBySum extends TableWriterAll {
       int col = table.findColumnNumber(orderBy[k]);
       if (col < 0)
         throw new SimpleException(
-            EDStatic.bilingual(language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderBySumAr)
+            EDStatic.bilingual(
+                    language,
+                    EDStatic.messages.queryErrorAr,
+                    EDStatic.messages.queryErrorOrderBySumAr)
                 + (language == 0 ? " " : "\n")
                 + "Unknown orderBy column="
                 + orderBy[k]
@@ -245,7 +248,9 @@ public class TableWriterOrderBySum extends TableWriterAll {
               if (!(column.isIntegerType() || column.isFloatingPointType())) {
                 throw new SimpleException(
                     EDStatic.bilingual(
-                            language, EDStatic.queryErrorAr, EDStatic.queryErrorOrderBySumAr)
+                            language,
+                            EDStatic.messages.queryErrorAr,
+                            EDStatic.messages.queryErrorOrderBySumAr)
                         + (language == 0 ? " " : "\n")
                         + "Cannot group numerically for column="
                         + columnName

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterUnits.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterUnits.java
@@ -68,7 +68,7 @@ public class TableWriterUnits extends TableWriter {
 
     if (toUnits == null || !(toUnits.equals("UDUNITS") || toUnits.equals("UCUM")))
       throw new SimpleException(
-          EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+          EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "toUnits="
               + fromUnits
               + " must be UDUNITS or UCUM.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterWav.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterWav.java
@@ -94,7 +94,7 @@ public class TableWriterWav extends TableWriter {
       boolean java8 = System.getProperty("java.version").startsWith("1.8.");
       if (java8 && (tClass.equals("float") || tClass.equals("double")))
         throw new SimpleException(
-            EDStatic.simpleBilingual(language, EDStatic.queryErrorAr)
+            EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
                 + "Until Java 9, float and double values can't be written to .wav files.");
       for (int col = 0; col < nColumns; col++) {
         Test.ensureEqual(

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridAggregateExistingDimensionHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridAggregateExistingDimensionHandler.java
@@ -22,7 +22,7 @@ public class EDDGridAggregateExistingDimensionHandler extends BaseGridHandler {
 
   private EDDGrid firstChild = null;
   private final StringArray tLocalSourceUrls = new StringArray();
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tMatchAxisNDigits = DEFAULT_MATCH_AXIS_N_DIGITS;
 
   private String tSUServerType = null;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridCopyHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridCopyHandler.java
@@ -24,7 +24,7 @@ public class EDDGridCopyHandler extends BaseGridHandler {
   private int tMatchAxisNDigits = DEFAULT_MATCH_AXIS_N_DIGITS;
   private boolean checkSourceData = EDDGridCopy.defaultCheckSourceData;
   private boolean tFileTableInMemory = false;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private String tOnlySince = null;
 
   @Override

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromEDDTableHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromEDDTableHandler.java
@@ -19,7 +19,7 @@ public class EDDGridFromEDDTableHandler extends BaseGridHandler {
     this.context = context;
   }
 
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tUpdateEveryNMillis = 0;
   private EDDTable tEDDTable = null;
   private int tGapThreshold = 1000;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromErddapHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromErddapHandler.java
@@ -13,8 +13,8 @@ public class EDDGridFromErddapHandler extends BaseGridHandler {
   }
 
   private int tUpdateEveryNMillis = 0;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
-  private boolean tSubscribeToRemoteErddapDataset = EDStatic.subscribeToRemoteErddapDataset;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
+  private boolean tSubscribeToRemoteErddapDataset = EDStatic.config.subscribeToRemoteErddapDataset;
   private boolean tRedirect = true;
   private String tLocalSourceUrl = null;
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromEtopoHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromEtopoHandler.java
@@ -17,7 +17,7 @@ public class EDDGridFromEtopoHandler extends StateWithParent {
   }
 
   private boolean tAccessibleViaWMS = true;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tnThreads = -1;
   private boolean tDimensionValuesInMemory = true;
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromFilesHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridFromFilesHandler.java
@@ -26,7 +26,7 @@ public class EDDGridFromFilesHandler extends BaseGridHandler {
   private String tFileNameRegex = ".*";
   private boolean tRecursive = false;
   private String tPathRegex = ".*";
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private String tMetadataFrom = MF_LAST;
   private int tMatchAxisNDigits = DEFAULT_MATCH_AXIS_N_DIGITS;
   private String tCacheFromUrl = null;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridLon0360Handler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridLon0360Handler.java
@@ -18,7 +18,7 @@ public class EDDGridLon0360Handler extends BaseGridHandler {
   }
 
   private EDDGrid tChildDataset = null;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tUpdateEveryNMillis = Integer.MAX_VALUE;
 
   @Override

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridLonPM180Handler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridLonPM180Handler.java
@@ -18,7 +18,7 @@ public class EDDGridLonPM180Handler extends BaseGridHandler {
   }
 
   private EDDGrid tChildDataset = null;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tUpdateEveryNMillis = Integer.MAX_VALUE;
 
   @Override

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridSideBySideHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDGridSideBySideHandler.java
@@ -21,7 +21,7 @@ public class EDDGridSideBySideHandler extends BaseGridHandler {
   }
 
   private final ArrayList<EDDGrid> tChildDatasets = new ArrayList<>();
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tMatchAxisNDigits = DEFAULT_MATCH_AXIS_N_DIGITS;
 
   @Override

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableCopyHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableCopyHandler.java
@@ -26,7 +26,7 @@ public class EDDTableCopyHandler extends BaseTableHandler {
   private boolean checkSourceData = defaultCheckSourceData;
   private boolean tSourceNeedsExpandedFP_EQ = true;
   private boolean tFileTableInMemory = false;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private int tStandardizeWhat = Integer.MAX_VALUE;
   private int tnThreads = -1;
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromEDDGridHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromEDDGridHandler.java
@@ -18,7 +18,7 @@ public class EDDTableFromEDDGridHandler extends BaseTableHandler {
   }
 
   private EDDGrid tChildDataset = null;
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
 
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromErddapHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromErddapHandler.java
@@ -13,8 +13,8 @@ public class EDDTableFromErddapHandler extends BaseTableHandler {
     super(saxHandler, datasetID, completeState);
   }
 
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
-  private boolean tSubscribeToRemoteErddapDataset = EDStatic.subscribeToRemoteErddapDataset;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
+  private boolean tSubscribeToRemoteErddapDataset = EDStatic.config.subscribeToRemoteErddapDataset;
   private boolean tRedirect = true;
   private String tLocalSourceUrl = null;
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromFilesHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/EDDTableFromFilesHandler.java
@@ -28,7 +28,7 @@ public class EDDTableFromFilesHandler extends BaseTableHandler {
   private String tFileNameRegex = ".*";
   private boolean tRecursive = false;
   private String tPathRegex = ".*";
-  private boolean tAccessibleViaFiles = EDStatic.defaultAccessibleViaFiles;
+  private boolean tAccessibleViaFiles = EDStatic.config.defaultAccessibleViaFiles;
   private String tMetadataFrom = MF_LAST;
   private String tPreExtractRegex = "", tPostExtractRegex = "", tExtractRegex = "";
   private String tColumnNameForExtract = "";
@@ -539,7 +539,9 @@ public class EDDTableFromFilesHandler extends BaseTableHandler {
         String qrName = quickRestartFullFileName(datasetID);
         long tCreationTime = System.currentTimeMillis();
 
-        if (EDStatic.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
+        if (EDStatic.config.quickRestart
+            && EDStatic.initialLoadDatasets()
+            && File2.isFile(qrName)) {
           tCreationTime = File2.getLastModified(qrName);
         } else {
           EDDTableFromHyraxFiles.makeDownloadFileTasks(
@@ -604,7 +606,9 @@ public class EDDTableFromFilesHandler extends BaseTableHandler {
         String qrName = quickRestartFullFileName(datasetID);
         long tCreationTime = System.currentTimeMillis(); // used below
 
-        if (EDStatic.quickRestart && EDStatic.initialLoadDatasets() && File2.isFile(qrName)) {
+        if (EDStatic.config.quickRestart
+            && EDStatic.initialLoadDatasets()
+            && File2.isFile(qrName)) {
           tCreationTime = File2.getLastModified(qrName);
         } else {
           EDDTableFromThreddsFiles.makeDownloadFileTasks(
@@ -667,10 +671,10 @@ public class EDDTableFromFilesHandler extends BaseTableHandler {
         dataset.creationTimeMillis = tCreationTime;
       }
       case "EDDTableFromWFSFiles" -> {
-        String fileDir = EDStatic.fullCopyDirectory + datasetID + "/";
+        String fileDir = EDStatic.config.fullCopyDirectory + datasetID + "/";
         String fileName = "data.tsv";
         long tCreationTime = System.currentTimeMillis();
-        if (EDStatic.quickRestart
+        if (EDStatic.config.quickRestart
             && EDStatic.initialLoadDatasets()
             && File2.isFile(fileDir + fileName)) {
           tCreationTime = File2.getLastModified(fileDir + fileName);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/HandlerFactory.java
@@ -35,7 +35,7 @@ public class HandlerFactory {
     EDStatic.cldStartMillis = timeToLoadThisDataset;
     EDStatic.cldDatasetID = datasetID;
 
-    if (EDStatic.useEddReflection) {
+    if (EDStatic.config.useEddReflection) {
       // use reflection to discover handlers
       EDD.EDDClassInfo eddClassInfo = EDD.EDD_CLASS_INFO_MAP.get(datasetType);
       if (eddClassInfo == null || !eddClassInfo.hasSaxHandlerClass()) {
@@ -224,9 +224,10 @@ public class HandlerFactory {
     // Test third: look at flag/age  or active=false
     if (!skip) {
       // always check both flag locations
-      boolean isFlagged = File2.delete(EDStatic.fullResetFlagDirectory + datasetID);
-      boolean isBadFilesFlagged = File2.delete(EDStatic.fullBadFilesFlagDirectory + datasetID);
-      boolean isHardFlagged = File2.delete(EDStatic.fullHardFlagDirectory + datasetID);
+      boolean isFlagged = File2.delete(EDStatic.config.fullResetFlagDirectory + datasetID);
+      boolean isBadFilesFlagged =
+          File2.delete(EDStatic.config.fullBadFilesFlagDirectory + datasetID);
+      boolean isHardFlagged = File2.delete(EDStatic.config.fullHardFlagDirectory + datasetID);
       if (isFlagged) {
         String2.log(
             "*** reloading datasetID=" + datasetID + " because it was in the flag directory.");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
@@ -77,7 +77,7 @@ public class TopLevelHandler extends State {
                   + "\" has invalid characters.\n\n");
 
           // is password invalid?
-        } else if (EDStatic.authentication.equals("custom")
+        } else if (EDStatic.config.authentication.equals("custom")
             && // others in future
             !String2.isHexString(tPassword)) {
           warningsFromLoadDatasets.append(
@@ -95,7 +95,8 @@ public class TopLevelHandler extends State {
           // add user info to tUserHashMap
         } else {
           Arrays.sort(tRoles);
-          if ("email".equals(EDStatic.authentication) || "google".equals(EDStatic.authentication)) {
+          if ("email".equals(EDStatic.config.authentication)
+              || "google".equals(EDStatic.config.authentication)) {
             tUsername = tUsername.toLowerCase();
           }
           if (reallyVerbose) {
@@ -159,7 +160,7 @@ public class TopLevelHandler extends State {
       case "awsS3OutputBucketUrl" -> {
         String ts = data.toString();
         if (!String2.isSomething(ts)) ts = null;
-        EDStatic.awsS3OutputBucketUrl = ts;
+        EDStatic.config.awsS3OutputBucketUrl = ts;
 
         if (reallyVerbose) {
           String2.log("awsS3OutputBucketUrl=" + ts);
@@ -167,12 +168,12 @@ public class TopLevelHandler extends State {
       }
       case "cacheMinutes" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.cacheMillis =
-            (tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_cacheMinutes : tnt)
+        EDStatic.config.cacheMillis =
+            (tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.config.DEFAULT_cacheMinutes : tnt)
                 * Calendar2.MILLIS_PER_MINUTE;
 
         if (reallyVerbose) {
-          String2.log("cacheMinutes=" + EDStatic.cacheMillis / Calendar2.MILLIS_PER_MINUTE);
+          String2.log("cacheMinutes=" + EDStatic.config.cacheMillis / Calendar2.MILLIS_PER_MINUTE);
         }
       }
       case "commonStandardNames" -> {
@@ -226,18 +227,18 @@ public class TopLevelHandler extends State {
       case "drawLandMask" -> {
         String ts = data.toString();
         int tnt = SgtMap.drawLandMask_OPTIONS.indexOf(ts);
-        EDStatic.drawLandMask =
-            tnt < 1 ? EDStatic.DEFAULT_drawLandMask : SgtMap.drawLandMask_OPTIONS.get(tnt);
+        EDStatic.config.drawLandMask =
+            tnt < 1 ? EDStatic.config.DEFAULT_drawLandMask : SgtMap.drawLandMask_OPTIONS.get(tnt);
 
         if (reallyVerbose) {
-          String2.log("drawLandMask=" + EDStatic.drawLandMask);
+          String2.log("drawLandMask=" + EDStatic.config.drawLandMask);
         }
       }
       case "emailDiagnosticsToErdData" -> {
         String ts = data.toString();
         boolean ted = !String2.isSomething(ts) || String2.parseBoolean(ts); // the default
 
-        EDStatic.emailDiagnosticsToErdData = ted;
+        EDStatic.config.emailDiagnosticsToErdData = ted;
 
         if (reallyVerbose) {
           String2.log("emailDiagnosticsToErdData=" + ted);
@@ -248,8 +249,8 @@ public class TopLevelHandler extends State {
         int tnt =
             String2.isSomething(ts)
                 ? String2.parseInt(ts)
-                : EDStatic.DEFAULT_graphBackgroundColorInt;
-        EDStatic.graphBackgroundColor = new Color(tnt, true); // hasAlpha
+                : EDStatic.config.DEFAULT_graphBackgroundColorInt;
+        EDStatic.config.graphBackgroundColor = new Color(tnt, true); // hasAlpha
 
         if (reallyVerbose) {
           String2.log("graphBackgroundColor=" + String2.to0xHexString(tnt, 8));
@@ -288,26 +289,30 @@ public class TopLevelHandler extends State {
       }
       case "loadDatasetsMinMinutes" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.loadDatasetsMinMillis =
-            (tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_loadDatasetsMinMinutes : tnt)
+        EDStatic.config.loadDatasetsMinMillis =
+            (tnt < 1 || tnt == Integer.MAX_VALUE
+                    ? EDStatic.config.DEFAULT_loadDatasetsMinMinutes
+                    : tnt)
                 * Calendar2.MILLIS_PER_MINUTE;
 
         if (reallyVerbose) {
           String2.log(
               "loadDatasetsMinMinutes="
-                  + EDStatic.loadDatasetsMinMillis / Calendar2.MILLIS_PER_MINUTE);
+                  + EDStatic.config.loadDatasetsMinMillis / Calendar2.MILLIS_PER_MINUTE);
         }
       }
       case "loadDatasetsMaxMinutes" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.loadDatasetsMaxMillis =
-            (tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_loadDatasetsMaxMinutes : tnt)
+        EDStatic.config.loadDatasetsMaxMillis =
+            (tnt < 1 || tnt == Integer.MAX_VALUE
+                    ? EDStatic.config.DEFAULT_loadDatasetsMaxMinutes
+                    : tnt)
                 * Calendar2.MILLIS_PER_MINUTE;
 
         if (reallyVerbose) {
           String2.log(
               "loadDatasetsMaxMinutes="
-                  + EDStatic.loadDatasetsMaxMillis / Calendar2.MILLIS_PER_MINUTE);
+                  + EDStatic.config.loadDatasetsMaxMillis / Calendar2.MILLIS_PER_MINUTE);
         }
       }
       case "logLevel" -> EDStatic.setLogLevel(data.toString());
@@ -352,35 +357,37 @@ public class TopLevelHandler extends State {
       }
       case "partialRequestMaxBytes" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.partialRequestMaxBytes =
+        EDStatic.config.partialRequestMaxBytes =
             tnt < 1000000 || tnt == Integer.MAX_VALUE
-                ? EDStatic.DEFAULT_partialRequestMaxBytes
+                ? EDStatic.config.DEFAULT_partialRequestMaxBytes
                 : tnt;
 
         if (reallyVerbose) {
-          String2.log("partialRequestMaxBytes=" + EDStatic.partialRequestMaxBytes);
+          String2.log("partialRequestMaxBytes=" + EDStatic.config.partialRequestMaxBytes);
         }
       }
       case "partialRequestMaxCells" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.partialRequestMaxCells =
-            tnt < 1000 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_partialRequestMaxCells : tnt;
+        EDStatic.config.partialRequestMaxCells =
+            tnt < 1000 || tnt == Integer.MAX_VALUE
+                ? EDStatic.config.DEFAULT_partialRequestMaxCells
+                : tnt;
 
         if (reallyVerbose) {
-          String2.log("partialRequestMaxCells=" + EDStatic.partialRequestMaxCells);
+          String2.log("partialRequestMaxCells=" + EDStatic.config.partialRequestMaxCells);
         }
       }
       case "requestBlacklist" -> EDStatic.setRequestBlacklist(data.toString());
       case "slowDownTroubleMillis" -> {
         int tms = String2.parseInt(data.toString());
-        EDStatic.slowDownTroubleMillis = tms < 0 || tms > 1000000 ? 1000 : tms;
+        EDStatic.config.slowDownTroubleMillis = tms < 0 || tms > 1000000 ? 1000 : tms;
 
         if (reallyVerbose) {
-          String2.log("slowDownTroubleMillis=" + EDStatic.slowDownTroubleMillis);
+          String2.log("slowDownTroubleMillis=" + EDStatic.config.slowDownTroubleMillis);
         }
       }
       case "subscriptionEmailBlacklist" -> {
-        if (EDStatic.subscriptionSystemActive) {
+        if (EDStatic.config.subscriptionSystemActive) {
           EDStatic.subscriptions.setEmailBlacklist(data.toString());
         }
       }
@@ -396,7 +403,9 @@ public class TopLevelHandler extends State {
       case "standardContact" -> {
         String ts = data.toString();
         ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardContactAr[0];
-        ts = String2.replaceAll(ts, "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.adminEmail));
+        ts =
+            String2.replaceAll(
+                ts, "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.config.adminEmail));
         EDStatic.messages.standardContactAr[0] = ts; // swap into place
 
         if (reallyVerbose) {
@@ -514,31 +523,31 @@ public class TopLevelHandler extends State {
       }
       case "unusualActivity" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.unusualActivity =
-            tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_unusualActivity : tnt;
+        EDStatic.config.unusualActivity =
+            tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.config.DEFAULT_unusualActivity : tnt;
 
         if (reallyVerbose) {
-          String2.log("unusualActivity=" + EDStatic.unusualActivity);
+          String2.log("unusualActivity=" + EDStatic.config.unusualActivity);
         }
       }
       case "updateMaxEvents" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.updateMaxEvents =
-            tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.DEFAULT_updateMaxEvents : tnt;
+        EDStatic.config.updateMaxEvents =
+            tnt < 1 || tnt == Integer.MAX_VALUE ? EDStatic.config.DEFAULT_updateMaxEvents : tnt;
 
         if (reallyVerbose) {
-          String2.log("updateMaxEvents=" + EDStatic.updateMaxEvents);
+          String2.log("updateMaxEvents=" + EDStatic.config.updateMaxEvents);
         }
       }
       case "unusualActivityFailPercent" -> {
         int tnt = String2.parseInt(data.toString());
-        EDStatic.unusualActivityFailPercent =
+        EDStatic.config.unusualActivityFailPercent =
             tnt < 0 || tnt > 100 || tnt == Integer.MAX_VALUE
-                ? EDStatic.DEFAULT_unusualActivityFailPercent
+                ? EDStatic.config.DEFAULT_unusualActivityFailPercent
                 : tnt;
 
         if (reallyVerbose) {
-          String2.log("unusualActivityFailPercent" + EDStatic.unusualActivityFailPercent);
+          String2.log("unusualActivityFailPercent" + EDStatic.config.unusualActivityFailPercent);
         }
       }
     }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/handlers/TopLevelHandler.java
@@ -177,13 +177,14 @@ public class TopLevelHandler extends State {
       }
       case "commonStandardNames" -> {
         String ts = data.toString();
-        EDStatic.commonStandardNames =
+        EDStatic.messages.commonStandardNames =
             String2.isSomething(ts)
                 ? String2.canonical(StringArray.arrayFromCSV(ts))
-                : EDStatic.DEFAULT_commonStandardNames;
+                : EDStatic.messages.DEFAULT_commonStandardNames;
 
         if (reallyVerbose) {
-          String2.log("commonStandardNames=" + String2.toCSSVString(EDStatic.commonStandardNames));
+          String2.log(
+              "commonStandardNames=" + String2.toCSSVString(EDStatic.messages.commonStandardNames));
         }
       }
       case "decompressedCacheMaxGB" -> {
@@ -333,17 +334,17 @@ public class TopLevelHandler extends State {
         String[] tPalettes =
             String2.isSomething(tContent)
                 ? String2.split(tContent, ',')
-                : EDStatic.DEFAULT_palettes;
+                : EDStatic.messages.DEFAULT_palettes;
         Set<String> newPaletteSet = String2.stringArrayToSet(tPalettes);
-        if (!newPaletteSet.containsAll(EDStatic.DEFAULT_palettes_set))
+        if (!newPaletteSet.containsAll(EDStatic.messages.DEFAULT_palettes_set))
           throw new RuntimeException(
               "The <palettes> tag MUST include all of the palettes listed in the <palettes> tag in messages.xml.");
         String[] tPalettes0 = new String[tPalettes.length + 1];
         tPalettes0[0] = "";
         System.arraycopy(tPalettes, 0, tPalettes0, 1, tPalettes.length);
         // then copy into place
-        EDStatic.palettes = tPalettes;
-        EDStatic.palettes0 = tPalettes0;
+        EDStatic.messages.palettes = tPalettes;
+        EDStatic.messages.palettes0 = tPalettes0;
 
         if (reallyVerbose) {
           String2.log("palettes=" + String2.toCSSVString(tPalettes));
@@ -385,7 +386,8 @@ public class TopLevelHandler extends State {
       }
       case "standardLicense" -> {
         String ts = data.toString();
-        EDStatic.standardLicense = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardLicense;
+        EDStatic.messages.standardLicense =
+            String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardLicense;
 
         if (reallyVerbose) {
           String2.log("standardLicense was set.");
@@ -393,9 +395,9 @@ public class TopLevelHandler extends State {
       }
       case "standardContact" -> {
         String ts = data.toString();
-        ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardContactAr[0];
+        ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardContactAr[0];
         ts = String2.replaceAll(ts, "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.adminEmail));
-        EDStatic.standardContactAr[0] = ts; // swap into place
+        EDStatic.messages.standardContactAr[0] = ts; // swap into place
 
         if (reallyVerbose) {
           String2.log("standardContact was set.");
@@ -403,8 +405,8 @@ public class TopLevelHandler extends State {
       }
       case "standardDataLicenses" -> {
         String ts = data.toString();
-        EDStatic.standardDataLicensesAr[0] =
-            String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardDataLicensesAr[0];
+        EDStatic.messages.standardDataLicensesAr[0] =
+            String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardDataLicensesAr[0];
 
         if (reallyVerbose) {
           String2.log("standardDataLicenses was set.");
@@ -412,8 +414,10 @@ public class TopLevelHandler extends State {
       }
       case "standardDisclaimerOfEndorsement" -> {
         String ts = data.toString();
-        EDStatic.standardDisclaimerOfEndorsementAr[0] =
-            String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardDisclaimerOfEndorsementAr[0];
+        EDStatic.messages.standardDisclaimerOfEndorsementAr[0] =
+            String2.isSomething(ts)
+                ? ts
+                : EDStatic.messages.DEFAULT_standardDisclaimerOfEndorsementAr[0];
 
         if (reallyVerbose) {
           String2.log("standardDisclaimerOfEndorsement was set.");
@@ -421,8 +425,10 @@ public class TopLevelHandler extends State {
       }
       case "standardDisclaimerOfExternalLinks" -> {
         String ts = data.toString();
-        EDStatic.standardDisclaimerOfExternalLinksAr[0] =
-            String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardDisclaimerOfExternalLinksAr[0];
+        EDStatic.messages.standardDisclaimerOfExternalLinksAr[0] =
+            String2.isSomething(ts)
+                ? ts
+                : EDStatic.messages.DEFAULT_standardDisclaimerOfExternalLinksAr[0];
 
         if (reallyVerbose) {
           String2.log("standardDisclaimerOfExternalLinks was set.");
@@ -430,8 +436,8 @@ public class TopLevelHandler extends State {
       }
       case "standardGeneralDisclaimer" -> {
         String ts = data.toString();
-        EDStatic.standardGeneralDisclaimerAr[0] =
-            String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardGeneralDisclaimerAr[0];
+        EDStatic.messages.standardGeneralDisclaimerAr[0] =
+            String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardGeneralDisclaimerAr[0];
 
         if (reallyVerbose) {
           String2.log("standardGeneralDisclaimer was set.");
@@ -439,8 +445,8 @@ public class TopLevelHandler extends State {
       }
       case "standardPrivacyPolicy" -> {
         String ts = data.toString();
-        EDStatic.standardPrivacyPolicyAr[0] =
-            String2.isSomething(ts) ? ts : EDStatic.DEFAULT_standardPrivacyPolicyAr[0];
+        EDStatic.messages.standardPrivacyPolicyAr[0] =
+            String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_standardPrivacyPolicyAr[0];
 
         if (reallyVerbose) {
           String2.log("standardPrivacyPolicy was set.");
@@ -448,14 +454,14 @@ public class TopLevelHandler extends State {
       }
       case "startHeadHtml5" -> {
         String ts = data.toString();
-        ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_startHeadHtml;
+        ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_startHeadHtml;
         if (!ts.startsWith("<!DOCTYPE html>")) {
           String2.log(
               String2.ERROR
                   + " in datasets.xml: <startHeadHtml> must start with \"<!DOCTYPE html>\". Using default <startHeadHtml> instead.");
-          ts = EDStatic.DEFAULT_startHeadHtml;
+          ts = EDStatic.messages.DEFAULT_startHeadHtml;
         }
-        EDStatic.startHeadHtml = ts; // swap into place
+        EDStatic.messages.startHeadHtml = ts; // swap into place
 
         if (reallyVerbose) {
           String2.log("startHeadHtml5 was set.");
@@ -463,8 +469,8 @@ public class TopLevelHandler extends State {
       }
       case "startBodyHtml5" -> {
         String ts = data.toString();
-        ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_startBodyHtmlAr[0];
-        EDStatic.startBodyHtmlAr[0] = ts; // swap into place
+        ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_startBodyHtmlAr[0];
+        EDStatic.messages.startBodyHtmlAr[0] = ts; // swap into place
 
         if (reallyVerbose) {
           String2.log("startBodyHtml5 was set.");
@@ -472,8 +478,8 @@ public class TopLevelHandler extends State {
       }
       case "theShortDescriptionHtml" -> {
         String ts = data.toString();
-        ts = String2.isSomething(ts) ? ts : EDStatic.DEFAULT_theShortDescriptionHtmlAr[0];
-        EDStatic.theShortDescriptionHtmlAr[0] = ts; // swap into place
+        ts = String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_theShortDescriptionHtmlAr[0];
+        EDStatic.messages.theShortDescriptionHtmlAr[0] = ts; // swap into place
 
         if (reallyVerbose) {
           String2.log("theShortDescriptionHtml was set.");
@@ -481,9 +487,9 @@ public class TopLevelHandler extends State {
       }
       case "endBodyHtml5" -> {
         String ts = data.toString();
-        EDStatic.endBodyHtmlAr[0] =
+        EDStatic.messages.endBodyHtmlAr[0] =
             String2.replaceAll(
-                String2.isSomething(ts) ? ts : EDStatic.DEFAULT_endBodyHtmlAr[0],
+                String2.isSomething(ts) ? ts : EDStatic.messages.DEFAULT_endBodyHtmlAr[0],
                 "&erddapVersion;",
                 EDStatic.erddapVersion);
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/http/CorsResponseFilter.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/http/CorsResponseFilter.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 
-/** Add CORS headers to the response if EDStatic.enableCors is true. */
+/** Add CORS headers to the response if EDStatic.config.enableCors is true. */
 @WebFilter("/*")
 public class CorsResponseFilter implements Filter {
   public static final String DEFAULT_ALLOW_HEADERS =
@@ -24,7 +24,7 @@ public class CorsResponseFilter implements Filter {
   public void doFilter(
       ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
       throws IOException, ServletException {
-    if (EDStatic.enableCors) {
+    if (EDStatic.config.enableCors) {
       HttpServletRequest request = (HttpServletRequest) servletRequest;
       HttpServletResponse response = (HttpServletResponse) servletResponse;
       String requestOrigin = StringUtils.trim(request.getHeader("Origin"));
@@ -32,7 +32,7 @@ public class CorsResponseFilter implements Filter {
         requestOrigin = null;
       }
 
-      if (EDStatic.corsAllowOrigin == null || EDStatic.corsAllowOrigin.length == 0) {
+      if (EDStatic.config.corsAllowOrigin == null || EDStatic.config.corsAllowOrigin.length == 0) {
         // If corsAllowOrigin is not set, any origin is allowed
         if (String2.isSomething(requestOrigin)) {
           response.setHeader("Access-Control-Allow-Origin", requestOrigin);
@@ -43,7 +43,8 @@ public class CorsResponseFilter implements Filter {
         // If corsAllowedOrigin is set, make sure the request origin was provided and is in the
         // corsAllowedOrigin list
         if (String2.isSomething(requestOrigin)) {
-          if (Arrays.asList(EDStatic.corsAllowOrigin).contains(requestOrigin.toLowerCase())) {
+          if (Arrays.asList(EDStatic.config.corsAllowOrigin)
+              .contains(requestOrigin.toLowerCase())) {
             response.setHeader("Access-Control-Allow-Origin", requestOrigin);
           } else {
             response.setHeader(
@@ -55,7 +56,7 @@ public class CorsResponseFilter implements Filter {
       }
 
       response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-      response.setHeader("Access-Control-Allow-Headers", EDStatic.corsAllowHeaders);
+      response.setHeader("Access-Control-Allow-Headers", EDStatic.config.corsAllowHeaders);
 
       if (request.getMethod().equalsIgnoreCase("OPTIONS")) {
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/BoundaryCounter.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/BoundaryCounter.java
@@ -1,0 +1,24 @@
+package gov.noaa.pfel.erddap.util;
+
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+
+public class BoundaryCounter {
+  private Counter counter;
+
+  public BoundaryCounter(String name, String help) {
+    counter = Counter.builder().name(name).help(help).labelNames("status").build();
+  }
+
+  public void increment(Metrics.BoundaryRequest status) {
+    counter.labelValues(status.name()).inc();
+  }
+
+  public long get(Metrics.BoundaryRequest status) {
+    return counter.labelValues(status.name()).getLongValue();
+  }
+
+  public void register(PrometheusRegistry registry) {
+    registry.register(counter);
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
@@ -1,0 +1,717 @@
+package gov.noaa.pfel.erddap.util;
+
+import com.cohort.array.StringArray;
+import com.cohort.util.Calendar2;
+import com.cohort.util.File2;
+import com.cohort.util.Image2;
+import com.cohort.util.Math2;
+import com.cohort.util.ResourceBundle2;
+import com.cohort.util.String2;
+import com.cohort.util.Test;
+import com.cohort.util.XML;
+import gov.noaa.pfel.coastwatch.sgt.SgtMap;
+import gov.noaa.pfel.coastwatch.util.FileVisitorDNLS;
+import gov.noaa.pfel.coastwatch.util.SSR;
+import gov.noaa.pfel.erddap.http.CorsResponseFilter;
+import gov.noaa.pfel.erddap.util.Metrics.FeatureFlag;
+import java.awt.Color;
+import java.awt.Image;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+public class EDConfig {
+  /**
+   * These are options used to control behavior for testing. They should be their default values
+   * during normal operation. Better encapsulation of EDStatic initilization would mean we can get
+   * rid of these.
+   */
+  public boolean skipEmailThread = false;
+
+  public boolean forceSynchronousLoading = false;
+
+  /**
+   * This is almost always false. During development, Bob sets this to true. No one else needs to.
+   * If true, ERDDAP uses setup2.xml and datasets2.xml (and messages2.xml if it exists).
+   */
+  public boolean developmentMode = false;
+
+  // End debug config
+
+  /**
+   * contentDirectory is the local directory on this computer, e.g., [tomcat]/content/erddap/ It
+   * will have a slash at the end.
+   */
+  public String contentDirectory;
+
+  // fgdc and iso19115XmlDirectory are used for virtual URLs.
+  public static final String fgdcXmlDirectory = "metadata/fgdc/xml/"; // virtual
+  public static final String iso19115XmlDirectory = "metadata/iso19115/xml/"; // virtual
+  public static final String IMAGES_DIR = "images/";
+  private static final String PUBLIC_DIR = "public/";
+  public final String fullPaletteDirectory;
+  public final String fullPublicDirectory;
+  public final String imageDir; // local directory on this computer
+  public final String fullDatasetDirectory; // all the Directory's have slash at end
+  public final String fullFileVisitorDirectory;
+  public final String fullCacheDirectory;
+  public final String fullDecompressedDirectory;
+  public final String fullDecompressedGenerateDatasetsXmlDirectory;
+  public final String fullLogsDirectory;
+  public final String fullCopyDirectory;
+  public final String fullLuceneDirectory;
+  public final String fullResetFlagDirectory;
+  public final String fullBadFilesFlagDirectory;
+  public final String fullHardFlagDirectory;
+  public final String fullCptCacheDirectory;
+  public final String fullPlainFileNcCacheDirectory;
+  public final String fullSgtMapTopographyCacheDirectory;
+  public final String fullTestCacheDirectory;
+  public final String fullWmsCacheDirectory;
+
+  /**
+   * These values are loaded from the [contentDirectory]setup.xml file. See comments in the
+   * [contentDirectory]setup.xml file.
+   */
+  public final String baseUrl;
+
+  public final String baseHttpsUrl; // won't be null, may be "(not specified)"
+  public String bigParentDirectory;
+  public final String adminInstitution;
+  public final String adminInstitutionUrl;
+  public final String adminIndividualName;
+  public final String adminPosition;
+  public final String adminPhone;
+  public final String adminAddress;
+  public final String adminCity;
+  public final String adminStateOrProvince;
+  public final String adminPostalCode;
+  public final String adminCountry;
+  public final String adminEmail;
+  public final String accessConstraints;
+  public final String accessRequiresAuthorization;
+  public final String fees;
+  public final String keywords;
+  public final String units_standard;
+
+  public
+  String /* For the wcs examples, pick one of your grid datasets that has longitude and latitude axes.
+         The sample variable must be a variable in the sample grid dataset.
+         The bounding box values are minx,miny,maxx,maxy.
+         */ wcsSampleDatasetID = "jplMURSST41";
+  public String wcsSampleVariable = "analysed_sst";
+  public String wcsSampleBBox = "-179.98,-89.98,179.98,89.98";
+  public String wcsSampleAltitude = "0";
+  public String wcsSampleTime = "2002-06-01T09:00:00Z";
+
+  public String /* For the wms examples, pick one of your grid datasets that has longitude
+      and latitude axes.
+      The sample variable must be a variable in the sample grid dataset.
+      The bounding box values are minx,miny,maxx,maxy.
+      The default for wmsActive is "true".
+      */
+      wmsSampleDatasetID = "jplMURSST41";
+  public String wmsSampleVariable = "analysed_sst";
+  public String /* The bounding box values are minLongitude,minLatitude,maxLongitude,maxLatitude.
+         Longitude values within -180 to 180, or 0 to 360, are now okay. */
+      wmsSampleBBox110 = "-179.99,-89.99,180.0,89.99";
+  public String wmsSampleBBox130 = "-89.99,-179.99,89.99,180.0";
+  public String wmsSampleTime = "2002-06-01T09:00:00Z";
+  public String sosFeatureOfInterest;
+  public String sosUrnBase;
+  public String sosBaseGmlName;
+  public String sosStandardNamePrefix;
+  public String
+      authentication; // will be one of "", "custom", "email", "google", "orcid", "oauth2". If
+  public final String // baseHttpsUrl doesn't start with https:, this will be "".
+      datasetsRegex;
+  public final String emailEverythingToCsv;
+  public final String emailDailyReportToCsv;
+  public final String emailSubscriptionsFrom;
+  public final String flagKeyKey;
+  public final String fontFamily;
+  public final String googleClientID; // if authentication=google or oauth2, this will be something
+  public final String orcidClientID; // if authentication=orcid  or oauth2, this will be something
+  public final String
+      orcidClientSecret; // if authentication=orcid  or oauth2, this will be something
+  public final String googleEarthLogoFile;
+  public final String highResLogoImageFile;
+  public final String lowResLogoImageFile;
+  public final String passwordEncoding; // will be one of "MD5", "UEPMD5", "SHA256", "UEPSHA256"
+  public final String searchEngine;
+  public final String warName;
+
+  public String accessibleViaNC4; // "" if accessible, else message why not
+  public final int lowResLogoImageFileWidth;
+  public final int lowResLogoImageFileHeight;
+  public final int highResLogoImageFileWidth;
+  public final int highResLogoImageFileHeight;
+  public final int googleEarthLogoFileWidth;
+  public final int googleEarthLogoFileHeight;
+
+  public final String emailSmtpHost;
+  public final String emailUserName;
+  public final String emailFromAddress;
+  public final String emailPassword;
+  public final String emailProperties;
+  public int emailSmtpPort = 0; // <=0 means inactive
+  @FeatureFlag public boolean emailIsActive = false; // ie if actual emails will be sent
+
+  // things that were in setup.xml (discouraged) and are now in datasets.xml (v2.00+)
+  public static final int DEFAULT_cacheMinutes = 60;
+  public static final String DEFAULT_drawLandMask = "under";
+  public static final int DEFAULT_graphBackgroundColorInt = 0xffccccff;
+  public static final int DEFAULT_loadDatasetsMinMinutes = 15;
+  public static final int DEFAULT_loadDatasetsMaxMinutes = 60;
+  public static final String DEFAULT_logLevel = "info"; // warning|info|all
+  public static final int DEFAULT_partialRequestMaxBytes =
+      490000000; // this is just below tds default <opendap><binLimit> of 500MB
+  public static final int DEFAULT_partialRequestMaxCells = 10000000;
+  public static final int DEFAULT_slowDownTroubleMillis = 1000;
+  public static final int DEFAULT_unusualActivity = 10000;
+  public static final int DEFAULT_updateMaxEvents = 10;
+  public static final int DEFAULT_unusualActivityFailPercent = 25;
+  public static final boolean DEFAULT_showLoadErrorsOnStatusPage = true;
+  public long cacheMillis = DEFAULT_cacheMinutes * Calendar2.MILLIS_PER_MINUTE;
+  public String drawLandMask = DEFAULT_drawLandMask;
+  public boolean emailDiagnosticsToErdData = true;
+  public Color graphBackgroundColor = new Color(DEFAULT_graphBackgroundColorInt, true); // hasAlpha
+  public long loadDatasetsMinMillis = DEFAULT_loadDatasetsMinMinutes * Calendar2.MILLIS_PER_MINUTE;
+  public long loadDatasetsMaxMillis = DEFAULT_loadDatasetsMaxMinutes * Calendar2.MILLIS_PER_MINUTE;
+  // logLevel handled specially by setLogLevel
+  public int partialRequestMaxBytes = DEFAULT_partialRequestMaxBytes;
+  public int partialRequestMaxCells = DEFAULT_partialRequestMaxCells;
+  public int slowDownTroubleMillis = DEFAULT_slowDownTroubleMillis;
+  public int unusualActivity = DEFAULT_unusualActivity;
+  public int updateMaxEvents = DEFAULT_updateMaxEvents;
+  public int unusualActivityFailPercent = DEFAULT_unusualActivityFailPercent;
+
+  public final String[] categoryAttributes; // as it appears in metadata (and used for hashmap)
+  public final String[] categoryAttributesInURLs; // fileNameSafe (as used in URLs)
+  public final boolean[] categoryIsGlobal;
+  public int variableNameCategoryAttributeIndex = -1;
+
+  // these are all non-null if in awsS3Output mode, otherwise all are null
+  public String awsS3OutputBucketUrl = null; // ends in slash
+  public String awsS3OutputBucket = null; // the short name of the bucket
+  public S3TransferManager awsS3OutputTransferManager = null;
+
+  public final String corsAllowHeaders;
+  public final String[] corsAllowOrigin;
+
+  public final int logMaxSizeMB;
+  public String deploymentInfo;
+  // Booleans
+  public boolean usePrometheusMetrics = true;
+  @FeatureFlag public final boolean listPrivateDatasets;
+  @FeatureFlag public final boolean subscriptionSystemActive;
+  @FeatureFlag public final boolean convertersActive;
+  @FeatureFlag public final boolean slideSorterActive;
+  @FeatureFlag public final boolean fgdcActive;
+  @FeatureFlag public final boolean iso19115Active;
+  @FeatureFlag public final boolean jsonldActive;
+  @FeatureFlag public final boolean geoServicesRestActive;
+  @FeatureFlag public final boolean filesActive;
+  @FeatureFlag public final boolean defaultAccessibleViaFiles;
+  @FeatureFlag public final boolean dataProviderFormActive;
+  @FeatureFlag public final boolean outOfDateDatasetsActive;
+  @FeatureFlag public final boolean politicalBoundariesActive;
+  @FeatureFlag public final boolean wmsClientActive;
+  @FeatureFlag public final boolean sosActive;
+  @FeatureFlag public final boolean wcsActive;
+  @FeatureFlag public final boolean wmsActive;
+  @FeatureFlag public final boolean quickRestart;
+  @FeatureFlag public final boolean subscribeToRemoteErddapDataset;
+  @FeatureFlag public boolean showLoadErrorsOnStatusPage = DEFAULT_showLoadErrorsOnStatusPage;
+
+  @FeatureFlag
+  public
+  boolean // if useLuceneSearchEngine=false (a setting, or after error), original search engine will
+      // be
+      // used
+      useLuceneSearchEngine;
+
+  @FeatureFlag public final boolean variablesMustHaveIoosCategory;
+  @FeatureFlag public boolean useSaxParser;
+  @FeatureFlag public boolean updateSubsRssOnFileChanges;
+  @FeatureFlag public final boolean useEddReflection;
+  @FeatureFlag public boolean enableCors;
+  @FeatureFlag public boolean useSharedWatchService = true;
+
+  public EDConfig(String webInfParentDirectory) throws Exception {
+    fullPaletteDirectory = webInfParentDirectory + "WEB-INF/cptfiles/";
+    fullPublicDirectory = webInfParentDirectory + PUBLIC_DIR;
+    imageDir = webInfParentDirectory + IMAGES_DIR; // local directory on this computer
+
+    skipEmailThread = Boolean.parseBoolean(System.getProperty("skipEmailThread"));
+    // **** find contentDirectory
+    String ecd = "erddapContentDirectory"; // the name of the environment variable
+    String errorInMethod;
+    contentDirectory = System.getProperty(ecd);
+    if (contentDirectory == null) {
+      // Or, it must be sibling of webapps
+      // e.g., c:/programs/_tomcat/webapps/erddap/WEB-INF/classes/[these classes]
+      // On windows, contentDirectory may have spaces as %20(!)
+      contentDirectory = File2.getClassPath(); // access a resource folder
+      int po = contentDirectory.indexOf("/webapps/");
+      contentDirectory =
+          contentDirectory.substring(0, po) + "/content/erddap/"; // exception if po=-1
+    } else {
+      contentDirectory = File2.addSlash(contentDirectory);
+    }
+    Test.ensureTrue(
+        File2.isDirectory(contentDirectory),
+        "contentDirectory (" + contentDirectory + ") doesn't exist.");
+
+    // **** setup.xml  *************************************************************
+    // This is read BEFORE messages.xml. If that is a problem for something,
+    //  defer reading it in setup and add it to the messages section.
+    // read static Strings from setup.xml
+    String setupFileName = contentDirectory + "setup" + (developmentMode ? "2" : "") + ".xml";
+    errorInMethod = "ERROR while reading " + setupFileName + ": ";
+    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false));
+    Map<String, String> ev = System.getenv();
+
+    // logLevel may be: warning, info(default), all
+    EDStatic.setLogLevel(getSetupEVString(setup, ev, "logLevel", DEFAULT_logLevel));
+
+    usePrometheusMetrics = getSetupEVBoolean(setup, ev, "usePrometheusMetrics", true);
+
+    bigParentDirectory = getSetupEVNotNothingString(setup, ev, "bigParentDirectory", "");
+    bigParentDirectory = File2.addSlash(bigParentDirectory);
+    Path bpd = Path.of(bigParentDirectory);
+    if (!bpd.isAbsolute()) {
+      if (!File2.isDirectory(bigParentDirectory)) {
+        bigParentDirectory = File2.getWebInfParentDirectory() + bigParentDirectory;
+      }
+    }
+    Test.ensureTrue(
+        File2.isDirectory(bigParentDirectory),
+        "bigParentDirectory (" + bigParentDirectory + ") doesn't exist.");
+
+    // email  (do early on so email can be sent if trouble later in this method)
+    emailSmtpHost = getSetupEVString(setup, ev, "emailSmtpHost", (String) null);
+    emailSmtpPort = getSetupEVInt(setup, ev, "emailSmtpPort", 25);
+    emailUserName = getSetupEVString(setup, ev, "emailUserName", (String) null);
+    emailPassword = getSetupEVString(setup, ev, "emailPassword", (String) null);
+    emailProperties = getSetupEVString(setup, ev, "emailProperties", (String) null);
+    emailFromAddress = getSetupEVString(setup, ev, "emailFromAddress", (String) null);
+    emailEverythingToCsv = getSetupEVString(setup, ev, "emailEverythingTo", ""); // won't be null
+    emailDailyReportToCsv =
+        Optional.ofNullable(getSetupEVString(setup, ev, "emailDailyReportTo", (String) null))
+            .orElse(getSetupEVString(setup, ev, "emailDailyReportsTo", ""));
+    emailIsActive = // ie if actual emails will be sent
+        String2.isSomething(emailSmtpHost)
+            && emailSmtpPort > 0
+            && String2.isSomething(emailUserName)
+            && String2.isSomething(emailPassword)
+            && String2.isEmailAddress(emailFromAddress);
+
+    String tsar[] = String2.split(emailEverythingToCsv, ',');
+    if (emailEverythingToCsv.length() > 0)
+      for (String s : tsar)
+        if (!String2.isEmailAddress(s)
+            || s.startsWith("your.")) // prohibit the default email addresses
+        throw new RuntimeException(
+              "setup.xml error: invalid email address=" + s + " in <emailEverythingTo>.");
+    emailSubscriptionsFrom = tsar.length > 0 ? tsar[0] : ""; // won't be null
+
+    tsar = String2.split(emailDailyReportToCsv, ',');
+    if (emailDailyReportToCsv.length() > 0) {
+      for (String s : tsar)
+        if (!String2.isEmailAddress(s)
+            || s.startsWith("your.")) // prohibit the default email addresses
+        throw new RuntimeException(
+              "setup.xml error: invalid email address=" + s + " in <emailDailyReportTo>.");
+    }
+
+    // *** set up directories  //all with slashes at end
+    // before 2011-12-30, was fullDatasetInfoDirectory datasetInfo/; see conversion below
+    fullDatasetDirectory = bigParentDirectory + "dataset/";
+    fullFileVisitorDirectory = fullDatasetDirectory + "_FileVisitor/";
+    File2.deleteAllFiles(
+        fullFileVisitorDirectory); // no temp file list can be active at ERDDAP restart
+    fullCacheDirectory = bigParentDirectory + "cache/";
+    fullDecompressedDirectory = bigParentDirectory + "decompressed/";
+    fullDecompressedGenerateDatasetsXmlDirectory =
+        bigParentDirectory + "decompressed/GenerateDatasetsXml/";
+    fullResetFlagDirectory = bigParentDirectory + "flag/";
+    fullBadFilesFlagDirectory = bigParentDirectory + "badFilesFlag/";
+    fullHardFlagDirectory = bigParentDirectory + "hardFlag/";
+    fullLogsDirectory = bigParentDirectory + "logs/";
+    fullCopyDirectory = bigParentDirectory + "copy/";
+    fullLuceneDirectory = bigParentDirectory + "lucene/";
+
+    Test.ensureTrue(
+        File2.isDirectory(fullPaletteDirectory),
+        "fullPaletteDirectory (" + fullPaletteDirectory + ") doesn't exist.");
+    errorInMethod =
+        "ERROR while creating directories: "; // File2.makeDir throws exception if failure
+    File2.makeDirectory(fullPublicDirectory); // make it, because Git doesn't track empty dirs
+    File2.makeDirectory(fullDatasetDirectory);
+    File2.makeDirectory(fullCacheDirectory);
+    File2.makeDirectory(fullDecompressedDirectory);
+    File2.makeDirectory(fullDecompressedGenerateDatasetsXmlDirectory);
+    File2.makeDirectory(fullResetFlagDirectory);
+    File2.makeDirectory(fullBadFilesFlagDirectory);
+    File2.makeDirectory(fullHardFlagDirectory);
+    File2.makeDirectory(fullLogsDirectory);
+    File2.makeDirectory(fullCopyDirectory);
+    File2.makeDirectory(fullLuceneDirectory);
+
+    String2.log(
+        "bigParentDirectory="
+            + bigParentDirectory
+            + String2.lineSeparator
+            + "webInfParentDirectory="
+            + webInfParentDirectory);
+
+    // make some subdirectories of fullCacheDirectory
+    // '_' distinguishes from dataset cache dirs
+    errorInMethod = "ERROR while creating directories: ";
+    fullCptCacheDirectory = fullCacheDirectory + "_cpt/";
+    fullPlainFileNcCacheDirectory = fullCacheDirectory + "_plainFileNc/";
+    fullSgtMapTopographyCacheDirectory = fullCacheDirectory + "_SgtMapTopography/";
+    fullTestCacheDirectory = fullCacheDirectory + "_test/";
+    fullWmsCacheDirectory =
+        fullCacheDirectory + "_wms/"; // for all-datasets WMS and subdirs for non-data layers
+    File2.makeDirectory(fullCptCacheDirectory);
+    File2.makeDirectory(fullPlainFileNcCacheDirectory);
+    File2.makeDirectory(fullSgtMapTopographyCacheDirectory);
+    File2.makeDirectory(fullTestCacheDirectory);
+    File2.makeDirectory(fullWmsCacheDirectory);
+    File2.makeDirectory(fullWmsCacheDirectory + "Land"); // includes LandMask
+    File2.makeDirectory(fullWmsCacheDirectory + "Coastlines");
+    File2.makeDirectory(fullWmsCacheDirectory + "LakesAndRivers");
+    File2.makeDirectory(fullWmsCacheDirectory + "Nations");
+    File2.makeDirectory(fullWmsCacheDirectory + "States");
+
+    // get other info from setup.xml
+    errorInMethod = "ERROR while reading " + setupFileName + ": ";
+    baseUrl = getSetupEVNotNothingString(setup, ev, "baseUrl", errorInMethod);
+    baseHttpsUrl =
+        getSetupEVString(
+            setup, ev, "baseHttpsUrl", "(not specified)"); // not "" (to avoid relative urls)
+    categoryAttributes =
+        String2.split(getSetupEVNotNothingString(setup, ev, "categoryAttributes", ""), ',');
+    int nCat = categoryAttributes.length;
+    categoryAttributesInURLs = new String[nCat];
+    categoryIsGlobal = new boolean[nCat]; // initially all false
+    for (int cati = 0; cati < nCat; cati++) {
+      String cat = categoryAttributes[cati];
+      if (cat.startsWith("global:")) {
+        categoryIsGlobal[cati] = true;
+        cat = cat.substring(7);
+        categoryAttributes[cati] = cat;
+      } else if (cat.equals("institution")) { // legacy special case
+        categoryIsGlobal[cati] = true;
+      }
+      categoryAttributesInURLs[cati] = String2.modifyToBeFileNameSafe(cat);
+    }
+    variableNameCategoryAttributeIndex = String2.indexOf(categoryAttributes, "variableName");
+
+    String wmsActiveString = getSetupEVString(setup, ev, "wmsActive", "");
+    wmsActive = !String2.isSomething(wmsActiveString) || String2.parseBoolean(wmsActiveString);
+    wmsSampleDatasetID = getSetupEVString(setup, ev, "wmsSampleDatasetID", wmsSampleDatasetID);
+    wmsSampleVariable = getSetupEVString(setup, ev, "wmsSampleVariable", wmsSampleVariable);
+    wmsSampleBBox110 = getSetupEVString(setup, ev, "wmsSampleBBox110", wmsSampleBBox110);
+    wmsSampleBBox130 = getSetupEVString(setup, ev, "wmsSampleBBox130", wmsSampleBBox130);
+    wmsSampleTime = getSetupEVString(setup, ev, "wmsSampleTime", wmsSampleTime);
+
+    adminInstitution = getSetupEVNotNothingString(setup, ev, "adminInstitution", errorInMethod);
+    adminInstitutionUrl =
+        getSetupEVNotNothingString(setup, ev, "adminInstitutionUrl", errorInMethod);
+    adminIndividualName =
+        getSetupEVNotNothingString(setup, ev, "adminIndividualName", errorInMethod);
+    adminPosition = getSetupEVNotNothingString(setup, ev, "adminPosition", errorInMethod);
+    adminPhone = getSetupEVNotNothingString(setup, ev, "adminPhone", errorInMethod);
+    adminAddress = getSetupEVNotNothingString(setup, ev, "adminAddress", errorInMethod);
+    adminCity = getSetupEVNotNothingString(setup, ev, "adminCity", errorInMethod);
+    adminStateOrProvince =
+        getSetupEVNotNothingString(setup, ev, "adminStateOrProvince", errorInMethod);
+    adminPostalCode = getSetupEVNotNothingString(setup, ev, "adminPostalCode", errorInMethod);
+    adminCountry = getSetupEVNotNothingString(setup, ev, "adminCountry", errorInMethod);
+    adminEmail = getSetupEVNotNothingString(setup, ev, "adminEmail", errorInMethod);
+
+    if (adminInstitution.startsWith("Your"))
+      throw new RuntimeException("setup.xml error: invalid <adminInstitution>=" + adminInstitution);
+    if (!adminInstitutionUrl.startsWith("http") || !String2.isUrl(adminInstitutionUrl))
+      throw new RuntimeException(
+          "setup.xml error: invalid <adminInstitutionUrl>=" + adminInstitutionUrl);
+    if (adminIndividualName.startsWith("Your"))
+      throw new RuntimeException(
+          "setup.xml error: invalid <adminIndividualName>=" + adminIndividualName);
+    // if (adminPosition.length() == 0)
+    //    throw new RuntimeException("setup.xml error: invalid <adminPosition>=" + adminPosition);
+    if (adminPhone.indexOf("999-999") >= 0)
+      throw new RuntimeException("setup.xml error: invalid <adminPhone>=" + adminPhone);
+    if (adminAddress.equals("123 Main St."))
+      throw new RuntimeException("setup.xml error: invalid <adminAddress>=" + adminAddress);
+    if (adminCity.equals("Some Town"))
+      throw new RuntimeException("setup.xml error: invalid <adminCity>=" + adminCity);
+    // if (adminStateOrProvince.length() == 0)
+    //    throw new RuntimeException("setup.xml error: invalid <adminStateOrProvince>=" +
+    // adminStateOrProvince);
+    if (adminPostalCode.equals("99999"))
+      throw new RuntimeException("setup.xml error: invalid <adminPostalCode>=" + adminPostalCode);
+    // if (adminCountry.length() == 0)
+    //    throw new RuntimeException("setup.xml error: invalid <adminCountry>=" + adminCountry);
+    if (!String2.isEmailAddress(adminEmail)
+        || adminEmail.startsWith("your.")) // prohibit default adminEmail
+    throw new RuntimeException("setup.xml error: invalid <adminEmail>=" + adminEmail);
+
+    accessConstraints = getSetupEVNotNothingString(setup, ev, "accessConstraints", errorInMethod);
+    accessRequiresAuthorization =
+        getSetupEVNotNothingString(setup, ev, "accessRequiresAuthorization", errorInMethod);
+    fees = getSetupEVNotNothingString(setup, ev, "fees", errorInMethod);
+    keywords = getSetupEVNotNothingString(setup, ev, "keywords", errorInMethod);
+
+    awsS3OutputBucketUrl = getSetupEVString(setup, ev, "awsS3OutputBucketUrl", (String) null);
+    if (!String2.isSomething(awsS3OutputBucketUrl)) awsS3OutputBucketUrl = null;
+
+    if (awsS3OutputBucketUrl != null) {
+
+      // ensure that it is valid
+      awsS3OutputBucketUrl = File2.addSlash(awsS3OutputBucketUrl);
+      String bro[] = String2.parseAwsS3Url(awsS3OutputBucketUrl);
+      if (bro == null)
+        throw new RuntimeException(
+            "The value of <awsS3OutputBucketUrl> specified in setup.xml doesn't match this regular expression: "
+                + String2.AWS_S3_REGEX());
+
+      awsS3OutputBucket = bro[0];
+      String region = bro[1];
+
+      // build the awsS3OutputTransferManager
+      awsS3OutputTransferManager = SSR.buildS3TransferManager(region);
+
+      // note that I could set LifecycleRule(s) for the bucket via
+      // awsS3OutputClient.putBucketLifecycleConfiguration
+      // but LifecycleRule precision seems to be days, not e.g., minutes
+      // So make my own system
+    }
+
+    units_standard = getSetupEVString(setup, ev, "units_standard", "UDUNITS");
+
+    fgdcActive = getSetupEVBoolean(setup, ev, "fgdcActive", true);
+    iso19115Active = getSetupEVBoolean(setup, ev, "iso19115Active", true);
+    jsonldActive = getSetupEVBoolean(setup, ev, "jsonldActive", true);
+    // until geoServicesRest is finished, it is always inactive
+    geoServicesRestActive =
+        false; // getSetupEVBoolean(setup, ev,          "geoServicesRestActive",      false);
+    filesActive = getSetupEVBoolean(setup, ev, "filesActive", true);
+    defaultAccessibleViaFiles =
+        getSetupEVBoolean(
+            setup, ev, "defaultAccessibleViaFiles", false); // false matches historical behavior
+    dataProviderFormActive = getSetupEVBoolean(setup, ev, "dataProviderFormActive", true);
+    outOfDateDatasetsActive = getSetupEVBoolean(setup, ev, "outOfDateDatasetsActive", true);
+    politicalBoundariesActive = getSetupEVBoolean(setup, ev, "politicalBoundariesActive", true);
+    wmsClientActive = getSetupEVBoolean(setup, ev, "wmsClientActive", true);
+
+    // until SOS is finished, it is always inactive
+    sosActive = false; //        sosActive                  = getSetupEVBoolean(setup, ev,
+    // "sosActive",                  false);
+    if (sosActive) {
+      sosFeatureOfInterest =
+          getSetupEVNotNothingString(setup, ev, "sosFeatureOfInterest", errorInMethod);
+      sosStandardNamePrefix =
+          getSetupEVNotNothingString(setup, ev, "sosStandardNamePrefix", errorInMethod);
+      sosUrnBase = getSetupEVNotNothingString(setup, ev, "sosUrnBase", errorInMethod);
+
+      // make the sosGmlName, e.g., https://coastwatch.pfeg.noaa.gov -> gov.noaa.pfeg.coastwatch
+      sosBaseGmlName = baseUrl;
+      int po = sosBaseGmlName.indexOf("//");
+      if (po > 0) sosBaseGmlName = sosBaseGmlName.substring(po + 2);
+      po = sosBaseGmlName.indexOf(":");
+      if (po > 0) sosBaseGmlName = sosBaseGmlName.substring(0, po);
+      StringArray sbgn = new StringArray(String2.split(sosBaseGmlName, '.'));
+      sbgn.reverse();
+      sosBaseGmlName = String2.toSVString(sbgn.toArray(), ".", false);
+    }
+
+    // until it is finished, it is always inactive
+    wcsActive =
+        false; // getSetupEVBoolean(setup, ev,          "wcsActive",                  false);
+
+    authentication = getSetupEVString(setup, ev, "authentication", "");
+    datasetsRegex = getSetupEVString(setup, ev, "datasetsRegex", ".*");
+    drawLandMask = getSetupEVString(setup, ev, "drawLandMask", (String) null); // new name
+    if (drawLandMask == null) // 2014-08-28 changed defaults below to "under". It will be in v1.48
+    drawLandMask =
+          getSetupEVString(
+              setup, ev, "drawLand", DEFAULT_drawLandMask); // old name. DEFAULT...="under"
+    int tdlm = SgtMap.drawLandMask_OPTIONS.indexOf(drawLandMask);
+    if (tdlm < 1) drawLandMask = DEFAULT_drawLandMask; // "under"
+    flagKeyKey = getSetupEVNotNothingString(setup, ev, "flagKeyKey", errorInMethod);
+    if (flagKeyKey.toUpperCase().indexOf("CHANGE THIS") >= 0)
+      // really old default: "A stitch in time saves nine. CHANGE THIS!!!"
+      // current default:    "CHANGE THIS TO YOUR FAVORITE QUOTE"
+      throw new RuntimeException(
+          String2.ERROR
+              + ": You must change the <flagKeyKey> in setup.xml to a new, unique, non-default value. "
+              + "NOTE that this will cause the flagKeys used by your datasets to change. "
+              + "Any subscriptions using the old flagKeys will need to be redone.");
+    fontFamily = getSetupEVString(setup, ev, "fontFamily", "DejaVu Sans");
+    graphBackgroundColor =
+        new Color(
+            String2.parseInt(
+                getSetupEVString(
+                    setup, ev, "graphBackgroundColor", "" + DEFAULT_graphBackgroundColorInt)),
+            true); // hasAlpha
+    googleClientID = getSetupEVString(setup, ev, "googleClientID", (String) null);
+    orcidClientID = getSetupEVString(setup, ev, "orcidClientID", (String) null);
+    orcidClientSecret = getSetupEVString(setup, ev, "orcidClientSecret", (String) null);
+    googleEarthLogoFile =
+        getSetupEVNotNothingString(setup, ev, "googleEarthLogoFile", errorInMethod);
+    highResLogoImageFile =
+        getSetupEVNotNothingString(setup, ev, "highResLogoImageFile", errorInMethod);
+    listPrivateDatasets = getSetupEVBoolean(setup, ev, "listPrivateDatasets", false);
+    logMaxSizeMB =
+        Math2.minMax(1, 2000, getSetupEVInt(setup, ev, "logMaxSizeMB", 20)); // 2048MB=2GB
+
+    // v2.00: these are now also in datasets.xml
+    cacheMillis = getSetupEVInt(setup, ev, "cacheMinutes", DEFAULT_cacheMinutes) * 60000L;
+    loadDatasetsMinMillis =
+        Math.max(
+                1,
+                getSetupEVInt(setup, ev, "loadDatasetsMinMinutes", DEFAULT_loadDatasetsMinMinutes))
+            * 60000L;
+    loadDatasetsMaxMillis =
+        getSetupEVInt(setup, ev, "loadDatasetsMaxMinutes", DEFAULT_loadDatasetsMaxMinutes) * 60000L;
+    loadDatasetsMaxMillis = Math.max(loadDatasetsMinMillis * 2, loadDatasetsMaxMillis);
+    partialRequestMaxBytes =
+        getSetupEVInt(setup, ev, "partialRequestMaxBytes", DEFAULT_partialRequestMaxBytes);
+    partialRequestMaxCells =
+        getSetupEVInt(setup, ev, "partialRequestMaxCells", DEFAULT_partialRequestMaxCells);
+    unusualActivity = getSetupEVInt(setup, ev, "unusualActivity", DEFAULT_unusualActivity);
+    showLoadErrorsOnStatusPage =
+        getSetupEVBoolean(
+            setup, ev, "showLoadErrorsOnStatusPage", DEFAULT_showLoadErrorsOnStatusPage);
+
+    lowResLogoImageFile =
+        getSetupEVNotNothingString(setup, ev, "lowResLogoImageFile", errorInMethod);
+    quickRestart = getSetupEVBoolean(setup, ev, "quickRestart", true);
+    passwordEncoding = getSetupEVString(setup, ev, "passwordEncoding", "UEPSHA256");
+    searchEngine = getSetupEVString(setup, ev, "searchEngine", "original");
+
+    subscribeToRemoteErddapDataset =
+        getSetupEVBoolean(setup, ev, "subscribeToRemoteErddapDataset", true);
+    subscriptionSystemActive = getSetupEVBoolean(setup, ev, "subscriptionSystemActive", true);
+    convertersActive = getSetupEVBoolean(setup, ev, "convertersActive", true);
+    useSaxParser = getSetupEVBoolean(setup, ev, "useSaxParser", false);
+    updateSubsRssOnFileChanges = getSetupEVBoolean(setup, ev, "updateSubsRssOnFileChanges", true);
+    useEddReflection = getSetupEVBoolean(setup, ev, "useEddReflection", false);
+    enableCors = getSetupEVBoolean(setup, ev, "enableCors", false);
+    corsAllowHeaders =
+        getSetupEVString(setup, ev, "corsAllowHeaders", CorsResponseFilter.DEFAULT_ALLOW_HEADERS);
+    corsAllowOrigin =
+        String2.split(
+            String2.toLowerCase(getSetupEVString(setup, ev, "corsAllowOrigin", (String) null)),
+            ',');
+    slideSorterActive = getSetupEVBoolean(setup, ev, "slideSorterActive", true);
+    variablesMustHaveIoosCategory =
+        getSetupEVBoolean(setup, ev, "variablesMustHaveIoosCategory", true);
+    warName = getSetupEVString(setup, ev, "warName", "erddap");
+    useSharedWatchService = getSetupEVBoolean(setup, ev, "useSharedWatchService", true);
+    deploymentInfo = getSetupEVString(setup, ev, "deploymentInfo", "");
+
+    // ensure images exist and get their sizes
+    Image tImage = Image2.getImage(imageDir + lowResLogoImageFile, 10000, false);
+    lowResLogoImageFileWidth = tImage.getWidth(null);
+    lowResLogoImageFileHeight = tImage.getHeight(null);
+    tImage = Image2.getImage(imageDir + highResLogoImageFile, 10000, false);
+    highResLogoImageFileWidth = tImage.getWidth(null);
+    highResLogoImageFileHeight = tImage.getHeight(null);
+    tImage = Image2.getImage(imageDir + googleEarthLogoFile, 10000, false);
+    googleEarthLogoFileWidth = tImage.getWidth(null);
+    googleEarthLogoFileHeight = tImage.getHeight(null);
+
+    lazyInitializeStatics();
+  }
+
+  private void lazyInitializeStatics() {
+    FileVisitorDNLS.FILE_VISITOR_DIRECTORY = fullFileVisitorDirectory;
+    SgtMap.drawPoliticalBoundaries = politicalBoundariesActive;
+  }
+
+  /**
+   * This gets a string from setup.xml or environmentalVariables (preferred).
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param tDefault the default value
+   * @return the desired value (or the default if it isn't defined anywhere)
+   */
+  private String getSetupEVString(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, String tDefault) {
+    String value = ev.get("ERDDAP_" + paramName);
+    if (String2.isSomething(value)) {
+      String2.log("got " + paramName + " from ERDDAP_" + paramName);
+      return value;
+    }
+    return setup.getString(paramName, tDefault);
+  }
+
+  /**
+   * This gets a boolean from setup.xml or environmentalVariables (preferred).
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param tDefault the default value
+   * @return the desired value (or the default if it isn't defined anywhere)
+   */
+  private boolean getSetupEVBoolean(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, boolean tDefault) {
+    String value = ev.get("ERDDAP_" + paramName);
+    if (value != null) {
+      String2.log("got " + paramName + " from ERDDAP_" + paramName);
+      return String2.parseBoolean(value);
+    }
+    return setup.getBoolean(paramName, tDefault);
+  }
+
+  /**
+   * This gets an int from setup.xml or environmentalVariables (preferred).
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param tDefault the default value
+   * @return the desired value (or the default if it isn't defined anywhere)
+   */
+  private int getSetupEVInt(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, int tDefault) {
+    String value = ev.get("ERDDAP_" + paramName);
+    if (value != null) {
+      int valuei = String2.parseInt(value);
+      if (valuei < Integer.MAX_VALUE) {
+        String2.log("got " + paramName + " from ERDDAP_" + paramName);
+        return valuei;
+      }
+    }
+    return setup.getInt(paramName, tDefault);
+  }
+
+  /**
+   * This gets a string from setup.xml or environmentalVariables (preferred).
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param errorInMethod the start of an Error message
+   * @return the desired value
+   * @throws RuntimeException if there is no value for key
+   */
+  private String getSetupEVNotNothingString(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, String errorInMethod) {
+    String value = ev.get("ERDDAP_" + paramName);
+    if (String2.isSomething(value)) {
+      String2.log("got " + paramName + " from ERDDAP_" + paramName);
+      return value;
+    }
+    return setup.getNotNothingString(paramName, errorInMethod);
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
@@ -1,0 +1,3003 @@
+package gov.noaa.pfel.erddap.util;
+
+import com.cohort.array.Attributes;
+import com.cohort.array.PrimitiveArray;
+import com.cohort.array.StringArray;
+import com.cohort.util.File2;
+import com.cohort.util.Math2;
+import com.cohort.util.MustBe;
+import com.cohort.util.ResourceBundle2;
+import com.cohort.util.String2;
+import com.cohort.util.Test;
+import com.cohort.util.Units2;
+import com.cohort.util.XML;
+import com.google.common.io.Resources;
+import gov.noaa.pfel.coastwatch.util.HtmlWidgets;
+import gov.noaa.pfel.coastwatch.util.SSR;
+import gov.noaa.pfel.erddap.dataset.EDD;
+import gov.noaa.pfel.erddap.dataset.TableWriterHtmlTable;
+import java.net.URL;
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.Set;
+
+public class EDMessages {
+  // not translated
+  public
+  String // these are set by setup.xml (deprecated) and/or messages.xml and/or datasets.xml (v2.00+)
+      DEFAULT_standardLicense;
+  public String standardLicense;
+  public String DEFAULT_startHeadHtml; // see xxx() methods
+  public String startHeadHtml; // see xxx() methods
+  public String legal;
+  public String legendTitle1;
+  public String legendTitle2;
+  public String DEFAULT_palettes[] = null; // set when messages.xml is read
+  public Set<String> DEFAULT_palettes_set = null; // set when messages.xml is read
+  public String palettes[]; // an array of palettes
+  public String palettes0[]; // the array of palettes with a blank [0] item inserted
+  public String questionMarkImageFile;
+
+  // NOT TRANSLATED
+  public final String admKeywords;
+
+  public final String admSubsetVariables;
+  public final String advl_datasetID;
+  public final String advr_cdm_data_type;
+  public final String advr_class;
+  public final String advr_dataStructure;
+  public final String EDDChangedWasnt;
+  public final String EDDChangedDifferentNVar;
+  public final String EDDChanged2Different;
+  public final String EDDChanged1Different;
+  public final String EDDChangedCGADifferent;
+  public final String EDDChangedAxesDifferentNVar;
+  public final String EDDChangedAxes2Different;
+  public final String EDDChangedAxes1Different;
+  public final String EDDChangedNoValue;
+  public final String EDDChangedTableToGrid;
+  public final String EDDFgdc;
+  public final String EDDIso19115;
+  public final String EDDSimilarDifferentNVar;
+  public final String EDDSimilarDifferent;
+  public final String[] extensionsNoRangeRequests; // an array of extensions (not translated)
+  public final String inotifyFixCommands;
+  public final String sparqlP01toP02pre;
+  public final String sparqlP01toP02post;
+
+  public String // the unencoded EDDGrid...Example attributes
+      EDDGridErddapUrlExample;
+  public String EDDGridIdExample;
+  public String EDDGridDimensionExample;
+  public String EDDGridNoHyperExample;
+  public String EDDGridDimNamesExample;
+  public String EDDGridDataTimeExample;
+  public String EDDGridDataValueExample;
+  public String EDDGridDataIndexExample;
+  public String EDDGridGraphExample;
+  public String EDDGridMapExample;
+  public String EDDGridMatlabPlotExample;
+
+  public String // the unencoded EDDTable...Example attributes
+      EDDTableErddapUrlExample;
+  public String EDDTableIdExample;
+  public String EDDTableVariablesExample;
+  public String EDDTableConstraintsExample;
+  public String EDDTableDataTimeExample;
+  public String EDDTableDataValueExample;
+  public String EDDTableGraphExample;
+  public String EDDTableMapExample;
+  public String EDDTableMatlabPlotExample;
+
+  public String // variants encoded to be Html Examples
+      EDDGridDimensionExampleHE;
+  public String EDDGridDataIndexExampleHE;
+  public String EDDGridDataValueExampleHE;
+  public String EDDGridDataTimeExampleHE;
+  public String EDDGridGraphExampleHE;
+  public String EDDGridMapExampleHE;
+
+  public String // variants encoded to be Html Attributes
+      EDDGridDimensionExampleHA;
+  public String EDDGridDataIndexExampleHA;
+  public String EDDGridDataValueExampleHA;
+  public String EDDGridDataTimeExampleHA;
+  public String EDDGridGraphExampleHA;
+  public String EDDGridMapExampleHA;
+  public String EDDTableFromHttpGetDatasetDescription;
+  public String EDDTableFromHttpGetAuthorDescription;
+  public String EDDTableFromHttpGetTimestampDescription;
+
+  public String // variants encoded to be Html Examples
+      EDDTableConstraintsExampleHE;
+  public String EDDTableDataTimeExampleHE;
+  public String EDDTableDataValueExampleHE;
+  public String EDDTableGraphExampleHE;
+  public String EDDTableMapExampleHE;
+
+  public String // variants encoded to be Html Attributes
+      EDDTableConstraintsExampleHA;
+  public String EDDTableDataTimeExampleHA;
+  public String EDDTableDataValueExampleHA;
+  public String EDDTableGraphExampleHA;
+  public String EDDTableMapExampleHA;
+
+  // translated
+  public final String
+          [] // these are set by setup.xml (deprecated) and/or messages.xml and/or datasets.xml
+      // (v2.00+)
+      DEFAULT_standardContactAr;
+  public final String[] DEFAULT_standardDataLicensesAr;
+  public final String[] DEFAULT_standardDisclaimerOfEndorsementAr;
+  public final String[] DEFAULT_standardDisclaimerOfExternalLinksAr;
+  public final String[] DEFAULT_standardGeneralDisclaimerAr;
+  public final String[] DEFAULT_standardPrivacyPolicyAr;
+  public final String[] DEFAULT_startBodyHtmlAr;
+  public final String[] DEFAULT_theShortDescriptionHtmlAr;
+  public final String[] DEFAULT_endBodyHtmlAr;
+  public final String[] standardContactAr;
+  public final String[] standardDataLicensesAr;
+  public final String[] standardDisclaimerOfEndorsementAr;
+  public final String[] standardDisclaimerOfExternalLinksAr;
+  public final String[] standardGeneralDisclaimerAr;
+  public final String[] standardPrivacyPolicyAr;
+  public final String[] startBodyHtmlAr;
+  public final String[] theShortDescriptionHtmlAr;
+  public final String[] endBodyHtmlAr;
+  public String[] // in messages.xml and perhaps in datasets.xml (v2.00+)
+      commonStandardNames;
+  public final String[] DEFAULT_commonStandardNames;
+
+  // TRANSLATED
+  private final String[] // private to force use via methods, e.g., acceptEncodingHtml()
+      acceptEncodingHtmlAr;
+  private final String[] filesDocumentationAr;
+  public final String[] accessRESTFULAr;
+  public final String[] acronymsAr;
+  public final String[] addConstraintsAr;
+  public final String[] addVarWhereAttNameAr;
+  public final String[] addVarWhereAttValueAr;
+  public final String[] addVarWhereAr;
+  public final String[] additionalLinksAr;
+  public final String[] admSummaryAr;
+  public final String[] admTitleAr;
+  public final String[] advc_accessibleAr;
+  public final String[] advl_accessibleAr;
+  public final String[] advl_institutionAr;
+  public final String[] advc_dataStructureAr;
+  public final String[] advl_dataStructureAr;
+  public final String[] advl_cdm_data_typeAr;
+  public final String[] advl_classAr;
+  public final String[] advl_titleAr;
+  public final String[] advl_minLongitudeAr;
+  public final String[] advl_maxLongitudeAr;
+  public final String[] advl_longitudeSpacingAr;
+  public final String[] advl_minLatitudeAr;
+  public final String[] advl_maxLatitudeAr;
+  public final String[] advl_latitudeSpacingAr;
+  public final String[] advl_minAltitudeAr;
+  public final String[] advl_maxAltitudeAr;
+  public final String[] advl_minTimeAr;
+  public final String[] advc_maxTimeAr;
+  public final String[] advl_maxTimeAr;
+  public final String[] advl_timeSpacingAr;
+  public final String[] advc_griddapAr;
+  public final String[] advl_griddapAr;
+  public final String[] advl_subsetAr;
+  public final String[] advc_tabledapAr;
+  public final String[] advl_tabledapAr;
+  public final String[] advl_MakeAGraphAr;
+  public final String[] advc_sosAr;
+  public final String[] advl_sosAr;
+  public final String[] advl_wcsAr;
+  public final String[] advl_wmsAr;
+  public final String[] advc_filesAr;
+  public final String[] advl_filesAr;
+  public final String[] advc_fgdcAr;
+  public final String[] advl_fgdcAr;
+  public final String[] advc_iso19115Ar;
+  public final String[] advl_iso19115Ar;
+  public final String[] advc_metadataAr;
+  public final String[] advl_metadataAr;
+  public final String[] advl_sourceUrlAr;
+  public final String[] advl_infoUrlAr;
+  public final String[] advl_rssAr;
+  public final String[] advc_emailAr;
+  public final String[] advl_emailAr;
+  public final String[] advl_summaryAr;
+  public final String[] advc_testOutOfDateAr;
+  public final String[] advl_testOutOfDateAr;
+  public final String[] advc_outOfDateAr;
+  public final String[] advl_outOfDateAr;
+  public final String[] advn_outOfDateAr;
+  public final String[] advancedSearchAr;
+  public final String[] advancedSearchResultsAr;
+  public final String[] advancedSearchDirectionsAr;
+  public final String[] advancedSearchTooltipAr;
+  public final String[] advancedSearchBoundsAr;
+  public final String[] advancedSearchMinLatAr;
+  public final String[] advancedSearchMaxLatAr;
+  public final String[] advancedSearchMinLonAr;
+  public final String[] advancedSearchMaxLonAr;
+  public final String[] advancedSearchMinMaxLonAr;
+  public final String[] advancedSearchMinTimeAr;
+  public final String[] advancedSearchMaxTimeAr;
+  public final String[] advancedSearchClearAr;
+  public final String[] advancedSearchClearHelpAr;
+  public final String[] advancedSearchCategoryTooltipAr;
+  public final String[] advancedSearchRangeTooltipAr;
+  public final String[] advancedSearchMapTooltipAr;
+  public final String[] advancedSearchLonTooltipAr;
+  public final String[] advancedSearchTimeTooltipAr;
+  public final String[] advancedSearchWithCriteriaAr;
+  public final String[] advancedSearchFewerCriteriaAr;
+  public final String[] advancedSearchNoCriteriaAr;
+  public final String[] advancedSearchErrorHandlingAr;
+  public final String[] autoRefreshAr;
+  public final String[] blacklistMsgAr;
+  public final String[] BroughtToYouByAr;
+  public final String[] categoryTitleHtmlAr;
+  public final String[] categoryHtmlAr;
+  public final String[] category3HtmlAr;
+  public final String[] categoryPickAttributeAr;
+  public final String[] categorySearchHtmlAr;
+  public final String[] categorySearchDifferentHtmlAr;
+  public final String[] categoryClickHtmlAr;
+  public final String[] categoryNotAnOptionAr;
+  public final String[] caughtInterruptedAr;
+  public final String[] cdmDataTypeHelpAr;
+  public final String[] clickAccessAr;
+  public final String[] clickBackgroundInfoAr;
+  public final String[] clickERDDAPAr;
+  public final String[] clickInfoAr;
+  public final String[] clickToSubmitAr;
+  public final String[] convertAr;
+  public final String[] convertBypassAr;
+  public final String[] convertToAFullNameAr;
+  public final String[] convertToAnAcronymAr;
+  public final String[] convertToACountyNameAr;
+  public final String[] convertToAFIPSCodeAr;
+  public final String[] convertToGCMDAr;
+  public final String[] convertToCFStandardNamesAr;
+  public final String[] convertToNumericTimeAr;
+  public final String[] convertToStringTimeAr;
+  public final String[] convertAnyStringTimeAr;
+  public final String[] convertToProperTimeUnitsAr;
+  public final String[] convertFromUDUNITSToUCUMAr;
+  public final String[] convertFromUCUMToUDUNITSAr;
+  public final String[] convertToUCUMAr;
+  public final String[] convertToUDUNITSAr;
+  public final String[] convertStandardizeUDUNITSAr;
+  public final String[] convertToFullNameAr;
+  public final String[] convertToVariableNameAr;
+  public final String[] converterWebServiceAr;
+  public final String[] convertOAAcronymsAr;
+  public final String[] convertOAAcronymsToFromAr;
+  public final String[] convertOAAcronymsIntroAr;
+  public final String[] convertOAAcronymsNotesAr;
+  public final String[] convertOAAcronymsServiceAr;
+  public final String[] convertOAVariableNamesAr;
+  public final String[] convertOAVariableNamesToFromAr;
+  public final String[] convertOAVariableNamesIntroAr;
+  public final String[] convertOAVariableNamesNotesAr;
+  public final String[] convertOAVariableNamesServiceAr;
+  public final String[] convertFipsCountyAr;
+  public final String[] convertFipsCountyIntroAr;
+  public final String[] convertFipsCountyNotesAr;
+  public final String[] convertFipsCountyServiceAr;
+  public final String[] convertHtmlAr;
+  public final String[] convertInterpolateAr;
+  public final String[] convertInterpolateIntroAr;
+  public final String[] convertInterpolateTLLTableAr;
+  public final String[] convertInterpolateTLLTableHelpAr;
+  public final String[] convertInterpolateDatasetIDVariableAr;
+  public final String[] convertInterpolateDatasetIDVariableHelpAr;
+  public final String[] convertInterpolateNotesAr;
+  public final String[] convertInterpolateServiceAr;
+  public final String[] convertKeywordsAr;
+  public final String[] convertKeywordsCfTooltipAr;
+  public final String[] convertKeywordsGcmdTooltipAr;
+  public final String[] convertKeywordsIntroAr;
+  public final String[] convertKeywordsNotesAr;
+  public final String[] convertKeywordsServiceAr;
+  public final String[] convertTimeAr;
+  public final String[] convertTimeReferenceAr;
+  public final String[] convertTimeIntroAr;
+  public final String[] convertTimeNotesAr;
+  public final String[] convertTimeServiceAr;
+  public final String[] convertTimeNumberTooltipAr;
+  public final String[] convertTimeStringTimeTooltipAr;
+  public final String[] convertTimeUnitsTooltipAr;
+  public final String[] convertTimeUnitsHelpAr;
+  public final String[] convertTimeIsoFormatErrorAr;
+  public final String[] convertTimeNoSinceErrorAr;
+  public final String[] convertTimeNumberErrorAr;
+  public final String[] convertTimeNumericTimeErrorAr;
+  public final String[] convertTimeParametersErrorAr;
+  public final String[] convertTimeStringFormatErrorAr;
+  public final String[] convertTimeTwoTimeErrorAr;
+  public final String[] convertTimeUnitsErrorAr;
+  public final String[] convertUnitsAr;
+  public final String[] convertUnitsComparisonAr;
+  public final String[] convertUnitsFilterAr;
+  public final String[] convertUnitsIntroAr;
+  public final String[] convertUnitsNotesAr;
+  public final String[] convertUnitsServiceAr;
+  public final String[] convertURLsAr;
+  public final String[] convertURLsIntroAr;
+  public final String[] convertURLsNotesAr;
+  public final String[] convertURLsServiceAr;
+  public final String[] cookiesHelpAr;
+  public final String[] copyImageToClipboardAr;
+  public final String[] copyTextToClipboardAr;
+  public final String[] copyToClipboardNotAvailableAr;
+  public final String[] dafAr;
+  public final String[] dafGridBypassTooltipAr;
+  public final String[] dafGridTooltipAr;
+  public final String[] dafTableBypassTooltipAr;
+  public final String[] dafTableTooltipAr;
+  public final String[] dasTitleAr;
+  public final String[] dataAccessNotAllowedAr;
+  public final String[] databaseUnableToConnectAr;
+  public final String[] dataProviderFormAr;
+  public final String[] dataProviderFormP1Ar;
+  public final String[] dataProviderFormP2Ar;
+  public final String[] dataProviderFormP3Ar;
+  public final String[] dataProviderFormP4Ar;
+  public final String[] dataProviderFormDoneAr;
+  public final String[] dataProviderFormSuccessAr;
+  public final String[] dataProviderFormShortDescriptionAr;
+  public final String[] dataProviderFormLongDescriptionHTMLAr;
+  public final String[] dataProviderFormPart1Ar;
+  public final String[] dataProviderFormPart2HeaderAr;
+  public final String[] dataProviderFormPart2GlobalMetadataAr;
+  public final String[] dataProviderContactInfoAr;
+  public final String[] dataProviderDataAr;
+  public final String[] documentationAr;
+  public final String[] dpf_submitAr;
+  public final String[] dpf_fixProblemAr;
+  public final String[] dpf_yourNameAr;
+  public final String[] dpf_emailAddressAr;
+  public final String[] dpf_TimestampAr;
+  public final String[] dpf_frequencyAr;
+  public final String[] dpf_titleAr;
+  public final String[] dpf_titleTooltipAr;
+  public final String[] dpf_summaryAr;
+  public final String[] dpf_summaryTooltipAr;
+  public final String[] dpf_creatorNameAr;
+  public final String[] dpf_creatorNameTooltipAr;
+  public final String[] dpf_creatorTypeAr;
+  public final String[] dpf_creatorTypeTooltipAr;
+  public final String[] dpf_creatorEmailAr;
+  public final String[] dpf_creatorEmailTooltipAr;
+  public final String[] dpf_institutionAr;
+  public final String[] dpf_institutionTooltipAr;
+  public final String[] dpf_infoUrlAr;
+  public final String[] dpf_infoUrlTooltipAr;
+  public final String[] dpf_licenseAr;
+  public final String[] dpf_licenseTooltipAr;
+  public final String[] dpf_howYouStoreDataAr;
+  public final String[] dpf_provideIfAvailableAr;
+  public final String[] dpf_acknowledgementAr;
+  public final String[] dpf_acknowledgementTooltipAr;
+  public final String[] dpf_historyAr;
+  public final String[] dpf_historyTooltipAr;
+  public final String[] dpf_idTooltipAr;
+  public final String[] dpf_namingAuthorityAr;
+  public final String[] dpf_namingAuthorityTooltipAr;
+  public final String[] dpf_productVersionAr;
+  public final String[] dpf_productVersionTooltipAr;
+  public final String[] dpf_referencesAr;
+  public final String[] dpf_referencesTooltipAr;
+  public final String[] dpf_commentAr;
+  public final String[] dpf_commentTooltipAr;
+  public final String[] dpf_dataTypeHelpAr;
+  public final String[] dpf_ioosCategoryAr;
+  public final String[] dpf_ioosCategoryHelpAr;
+  public final String[] dpf_part3HeaderAr;
+  public final String[] dpf_variableMetadataAr;
+  public final String[] dpf_sourceNameAr;
+  public final String[] dpf_sourceNameTooltipAr;
+  public final String[] dpf_destinationNameAr;
+  public final String[] dpf_destinationNameTooltipAr;
+  public final String[] dpf_longNameAr;
+  public final String[] dpf_longNameTooltipAr;
+  public final String[] dpf_standardNameAr;
+  public final String[] dpf_standardNameTooltipAr;
+  public final String[] dpf_dataTypeAr;
+  public final String[] dpf_fillValueAr;
+  public final String[] dpf_fillValueTooltipAr;
+  public final String[] dpf_unitsAr;
+  public final String[] dpf_unitsTooltipAr;
+  public final String[] dpf_rangeAr;
+  public final String[] dpf_rangeTooltipAr;
+  public final String[] dpf_part4HeaderAr;
+  public final String[] dpf_otherCommentAr;
+  public final String[] dpf_finishPart4Ar;
+  public final String[] dpf_congratulationAr;
+  public final String[] disabledAr;
+  public final String[] distinctValuesTooltipAr;
+  public final String[] doWithGraphsAr;
+  public final String[] dtAccessibleAr;
+  public final String[] dtAccessiblePublicAr;
+  public final String[] dtAccessibleYesAr;
+  public final String[] dtAccessibleGraphsAr;
+  public final String[] dtAccessibleNoAr;
+  public final String[] dtAccessibleLogInAr;
+  public final String[] dtLogInAr;
+  public final String[] dtDAFAr;
+  public final String[] dtFilesAr;
+  public final String[] dtMAGAr;
+  public final String[] dtSOSAr;
+  public final String[] dtSubsetAr;
+  public final String[] dtWCSAr;
+  public final String[] dtWMSAr;
+  public final String[] EasierAccessToScientificDataAr;
+  public final String[] EDDDatasetIDAr;
+  public final String[] EDDFgdcMetadataAr;
+  public final String[] EDDFilesAr;
+  public final String[] EDDIso19115MetadataAr;
+  public final String[] EDDMetadataAr;
+  public final String[] EDDBackgroundAr;
+  public final String[] EDDClickOnSubmitHtmlAr;
+  public final String[] EDDInstitutionAr;
+  public final String[] EDDInformationAr;
+  public final String[] EDDSummaryAr;
+  public final String[] EDDDatasetTitleAr;
+  public final String[] EDDDownloadDataAr;
+  public final String[] EDDMakeAGraphAr;
+  public final String[] EDDMakeAMapAr;
+  public final String[] EDDFileTypeAr;
+  public final String[] EDDFileTypeInformationAr;
+  public final String[] EDDSelectFileTypeAr;
+  public final String[] EDDMinimumAr;
+  public final String[] EDDMaximumAr;
+  public final String[] EDDConstraintAr;
+  public final String[] EDDGridDapDescriptionAr;
+  public final String[] EDDGridDapLongDescriptionAr;
+  public final String[] EDDGridDownloadDataTooltipAr;
+  public final String[] EDDGridDimensionAr;
+  public final String[] EDDGridDimensionRangesAr;
+  public final String[] EDDGridFirstAr;
+  public final String[] EDDGridLastAr;
+  public final String[] EDDGridStartAr;
+  public final String[] EDDGridStopAr;
+  public final String[] EDDGridStartStopTooltipAr;
+  public final String[] EDDGridStrideAr;
+  public final String[] EDDGridNValuesAr;
+  public final String[] EDDGridNValuesHtmlAr;
+  public final String[] EDDGridSpacingAr;
+  public final String[] EDDGridJustOneValueAr;
+  public final String[] EDDGridEvenAr;
+  public final String[] EDDGridUnevenAr;
+  public final String[] EDDGridDimensionTooltipAr;
+  public final String[] EDDGridDimensionFirstTooltipAr;
+  public final String[] EDDGridDimensionLastTooltipAr;
+  public final String[] EDDGridVarHasDimTooltipAr;
+  public final String[] EDDGridSSSTooltipAr;
+  public final String[] EDDGridStartTooltipAr;
+  public final String[] EDDGridStopTooltipAr;
+  public final String[] EDDGridStrideTooltipAr;
+  public final String[] EDDGridSpacingTooltipAr;
+  public final String[] EDDGridDownloadTooltipAr;
+  public final String[] EDDGridGridVariableHtmlAr;
+  public final String[] EDDGridCheckAllAr;
+  public final String[] EDDGridCheckAllTooltipAr;
+  public final String[] EDDGridUncheckAllAr;
+  public final String[] EDDGridUncheckAllTooltipAr;
+  public final String[] EDDTableConstraintsAr;
+  public final String[] EDDTableTabularDatasetTooltipAr;
+  public final String[] EDDTableVariableAr;
+  public final String[] EDDTableCheckAllAr;
+  public final String[] EDDTableCheckAllTooltipAr;
+  public final String[] EDDTableUncheckAllAr;
+  public final String[] EDDTableUncheckAllTooltipAr;
+  public final String[] EDDTableMinimumTooltipAr;
+  public final String[] EDDTableMaximumTooltipAr;
+  public final String[] EDDTableCheckTheVariablesAr;
+  public final String[] EDDTableSelectAnOperatorAr;
+  public final String[] EDDTableFromEDDGridSummaryAr;
+  public final String[] EDDTableOptConstraint1HtmlAr;
+  public final String[] EDDTableOptConstraint2HtmlAr;
+  public final String[] EDDTableOptConstraintVarAr;
+  public final String[] EDDTableNumericConstraintTooltipAr;
+  public final String[] EDDTableStringConstraintTooltipAr;
+  public final String[] EDDTableTimeConstraintTooltipAr;
+  public final String[] EDDTableConstraintTooltipAr;
+  public final String[] EDDTableSelectConstraintTooltipAr;
+  public final String[] EDDTableDapDescriptionAr;
+  public final String[] EDDTableDapLongDescriptionAr;
+  public final String[] EDDTableDownloadDataTooltipAr;
+  public final String[] erddapIsAr;
+  public final String[] erddapVersionHTMLAr;
+  public final String[] errorTitleAr;
+  public final String[] errorRequestUrlAr;
+  public final String[] errorRequestQueryAr;
+  public final String[] errorTheErrorAr;
+  public final String[] errorCopyFromAr;
+  public final String[] errorFileNotFoundAr;
+  public final String[] errorFileNotFoundImageAr;
+  public final String[] errorInternalAr;
+  public final String[] errorJsonpFunctionNameAr;
+  public final String[] errorJsonpNotAllowedAr;
+  public final String[] errorMoreThan2GBAr;
+  public final String[] errorNotFoundAr;
+  public final String[] errorNotFoundInAr;
+  public final String[] errorOdvLLTGridAr;
+  public final String[] errorOdvLLTTableAr;
+  public final String[] errorOnWebPageAr;
+  public final String[] externalLinkAr;
+  public final String[] externalWebSiteAr;
+  public final String[] fileHelp_ascAr;
+  public final String[] fileHelp_csvAr;
+  public final String[] fileHelp_csvpAr;
+  public final String[] fileHelp_csv0Ar;
+  public final String[] fileHelp_dataTableAr;
+  public final String[] fileHelp_dasAr;
+  public final String[] fileHelp_ddsAr;
+  public final String[] fileHelp_dodsAr;
+  public final String[] fileHelpGrid_esriAsciiAr;
+  public final String[] fileHelpTable_esriCsvAr;
+  public final String[] fileHelp_fgdcAr;
+  public final String[] fileHelp_geoJsonAr;
+  public final String[] fileHelp_graphAr;
+  public final String[] fileHelpGrid_helpAr;
+  public final String[] fileHelpTable_helpAr;
+  public final String[] fileHelp_htmlAr;
+  public final String[] fileHelp_htmlTableAr;
+  public final String[] fileHelp_iso19115Ar;
+  public final String[] fileHelp_itxGridAr;
+  public final String[] fileHelp_itxTableAr;
+  public final String[] fileHelp_jsonAr;
+  public final String[] fileHelp_jsonlCSV1Ar;
+  public final String[] fileHelp_jsonlCSVAr;
+  public final String[] fileHelp_jsonlKVPAr;
+  public final String[] fileHelp_matAr;
+  public final String[] fileHelpGrid_nc3Ar;
+  public final String[] fileHelpGrid_nc4Ar;
+  public final String[] fileHelpTable_nc3Ar;
+  public final String[] fileHelpTable_nc4Ar;
+  public final String[] fileHelp_nc3HeaderAr;
+  public final String[] fileHelp_nc4HeaderAr;
+  public final String[] fileHelp_nccsvAr;
+  public final String[] fileHelp_nccsvMetadataAr;
+  public final String[] fileHelp_ncCFAr;
+  public final String[] fileHelp_ncCFHeaderAr;
+  public final String[] fileHelp_ncCFMAAr;
+  public final String[] fileHelp_ncCFMAHeaderAr;
+  public final String[] fileHelp_ncmlAr;
+  public final String[] fileHelp_ncoJsonAr;
+  public final String[] fileHelpGrid_odvTxtAr;
+  public final String[] fileHelpTable_odvTxtAr;
+  public final String[] fileHelp_parquetAr;
+  public final String[] fileHelp_parquet_with_metaAr;
+  public final String[] fileHelp_subsetAr;
+  public final String[] fileHelp_timeGapsAr;
+  public final String[] fileHelp_tsvAr;
+  public final String[] fileHelp_tsvpAr;
+  public final String[] fileHelp_tsv0Ar;
+  public final String[] fileHelp_wavAr;
+  public final String[] fileHelp_xhtmlAr;
+  public final String[] fileHelp_geotifAr; // graphical
+  public final String[] fileHelpGrid_kmlAr;
+  public final String[] fileHelpTable_kmlAr;
+  public final String[] fileHelp_smallPdfAr;
+  public final String[] fileHelp_pdfAr;
+  public final String[] fileHelp_largePdfAr;
+  public final String[] fileHelp_smallPngAr;
+  public final String[] fileHelp_pngAr;
+  public final String[] fileHelp_largePngAr;
+  public final String[] fileHelp_transparentPngAr;
+  public final String[] filesDescriptionAr;
+  public final String[] filesSortAr;
+  public final String[] filesWarningAr;
+  public final String[] findOutChangeAr;
+  public final String[] FIPSCountyCodesAr;
+  public final String[] forSOSUseAr;
+  public final String[] forWCSUseAr;
+  public final String[] forWMSUseAr;
+  public final String[] functionsAr;
+  public final String[] functionTooltipAr;
+  public final String[] functionDistinctCheckAr;
+  public final String[] functionDistinctTooltipAr;
+  public final String[] functionOrderByExtraAr;
+  public final String[] functionOrderByTooltipAr;
+  public final String[] functionOrderBySortAr;
+  public final String[] functionOrderBySort1Ar;
+  public final String[] functionOrderBySort2Ar;
+  public final String[] functionOrderBySort3Ar;
+  public final String[] functionOrderBySort4Ar;
+  public final String[] functionOrderBySortLeastAr;
+  public final String[] functionOrderBySortRowMaxAr;
+  public final String[] generatedAtAr;
+  public final String[] geoServicesDescriptionAr;
+  public final String[] getStartedHtmlAr;
+  public final String[] helpAr;
+  public final String[] htmlTableMaxMessageAr;
+  public final String[] imageDataCourtesyOfAr;
+  public final String[] imagesEmbedAr;
+  public final String[] indexViewAllAr;
+  public final String[] indexSearchWithAr;
+  public final String[] indexDevelopersSearchAr;
+  public final String[] indexProtocolAr;
+  public final String[] indexDescriptionAr;
+  public final String[] indexDatasetsAr;
+  public final String[] indexDocumentationAr;
+  public final String[] indexRESTfulSearchAr;
+  public final String[] indexAllDatasetsSearchAr;
+  public final String[] indexOpenSearchAr;
+  public final String[] indexServicesAr;
+  public final String[] indexDescribeServicesAr;
+  public final String[] indexMetadataAr;
+  public final String[] indexWAF1Ar;
+  public final String[] indexWAF2Ar;
+  public final String[] indexConvertersAr;
+  public final String[] indexDescribeConvertersAr;
+  public final String[] infoAboutFromAr;
+  public final String[] infoTableTitleHtmlAr;
+  public final String[] infoRequestFormAr;
+  public final String[] informationAr;
+  public final String[] inotifyFixAr;
+  public final String[] interpolateAr;
+  public final String[] javaProgramsHTMLAr;
+  public final String[] justGenerateAndViewAr;
+  public final String[] justGenerateAndViewTooltipAr;
+  public final String[] justGenerateAndViewUrlAr;
+  public final String[] justGenerateAndViewGraphUrlTooltipAr;
+  public final String[] keywordsAr;
+  public final String[] langCodeAr;
+  public final String[] legalNoticesAr;
+  public final String[] legalNoticesTitleAr;
+  public final String[] licenseAr;
+  public final String[] likeThisAr;
+  public final String[] listAllAr;
+  public final String[] listOfDatasetsAr;
+  public final String[] LogInAr;
+  public final String[] loginAr;
+  public final String[] loginHTMLAr;
+  public final String[] loginAttemptBlockedAr;
+  public final String[] loginDescribeCustomAr;
+  public final String[] loginDescribeEmailAr;
+  public final String[] loginDescribeGoogleAr;
+  public final String[] loginDescribeOrcidAr;
+  public final String[] loginDescribeOauth2Ar;
+  public final String[] loginErddapAr;
+  public final String[] loginCanNotAr;
+  public final String[] loginAreNotAr;
+  public final String[] loginToLogInAr;
+  public final String[] loginEmailAddressAr;
+  public final String[] loginYourEmailAddressAr;
+  public final String[] loginUserNameAr;
+  public final String[] loginPasswordAr;
+  public final String[] loginUserNameAndPasswordAr;
+  public final String[] loginGoogleSignInAr;
+  public final String[] loginOrcidSignInAr;
+  public final String[] loginOpenIDAr;
+  public final String[] loginOpenIDOrAr;
+  public final String[] loginOpenIDCreateAr;
+  public final String[] loginOpenIDFreeAr;
+  public final String[] loginOpenIDSameAr;
+  public final String[] loginAsAr;
+  public final String[] loginPartwayAsAr;
+  public final String[] loginFailedAr;
+  public final String[] loginSucceededAr;
+  public final String[] loginInvalidAr;
+  public final String[] loginNotAr;
+  public final String[] loginBackAr;
+  public final String[] loginProblemExactAr;
+  public final String[] loginProblemExpireAr;
+  public final String[] loginProblemGoogleAgainAr;
+  public final String[] loginProblemOrcidAgainAr;
+  public final String[] loginProblemOauth2AgainAr;
+  public final String[] loginProblemSameBrowserAr;
+  public final String[] loginProblem3TimesAr;
+  public final String[] loginProblemsAr;
+  public final String[] loginProblemsAfterAr;
+  public final String[] loginPublicAccessAr;
+  public final String[] LogOutAr;
+  public final String[] logoutAr;
+  public final String[] logoutOpenIDAr;
+  public final String[] logoutSuccessAr;
+  public final String[] magAr;
+  public final String[] magAxisXAr;
+  public final String[] magAxisYAr;
+  public final String[] magAxisColorAr;
+  public final String[] magAxisStickXAr;
+  public final String[] magAxisStickYAr;
+  public final String[] magAxisVectorXAr;
+  public final String[] magAxisVectorYAr;
+  public final String[] magAxisHelpGraphXAr;
+  public final String[] magAxisHelpGraphYAr;
+  public final String[] magAxisHelpMarkerColorAr;
+  public final String[] magAxisHelpSurfaceColorAr;
+  public final String[] magAxisHelpStickXAr;
+  public final String[] magAxisHelpStickYAr;
+  public final String[] magAxisHelpMapXAr;
+  public final String[] magAxisHelpMapYAr;
+  public final String[] magAxisHelpVectorXAr;
+  public final String[] magAxisHelpVectorYAr;
+  public final String[] magAxisVarHelpAr;
+  public final String[] magAxisVarHelpGridAr;
+  public final String[] magConstraintHelpAr;
+  public final String[] magDocumentationAr;
+  public final String[] magDownloadAr;
+  public final String[] magDownloadTooltipAr;
+  public final String[] magFileTypeAr;
+  public final String[] magGraphTypeAr;
+  public final String[] magGraphTypeTooltipGridAr;
+  public final String[] magGraphTypeTooltipTableAr;
+  public final String[] magGSAr;
+  public final String[] magGSMarkerTypeAr;
+  public final String[] magGSSizeAr;
+  public final String[] magGSColorAr;
+  public final String[] magGSColorBarAr;
+  public final String[] magGSColorBarTooltipAr;
+  public final String[] magGSContinuityAr;
+  public final String[] magGSContinuityTooltipAr;
+  public final String[] magGSScaleAr;
+  public final String[] magGSScaleTooltipAr;
+  public final String[] magGSMinAr;
+  public final String[] magGSMinTooltipAr;
+  public final String[] magGSMaxAr;
+  public final String[] magGSMaxTooltipAr;
+  public final String[] magGSNSectionsAr;
+  public final String[] magGSNSectionsTooltipAr;
+  public final String[] magGSLandMaskAr;
+  public final String[] magGSLandMaskTooltipGridAr;
+  public final String[] magGSLandMaskTooltipTableAr;
+  public final String[] magGSVectorStandardAr;
+  public final String[] magGSVectorStandardTooltipAr;
+  public final String[] magGSYAscendingTooltipAr;
+  public final String[] magGSYAxisMinAr;
+  public final String[] magGSYAxisMaxAr;
+  public final String[] magGSYRangeMinTooltipAr;
+  public final String[] magGSYRangeMaxTooltipAr;
+  public final String[] magGSYRangeTooltipAr;
+  public final String[] magGSYScaleTooltipAr;
+  public final String[] magItemFirstAr;
+  public final String[] magItemPreviousAr;
+  public final String[] magItemNextAr;
+  public final String[] magItemLastAr;
+  public final String[] magJust1ValueAr;
+  public final String[] magRangeAr;
+  public final String[] magRangeToAr;
+  public final String[] magRedrawAr;
+  public final String[] magRedrawTooltipAr;
+  public final String[] magTimeRangeAr;
+  public final String[] magTimeRangeFirstAr;
+  public final String[] magTimeRangeBackAr;
+  public final String[] magTimeRangeForwardAr;
+  public final String[] magTimeRangeLastAr;
+  public final String[] magTimeRangeTooltipAr;
+  public final String[] magTimeRangeTooltip2Ar;
+  public final String[] magTimesVaryAr;
+  public final String[] magViewUrlAr;
+  public final String[] magZoomAr;
+  public final String[] magZoomCenterAr;
+  public final String[] magZoomCenterTooltipAr;
+  public final String[] magZoomInAr;
+  public final String[] magZoomInTooltipAr;
+  public final String[] magZoomOutAr;
+  public final String[] magZoomOutTooltipAr;
+  public final String[] magZoomALittleAr;
+  public final String[] magZoomDataAr;
+  public final String[] magZoomOutDataAr;
+  public final String[] magGridTooltipAr;
+  public final String[] magTableTooltipAr;
+  public final String[] metadataDownloadAr;
+  public final String[] moreInformationAr;
+  public final String[] nMatching1Ar;
+  public final String[] nMatchingAr;
+  public final String[] nMatchingAlphabeticalAr;
+  public final String[] nMatchingMostRelevantAr;
+  public final String[] nMatchingPageAr;
+  public final String[] nMatchingCurrentAr;
+  public final String[] noDataFixedValueAr;
+  public final String[] noDataNoLLAr;
+  public final String[] noDatasetWithAr;
+  public final String[] noPage1Ar;
+  public final String[] noPage2Ar;
+  public final String[] notAllowedAr;
+  public final String[] notAuthorizedAr;
+  public final String[] notAuthorizedForDataAr;
+  public final String[] notAvailableAr;
+  public final String[] noteAr;
+  public final String[] noXxxAr;
+  public final String[] noXxxBecauseAr;
+  public final String[] noXxxBecause2Ar;
+  public final String[] noXxxNotActiveAr;
+  public final String[] noXxxNoAxis1Ar;
+  public final String[] noXxxNoColorBarAr;
+  public final String[] noXxxNoCdmDataTypeAr;
+  public final String[] noXxxNoLLAr;
+  public final String[] noXxxNoLLEvenlySpacedAr;
+  public final String[] noXxxNoLLGt1Ar;
+  public final String[] noXxxNoLLTAr;
+  public final String[] noXxxNoLonIn180Ar;
+  public final String[] noXxxNoNonStringAr;
+  public final String[] noXxxNo2NonStringAr;
+  public final String[] noXxxNoStationAr;
+  public final String[] noXxxNoStationIDAr;
+  public final String[] noXxxNoSubsetVariablesAr;
+  public final String[] noXxxNoOLLSubsetVariablesAr;
+  public final String[] noXxxNoMinMaxAr;
+  public final String[] noXxxItsGriddedAr;
+  public final String[] noXxxItsTabularAr;
+  public final String[] oneRequestAtATimeAr;
+  public final String[] openSearchDescriptionAr;
+  public final String[] optionalAr;
+  public final String[] optionsAr;
+  public final String[] orAListOfValuesAr;
+  public final String[] orRefineSearchWithAr;
+  public final String[] orSearchWithAr;
+  public final String[] orCommaAr;
+  public final String[] otherFeaturesAr;
+  public final String[] outOfDateDatasetsAr;
+  public final String[] outOfDateKeepTrackAr;
+  public final String[] outOfDateHtmlAr;
+  public final String[] patientDataAr;
+  public final String[] patientYourGraphAr;
+  public final String[] percentEncodeAr;
+  public final String[] pickADatasetAr;
+  public final String[] protocolSearchHtmlAr;
+  public final String[] protocolSearch2HtmlAr;
+  public final String[] protocolClickAr;
+  public final String[] queryErrorAr;
+  public final String[] queryError180Ar;
+  public final String[] queryError1ValueAr;
+  public final String[] queryError1VarAr;
+  public final String[] queryError2VarAr;
+  public final String[] queryErrorActualRangeAr;
+  public final String[] queryErrorAdjustedAr;
+  public final String[] queryErrorAscendingAr;
+  public final String[] queryErrorConstraintNaNAr;
+  public final String[] queryErrorEqualSpacingAr;
+  public final String[] queryErrorExpectedAtAr;
+  public final String[] queryErrorFileTypeAr;
+  public final String[] queryErrorInvalidAr;
+  public final String[] queryErrorLLAr;
+  public final String[] queryErrorLLGt1Ar;
+  public final String[] queryErrorLLTAr;
+  public final String[] queryErrorNeverTrueAr;
+  public final String[] queryErrorNeverBothTrueAr;
+  public final String[] queryErrorNotAxisAr;
+  public final String[] queryErrorNotExpectedAtAr;
+  public final String[] queryErrorNotFoundAfterAr;
+  public final String[] queryErrorOccursTwiceAr;
+  public final String[] queryErrorOrderByClosestAr;
+  public final String[] queryErrorOrderByLimitAr;
+  public final String[] queryErrorOrderByMeanAr;
+  public final String[] queryErrorOrderBySumAr;
+  public final String[] queryErrorOrderByVariableAr;
+  public final String[] queryErrorUnknownVariableAr;
+  public final String[] queryErrorGrid1AxisAr;
+  public final String[] queryErrorGridAmpAr;
+  public final String[] queryErrorGridDiagnosticAr;
+  public final String[] queryErrorGridBetweenAr;
+  public final String[] queryErrorGridLessMinAr;
+  public final String[] queryErrorGridGreaterMaxAr;
+  public final String[] queryErrorGridMissingAr;
+  public final String[] queryErrorGridNoAxisVarAr;
+  public final String[] queryErrorGridNoDataVarAr;
+  public final String[] queryErrorGridNotIdenticalAr;
+  public final String[] queryErrorGridSLessSAr;
+  public final String[] queryErrorLastEndPAr;
+  public final String[] queryErrorLastExpectedAr;
+  public final String[] queryErrorLastUnexpectedAr;
+  public final String[] queryErrorLastPMInvalidAr;
+  public final String[] queryErrorLastPMIntegerAr;
+  public final String[] rangesFromToAr;
+  public final String[] requiredAr;
+  public final String[] resetTheFormAr;
+  public final String[] resetTheFormWasAr;
+  public final String[] resourceNotFoundAr;
+  public final String[] restfulWebServicesAr;
+  public final String[] restfulHTMLAr;
+  public final String[] restfulHTMLContinuedAr;
+  public final String[] restfulGetAllDatasetAr;
+  public final String[] restfulProtocolsAr;
+  public final String[] SOSDocumentationAr;
+  public final String[] WCSDocumentationAr;
+  public final String[] WMSDocumentationAr;
+  public final String[] requestFormatExamplesHtmlAr;
+  public final String[] resultsFormatExamplesHtmlAr;
+  public final String[] resultsOfSearchForAr;
+  public final String[] restfulInformationFormatsAr;
+  public final String[] restfulViaServiceAr;
+  public final String[] rowsAr;
+  public final String[] rssNoAr;
+  public final String[] searchTitleAr;
+  public final String[] searchDoFullTextHtmlAr;
+  public final String[] searchFullTextHtmlAr;
+  public final String[] searchHintsLuceneTooltipAr;
+  public final String[] searchHintsOriginalTooltipAr;
+  public final String[] searchHintsTooltipAr;
+  public final String[] searchButtonAr;
+  public final String[] searchClickTipAr;
+  public final String[] searchMultipleERDDAPsAr;
+  public final String[] searchMultipleERDDAPsDescriptionAr;
+  public final String[] searchNotAvailableAr;
+  public final String[] searchTipAr;
+  public final String[] searchSpellingAr;
+  public final String[] searchFewerWordsAr;
+  public final String[] searchWithQueryAr;
+  public final String[] seeProtocolDocumentationAr;
+  public final String[] selectNextAr;
+  public final String[] selectPreviousAr;
+  public final String[] shiftXAllTheWayLeftAr;
+  public final String[] shiftXLeftAr;
+  public final String[] shiftXRightAr;
+  public final String[] shiftXAllTheWayRightAr;
+  public final String[] slideSorterAr;
+  public final String[] SOSAr;
+  public final String[] sosDescriptionHtmlAr;
+  public final String[] sosLongDescriptionHtmlAr;
+  public final String[] sosOverview1Ar;
+  public final String[] sosOverview2Ar;
+  public final String[] ssUseAr;
+  public final String[] ssUsePlainAr;
+  public final String[] ssBePatientAr;
+  public final String[] ssInstructionsHtmlAr;
+  public final String[] standardShortDescriptionHtmlAr;
+  public final String[] statusAr;
+  public final String[] statusHtmlAr;
+  public final String[] submitAr;
+  public final String[] submitTooltipAr;
+  public final String[] subscriptionOfferRssAr;
+  public final String[] subscriptionOfferUrlAr;
+  public final String[] subscriptionsTitleAr;
+  public final String[] subscriptionEmailListAr;
+  public final String[] subscriptionAddAr;
+  public final String[] subscriptionAddHtmlAr;
+  public final String[] subscriptionValidateAr;
+  public final String[] subscriptionValidateHtmlAr;
+  public final String[] subscriptionListAr;
+  public final String[] subscriptionListHtmlAr;
+  public final String[] subscriptionRemoveAr;
+  public final String[] subscriptionRemoveHtmlAr;
+  public final String[] subscriptionAbuseAr;
+  public final String[] subscriptionAddErrorAr;
+  public final String[] subscriptionAdd2Ar;
+  public final String[] subscriptionAddSuccessAr;
+  public final String[] subscriptionEmailAr;
+  public final String[] subscriptionEmailOnBlacklistAr;
+  public final String[] subscriptionEmailInvalidAr;
+  public final String[] subscriptionEmailTooLongAr;
+  public final String[] subscriptionEmailUnspecifiedAr;
+  public final String[] subscription0HtmlAr;
+  public final String[] subscription1HtmlAr;
+  public final String[] subscription2HtmlAr;
+  public final String[] subscriptionIDInvalidAr;
+  public final String[] subscriptionIDTooLongAr;
+  public final String[] subscriptionIDUnspecifiedAr;
+  public final String[] subscriptionKeyInvalidAr;
+  public final String[] subscriptionKeyUnspecifiedAr;
+  public final String[] subscriptionListErrorAr;
+  public final String[] subscriptionListSuccessAr;
+  public final String[] subscriptionRemoveErrorAr;
+  public final String[] subscriptionRemove2Ar;
+  public final String[] subscriptionRemoveSuccessAr;
+  public final String[] subscriptionRSSAr;
+  public final String[] subscriptionsNotAvailableAr;
+  public final String[] subscriptionUrlHtmlAr;
+  public final String[] subscriptionUrlInvalidAr;
+  public final String[] subscriptionUrlTooLongAr;
+  public final String[] subscriptionValidateErrorAr;
+  public final String[] subscriptionValidateSuccessAr;
+  public final String[] subsetAr;
+  public final String[] subsetSelectAr;
+  public final String[] subsetNMatchingAr;
+  public final String[] subsetInstructionsAr;
+  public final String[] subsetOptionAr;
+  public final String[] subsetOptionsAr;
+  public final String[] subsetRefineMapDownloadAr;
+  public final String[] subsetRefineSubsetDownloadAr;
+  public final String[] subsetClickResetClosestAr;
+  public final String[] subsetClickResetLLAr;
+  public final String[] subsetMetadataAr;
+  public final String[] subsetCountAr;
+  public final String[] subsetPercentAr;
+  public final String[] subsetViewSelectAr;
+  public final String[] subsetViewSelectDistinctCombosAr;
+  public final String[] subsetViewSelectRelatedCountsAr;
+  public final String[] subsetWhenAr;
+  public final String[] subsetWhenNoConstraintsAr;
+  public final String[] subsetWhenCountsAr;
+  public final String[] subsetComboClickSelectAr;
+  public final String[] subsetNVariableCombosAr;
+  public final String[] subsetShowingAllRowsAr;
+  public final String[] subsetShowingNRowsAr;
+  public final String[] subsetChangeShowingAr;
+  public final String[] subsetNRowsRelatedDataAr;
+  public final String[] subsetViewRelatedChangeAr;
+  public final String[] subsetTotalCountAr;
+  public final String[] subsetViewAr;
+  public final String[] subsetViewCheckAr;
+  public final String[] subsetViewCheck1Ar;
+  public final String[] subsetViewDistinctMapAr;
+  public final String[] subsetViewRelatedMapAr;
+  public final String[] subsetViewDistinctDataCountsAr;
+  public final String[] subsetViewDistinctDataAr;
+  public final String[] subsetViewRelatedDataCountsAr;
+  public final String[] subsetViewRelatedDataAr;
+  public final String[] subsetViewDistinctMapTooltipAr;
+  public final String[] subsetViewRelatedMapTooltipAr;
+  public final String[] subsetViewDistinctDataCountsTooltipAr;
+  public final String[] subsetViewDistinctDataTooltipAr;
+  public final String[] subsetViewRelatedDataCountsTooltipAr;
+  public final String[] subsetViewRelatedDataTooltipAr;
+  public final String[] subsetWarnAr;
+  public final String[] subsetWarn10000Ar;
+  public final String[] subsetTooltipAr;
+  public final String[] subsetNotSetUpAr;
+  public final String[] subsetLongNotShownAr;
+  public final String[] tabledapVideoIntroAr;
+  public final String[] theDatasetIDAr;
+  public final String[] theKeyAr;
+  public final String[] theSubscriptionIDAr;
+  public final String[] theUrlActionAr;
+  public final String[] ThenAr;
+  public final String[] thisParticularErddapAr;
+  public final String[] timeAr;
+  public final String[] timeoutOtherRequestsAr;
+  public final String[] unitsAr;
+  public final String[] unknownDatasetIDAr;
+  public final String[] unknownProtocolAr;
+  public final String[] unsupportedFileTypeAr;
+  public final String[] updateUrlsFrom; // not Ar. They were arrays before and now
+  public final String[] updateUrlsTo; // not Ar
+  public final String[] updateUrlsSkipAttributes; // not Ar
+  public final String[] usingGriddapAr;
+  public final String[] usingTabledapAr;
+  public final String[] variableNamesAr;
+  public final String[] viewAllDatasetsHtmlAr;
+  public final String[] waitThenTryAgainAr;
+  public final String[] warningAr;
+  public final String[] WCSAr;
+  public final String[] wcsDescriptionHtmlAr;
+  public final String[] wcsLongDescriptionHtmlAr;
+  public final String[] wcsOverview1Ar;
+  public final String[] wcsOverview2Ar;
+  public final String[] wmsDescriptionHtmlAr;
+  public final String[] WMSDocumentation1Ar;
+  public final String[] WMSGetCapabilitiesAr;
+  public final String[] WMSGetMapAr;
+  public final String[] WMSNotesAr;
+  public final String[] wmsInstructionsAr;
+  public final String[] wmsLongDescriptionHtmlAr;
+  public final String[] wmsManyDatasetsAr;
+  public final String[] yourEmailAddressAr;
+  public final String[] zoomInAr;
+  public final String[] zoomOutAr;
+  public final int[] imageWidths;
+  public final int[] imageHeights;
+  public final int[] pdfWidths;
+  public final int[] pdfHeights;
+  private final String[] theLongDescriptionHtmlAr; // see the xxx() methods
+  public final String errorFromDataSource = String2.ERROR + " from data source: ";
+  public final int nLanguages = TranslateMessages.languageList.size();
+
+  public EDMessages(String contentDirectory, ResourceBundle2 setup, Map<String, String> ev) {
+    // **** messages.xml *************************************************************
+    // This is read AFTER setup.xml. If that is a problem for something, defer reading it in setup
+    // and add it below.
+    // Read static messages from messages(2).xml in contentDirectory.
+    String errorInMethod;
+    ResourceBundle2[] messagesAr = new ResourceBundle2[nLanguages];
+    String messagesFileName = contentDirectory + "messages.xml";
+    try {
+      if (File2.isFile(messagesFileName)) {
+        String2.log("Using custom messages.xml from " + messagesFileName);
+        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
+        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false));
+      } else {
+        // use default messages.xml
+        String2.log("Custom messages.xml not found at " + messagesFileName);
+        // use String2.getClass(), not ClassLoader.getSystemResource (which fails in Tomcat)
+        URL messagesResourceFile = Resources.getResource("gov/noaa/pfel/erddap/util/messages.xml");
+        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
+        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesResourceFile, false));
+        String2.log("Using default messages.xml from  " + messagesFileName);
+      }
+
+      for (int tl = 1; tl < nLanguages; tl++) {
+        String tName = "messages-" + TranslateMessages.languageCodeList.get(tl) + ".xml";
+        errorInMethod = "ERROR while reading " + tName + ": ";
+        URL messageFile = new URL(TranslateMessages.translatedMessagesDir + tName);
+        messagesAr[tl] = ResourceBundle2.fromXml(XML.parseXml(messageFile, false));
+      }
+    } catch (Exception e) {
+      String2.log("EDMessages error loading files\n" + e.toString());
+    }
+    // read all the static Strings from messages.xml
+    errorInMethod = "ERROR while reading from all the messages.xml files: ";
+    acceptEncodingHtmlAr = getNotNothingString(messagesAr, "acceptEncodingHtml", errorInMethod);
+    accessRESTFULAr = getNotNothingString(messagesAr, "accessRestful", errorInMethod);
+    acronymsAr = getNotNothingString(messagesAr, "acronyms", errorInMethod);
+    addConstraintsAr = getNotNothingString(messagesAr, "addConstraints", errorInMethod);
+    addVarWhereAttNameAr = getNotNothingString(messagesAr, "addVarWhereAttName", errorInMethod);
+    addVarWhereAttValueAr = getNotNothingString(messagesAr, "addVarWhereAttValue", errorInMethod);
+    addVarWhereAr = getNotNothingString(messagesAr, "addVarWhere", errorInMethod);
+    additionalLinksAr = getNotNothingString(messagesAr, "additionalLinks", errorInMethod);
+    admKeywords = messagesAr[0].getNotNothingString("admKeywords", errorInMethod);
+    admSubsetVariables = messagesAr[0].getNotNothingString("admSubsetVariables", errorInMethod);
+    admSummaryAr = getNotNothingString(messagesAr, "admSummary", errorInMethod);
+    admTitleAr = getNotNothingString(messagesAr, "admTitle", errorInMethod);
+    advl_datasetID = messagesAr[0].getNotNothingString("advl_datasetID", errorInMethod);
+    advc_accessibleAr = getNotNothingString(messagesAr, "advc_accessible", errorInMethod);
+    advl_accessibleAr = getNotNothingString(messagesAr, "advl_accessible", errorInMethod);
+    advl_institutionAr = getNotNothingString(messagesAr, "advl_institution", errorInMethod);
+    advc_dataStructureAr = getNotNothingString(messagesAr, "advc_dataStructure", errorInMethod);
+    advl_dataStructureAr = getNotNothingString(messagesAr, "advl_dataStructure", errorInMethod);
+    advr_dataStructure = messagesAr[0].getNotNothingString("advr_dataStructure", errorInMethod);
+    advl_cdm_data_typeAr = getNotNothingString(messagesAr, "advl_cdm_data_type", errorInMethod);
+    advr_cdm_data_type = messagesAr[0].getNotNothingString("advr_cdm_data_type", errorInMethod);
+    advl_classAr = getNotNothingString(messagesAr, "advl_class", errorInMethod);
+    advr_class = messagesAr[0].getNotNothingString("advr_class", errorInMethod);
+    advl_titleAr = getNotNothingString(messagesAr, "advl_title", errorInMethod);
+    advl_minLongitudeAr = getNotNothingString(messagesAr, "advl_minLongitude", errorInMethod);
+    advl_maxLongitudeAr = getNotNothingString(messagesAr, "advl_maxLongitude", errorInMethod);
+    advl_longitudeSpacingAr =
+        getNotNothingString(messagesAr, "advl_longitudeSpacing", errorInMethod);
+    advl_minLatitudeAr = getNotNothingString(messagesAr, "advl_minLatitude", errorInMethod);
+    advl_maxLatitudeAr = getNotNothingString(messagesAr, "advl_maxLatitude", errorInMethod);
+    advl_latitudeSpacingAr = getNotNothingString(messagesAr, "advl_latitudeSpacing", errorInMethod);
+    advl_minAltitudeAr = getNotNothingString(messagesAr, "advl_minAltitude", errorInMethod);
+    advl_maxAltitudeAr = getNotNothingString(messagesAr, "advl_maxAltitude", errorInMethod);
+    advl_minTimeAr = getNotNothingString(messagesAr, "advl_minTime", errorInMethod);
+    advc_maxTimeAr = getNotNothingString(messagesAr, "advc_maxTime", errorInMethod);
+    advl_maxTimeAr = getNotNothingString(messagesAr, "advl_maxTime", errorInMethod);
+    advl_timeSpacingAr = getNotNothingString(messagesAr, "advl_timeSpacing", errorInMethod);
+    advc_griddapAr = getNotNothingString(messagesAr, "advc_griddap", errorInMethod);
+    advl_griddapAr = getNotNothingString(messagesAr, "advl_griddap", errorInMethod);
+    advl_subsetAr = getNotNothingString(messagesAr, "advl_subset", errorInMethod);
+    advc_tabledapAr = getNotNothingString(messagesAr, "advc_tabledap", errorInMethod);
+    advl_tabledapAr = getNotNothingString(messagesAr, "advl_tabledap", errorInMethod);
+    advl_MakeAGraphAr = getNotNothingString(messagesAr, "advl_MakeAGraph", errorInMethod);
+    advc_sosAr = getNotNothingString(messagesAr, "advc_sos", errorInMethod);
+    advl_sosAr = getNotNothingString(messagesAr, "advl_sos", errorInMethod);
+    advl_wcsAr = getNotNothingString(messagesAr, "advl_wcs", errorInMethod);
+    advl_wmsAr = getNotNothingString(messagesAr, "advl_wms", errorInMethod);
+    advc_filesAr = getNotNothingString(messagesAr, "advc_files", errorInMethod);
+    advl_filesAr = getNotNothingString(messagesAr, "advl_files", errorInMethod);
+    advc_fgdcAr = getNotNothingString(messagesAr, "advc_fgdc", errorInMethod);
+    advl_fgdcAr = getNotNothingString(messagesAr, "advl_fgdc", errorInMethod);
+    advc_iso19115Ar = getNotNothingString(messagesAr, "advc_iso19115", errorInMethod);
+    advl_iso19115Ar = getNotNothingString(messagesAr, "advl_iso19115", errorInMethod);
+    advc_metadataAr = getNotNothingString(messagesAr, "advc_metadata", errorInMethod);
+    advl_metadataAr = getNotNothingString(messagesAr, "advl_metadata", errorInMethod);
+    advl_sourceUrlAr = getNotNothingString(messagesAr, "advl_sourceUrl", errorInMethod);
+    advl_infoUrlAr = getNotNothingString(messagesAr, "advl_infoUrl", errorInMethod);
+    advl_rssAr = getNotNothingString(messagesAr, "advl_rss", errorInMethod);
+    advc_emailAr = getNotNothingString(messagesAr, "advc_email", errorInMethod);
+    advl_emailAr = getNotNothingString(messagesAr, "advl_email", errorInMethod);
+    advl_summaryAr = getNotNothingString(messagesAr, "advl_summary", errorInMethod);
+    advc_testOutOfDateAr = getNotNothingString(messagesAr, "advc_testOutOfDate", errorInMethod);
+    advl_testOutOfDateAr = getNotNothingString(messagesAr, "advl_testOutOfDate", errorInMethod);
+    advc_outOfDateAr = getNotNothingString(messagesAr, "advc_outOfDate", errorInMethod);
+    advl_outOfDateAr = getNotNothingString(messagesAr, "advl_outOfDate", errorInMethod);
+    advn_outOfDateAr = getNotNothingString(messagesAr, "advn_outOfDate", errorInMethod);
+    advancedSearchAr = getNotNothingString(messagesAr, "advancedSearch", errorInMethod);
+    advancedSearchResultsAr =
+        getNotNothingString(messagesAr, "advancedSearchResults", errorInMethod);
+    advancedSearchDirectionsAr =
+        getNotNothingString(messagesAr, "advancedSearchDirections", errorInMethod);
+    advancedSearchTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchTooltip", errorInMethod);
+    advancedSearchBoundsAr = getNotNothingString(messagesAr, "advancedSearchBounds", errorInMethod);
+    advancedSearchMinLatAr = getNotNothingString(messagesAr, "advancedSearchMinLat", errorInMethod);
+    advancedSearchMaxLatAr = getNotNothingString(messagesAr, "advancedSearchMaxLat", errorInMethod);
+    advancedSearchMinLonAr = getNotNothingString(messagesAr, "advancedSearchMinLon", errorInMethod);
+    advancedSearchMaxLonAr = getNotNothingString(messagesAr, "advancedSearchMaxLon", errorInMethod);
+    advancedSearchMinMaxLonAr =
+        getNotNothingString(messagesAr, "advancedSearchMinMaxLon", errorInMethod);
+    advancedSearchMinTimeAr =
+        getNotNothingString(messagesAr, "advancedSearchMinTime", errorInMethod);
+    advancedSearchMaxTimeAr =
+        getNotNothingString(messagesAr, "advancedSearchMaxTime", errorInMethod);
+    advancedSearchClearAr = getNotNothingString(messagesAr, "advancedSearchClear", errorInMethod);
+    advancedSearchClearHelpAr =
+        getNotNothingString(messagesAr, "advancedSearchClearHelp", errorInMethod);
+    advancedSearchCategoryTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchCategoryTooltip", errorInMethod);
+    advancedSearchRangeTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchRangeTooltip", errorInMethod);
+    advancedSearchMapTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchMapTooltip", errorInMethod);
+    advancedSearchLonTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchLonTooltip", errorInMethod);
+    advancedSearchTimeTooltipAr =
+        getNotNothingString(messagesAr, "advancedSearchTimeTooltip", errorInMethod);
+    advancedSearchWithCriteriaAr =
+        getNotNothingString(messagesAr, "advancedSearchWithCriteria", errorInMethod);
+    advancedSearchFewerCriteriaAr =
+        getNotNothingString(messagesAr, "advancedSearchFewerCriteria", errorInMethod);
+    advancedSearchNoCriteriaAr =
+        getNotNothingString(messagesAr, "advancedSearchNoCriteria", errorInMethod);
+    advancedSearchErrorHandlingAr =
+        getNotNothingString(messagesAr, "advancedSearchErrorHandling", errorInMethod);
+
+    autoRefreshAr = getNotNothingString(messagesAr, "autoRefresh", errorInMethod);
+    blacklistMsgAr = getNotNothingString(messagesAr, "blacklistMsg", errorInMethod);
+    BroughtToYouByAr = getNotNothingString(messagesAr, "BroughtToYouBy", errorInMethod);
+
+    categoryTitleHtmlAr = getNotNothingString(messagesAr, "categoryTitleHtml", errorInMethod);
+    categoryHtmlAr = getNotNothingString(messagesAr, "categoryHtml", errorInMethod);
+    category3HtmlAr = getNotNothingString(messagesAr, "category3Html", errorInMethod);
+    categoryPickAttributeAr =
+        getNotNothingString(messagesAr, "categoryPickAttribute", errorInMethod);
+    categorySearchHtmlAr = getNotNothingString(messagesAr, "categorySearchHtml", errorInMethod);
+    categorySearchDifferentHtmlAr =
+        getNotNothingString(messagesAr, "categorySearchDifferentHtml", errorInMethod);
+    categoryClickHtmlAr = getNotNothingString(messagesAr, "categoryClickHtml", errorInMethod);
+    categoryNotAnOptionAr = getNotNothingString(messagesAr, "categoryNotAnOption", errorInMethod);
+    caughtInterruptedAr = getNotNothingString(messagesAr, "caughtInterrupted", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) caughtInterruptedAr[tl] = " " + caughtInterruptedAr[tl];
+
+    cdmDataTypeHelpAr = getNotNothingString(messagesAr, "cdmDataTypeHelp", errorInMethod);
+
+    clickAccessAr = getNotNothingString(messagesAr, "clickAccess", errorInMethod);
+    clickBackgroundInfoAr = getNotNothingString(messagesAr, "clickBackgroundInfo", errorInMethod);
+    clickERDDAPAr = getNotNothingString(messagesAr, "clickERDDAP", errorInMethod);
+    clickInfoAr = getNotNothingString(messagesAr, "clickInfo", errorInMethod);
+    clickToSubmitAr = getNotNothingString(messagesAr, "clickToSubmit", errorInMethod);
+    convertAr = getNotNothingString(messagesAr, "convert", errorInMethod);
+    convertBypassAr = getNotNothingString(messagesAr, "convertBypass", errorInMethod);
+
+    convertToAFullNameAr = getNotNothingString(messagesAr, "convertToAFullName", errorInMethod);
+    convertToAnAcronymAr = getNotNothingString(messagesAr, "convertToAnAcronym", errorInMethod);
+    convertToACountyNameAr = getNotNothingString(messagesAr, "convertToACountyName", errorInMethod);
+    convertToAFIPSCodeAr = getNotNothingString(messagesAr, "convertToAFIPSCode", errorInMethod);
+    convertToGCMDAr = getNotNothingString(messagesAr, "convertToGCMD", errorInMethod);
+    convertToCFStandardNamesAr =
+        getNotNothingString(messagesAr, "convertToCFStandardNames", errorInMethod);
+    convertToNumericTimeAr = getNotNothingString(messagesAr, "convertToNumericTime", errorInMethod);
+    convertToStringTimeAr = getNotNothingString(messagesAr, "convertToStringTime", errorInMethod);
+    convertAnyStringTimeAr = getNotNothingString(messagesAr, "convertAnyStringTime", errorInMethod);
+    convertToProperTimeUnitsAr =
+        getNotNothingString(messagesAr, "convertToProperTimeUnits", errorInMethod);
+    convertFromUDUNITSToUCUMAr =
+        getNotNothingString(messagesAr, "convertFromUDUNITSToUCUM", errorInMethod);
+    convertFromUCUMToUDUNITSAr =
+        getNotNothingString(messagesAr, "convertFromUCUMToUDUNITS", errorInMethod);
+    convertToUCUMAr = getNotNothingString(messagesAr, "convertToUCUM", errorInMethod);
+    convertToUDUNITSAr = getNotNothingString(messagesAr, "convertToUDUNITS", errorInMethod);
+    convertStandardizeUDUNITSAr =
+        getNotNothingString(messagesAr, "convertStandardizeUDUNITS", errorInMethod);
+    convertToFullNameAr = getNotNothingString(messagesAr, "convertToFullName", errorInMethod);
+    convertToVariableNameAr =
+        getNotNothingString(messagesAr, "convertToVariableName", errorInMethod);
+
+    converterWebServiceAr = getNotNothingString(messagesAr, "converterWebService", errorInMethod);
+    convertOAAcronymsAr = getNotNothingString(messagesAr, "convertOAAcronyms", errorInMethod);
+    convertOAAcronymsToFromAr =
+        getNotNothingString(messagesAr, "convertOAAcronymsToFrom", errorInMethod);
+    convertOAAcronymsIntroAr =
+        getNotNothingString(messagesAr, "convertOAAcronymsIntro", errorInMethod);
+    convertOAAcronymsNotesAr =
+        getNotNothingString(messagesAr, "convertOAAcronymsNotes", errorInMethod);
+    convertOAAcronymsServiceAr =
+        getNotNothingString(messagesAr, "convertOAAcronymsService", errorInMethod);
+    convertOAVariableNamesAr =
+        getNotNothingString(messagesAr, "convertOAVariableNames", errorInMethod);
+    convertOAVariableNamesToFromAr =
+        getNotNothingString(messagesAr, "convertOAVariableNamesToFrom", errorInMethod);
+    convertOAVariableNamesIntroAr =
+        getNotNothingString(messagesAr, "convertOAVariableNamesIntro", errorInMethod);
+    convertOAVariableNamesNotesAr =
+        getNotNothingString(messagesAr, "convertOAVariableNamesNotes", errorInMethod);
+    convertOAVariableNamesServiceAr =
+        getNotNothingString(messagesAr, "convertOAVariableNamesService", errorInMethod);
+    convertFipsCountyAr = getNotNothingString(messagesAr, "convertFipsCounty", errorInMethod);
+    convertFipsCountyIntroAr =
+        getNotNothingString(messagesAr, "convertFipsCountyIntro", errorInMethod);
+    convertFipsCountyNotesAr =
+        getNotNothingString(messagesAr, "convertFipsCountyNotes", errorInMethod);
+    convertFipsCountyServiceAr =
+        getNotNothingString(messagesAr, "convertFipsCountyService", errorInMethod);
+    convertHtmlAr = getNotNothingString(messagesAr, "convertHtml", errorInMethod);
+    convertInterpolateAr = getNotNothingString(messagesAr, "convertInterpolate", errorInMethod);
+    convertInterpolateIntroAr =
+        getNotNothingString(messagesAr, "convertInterpolateIntro", errorInMethod);
+    convertInterpolateTLLTableAr =
+        getNotNothingString(messagesAr, "convertInterpolateTLLTable", errorInMethod);
+    convertInterpolateTLLTableHelpAr =
+        getNotNothingString(messagesAr, "convertInterpolateTLLTableHelp", errorInMethod);
+    convertInterpolateDatasetIDVariableAr =
+        getNotNothingString(messagesAr, "convertInterpolateDatasetIDVariable", errorInMethod);
+    convertInterpolateDatasetIDVariableHelpAr =
+        getNotNothingString(messagesAr, "convertInterpolateDatasetIDVariableHelp", errorInMethod);
+    convertInterpolateNotesAr =
+        getNotNothingString(messagesAr, "convertInterpolateNotes", errorInMethod);
+    convertInterpolateServiceAr =
+        getNotNothingString(messagesAr, "convertInterpolateService", errorInMethod);
+    convertKeywordsAr = getNotNothingString(messagesAr, "convertKeywords", errorInMethod);
+    convertKeywordsCfTooltipAr =
+        getNotNothingString(messagesAr, "convertKeywordsCfTooltip", errorInMethod);
+    convertKeywordsGcmdTooltipAr =
+        getNotNothingString(messagesAr, "convertKeywordsGcmdTooltip", errorInMethod);
+    convertKeywordsIntroAr = getNotNothingString(messagesAr, "convertKeywordsIntro", errorInMethod);
+    convertKeywordsNotesAr = getNotNothingString(messagesAr, "convertKeywordsNotes", errorInMethod);
+    convertKeywordsServiceAr =
+        getNotNothingString(messagesAr, "convertKeywordsService", errorInMethod);
+
+    convertTimeAr = getNotNothingString(messagesAr, "convertTime", errorInMethod);
+    convertTimeReferenceAr = getNotNothingString(messagesAr, "convertTimeReference", errorInMethod);
+    convertTimeIntroAr = getNotNothingString(messagesAr, "convertTimeIntro", errorInMethod);
+    convertTimeNotesAr = getNotNothingString(messagesAr, "convertTimeNotes", errorInMethod);
+    convertTimeServiceAr = getNotNothingString(messagesAr, "convertTimeService", errorInMethod);
+    convertTimeNumberTooltipAr =
+        getNotNothingString(messagesAr, "convertTimeNumberTooltip", errorInMethod);
+    convertTimeStringTimeTooltipAr =
+        getNotNothingString(messagesAr, "convertTimeStringTimeTooltip", errorInMethod);
+    convertTimeUnitsTooltipAr =
+        getNotNothingString(messagesAr, "convertTimeUnitsTooltip", errorInMethod);
+    convertTimeUnitsHelpAr = getNotNothingString(messagesAr, "convertTimeUnitsHelp", errorInMethod);
+    convertTimeIsoFormatErrorAr =
+        getNotNothingString(messagesAr, "convertTimeIsoFormatError", errorInMethod);
+    convertTimeNoSinceErrorAr =
+        getNotNothingString(messagesAr, "convertTimeNoSinceError", errorInMethod);
+    convertTimeNumberErrorAr =
+        getNotNothingString(messagesAr, "convertTimeNumberError", errorInMethod);
+    convertTimeNumericTimeErrorAr =
+        getNotNothingString(messagesAr, "convertTimeNumericTimeError", errorInMethod);
+    convertTimeParametersErrorAr =
+        getNotNothingString(messagesAr, "convertTimeParametersError", errorInMethod);
+    convertTimeStringFormatErrorAr =
+        getNotNothingString(messagesAr, "convertTimeStringFormatError", errorInMethod);
+    convertTimeTwoTimeErrorAr =
+        getNotNothingString(messagesAr, "convertTimeTwoTimeError", errorInMethod);
+    convertTimeUnitsErrorAr =
+        getNotNothingString(messagesAr, "convertTimeUnitsError", errorInMethod);
+    convertUnitsAr = getNotNothingString(messagesAr, "convertUnits", errorInMethod);
+    convertUnitsComparisonAr =
+        getNotNothingString(messagesAr, "convertUnitsComparison", errorInMethod);
+    convertUnitsFilterAr = getNotNothingString(messagesAr, "convertUnitsFilter", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) {
+      convertUnitsComparisonAr[tl] =
+          convertUnitsComparisonAr[tl]
+              .replaceAll(
+                  "&C;",
+                  "C") // these handled this way be cause you can't just avoid translating all
+              // words with 'C'
+              .replaceAll("&g;", "g") // "
+              .replaceAll("&F;", "F") // "
+              .replaceAll("&NTU;", "NTU")
+              .replaceAll("&ntu;", "ntu")
+              .replaceAll("&PSU;", "PSU")
+              .replaceAll("&psu;", "psu");
+    }
+
+    convertUnitsIntroAr = getNotNothingString(messagesAr, "convertUnitsIntro", errorInMethod);
+    convertUnitsNotesAr = getNotNothingString(messagesAr, "convertUnitsNotes", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++)
+      convertUnitsNotesAr[tl] =
+          convertUnitsNotesAr[tl].replace("&unitsStandard;", EDStatic.units_standard);
+    convertUnitsServiceAr = getNotNothingString(messagesAr, "convertUnitsService", errorInMethod);
+    convertURLsAr = getNotNothingString(messagesAr, "convertURLs", errorInMethod);
+    convertURLsIntroAr = getNotNothingString(messagesAr, "convertURLsIntro", errorInMethod);
+    convertURLsNotesAr = getNotNothingString(messagesAr, "convertURLsNotes", errorInMethod);
+    convertURLsServiceAr = getNotNothingString(messagesAr, "convertURLsService", errorInMethod);
+    cookiesHelpAr = getNotNothingString(messagesAr, "cookiesHelp", errorInMethod);
+    copyImageToClipboardAr = getNotNothingString(messagesAr, "copyImageToClipboard", errorInMethod);
+    copyTextToClipboardAr = getNotNothingString(messagesAr, "copyTextToClipboard", errorInMethod);
+    copyToClipboardNotAvailableAr =
+        getNotNothingString(messagesAr, "copyToClipboardNotAvailable", errorInMethod);
+
+    dafAr = getNotNothingString(messagesAr, "daf", errorInMethod);
+    dafGridBypassTooltipAr = getNotNothingString(messagesAr, "dafGridBypassTooltip", errorInMethod);
+    dafGridTooltipAr = getNotNothingString(messagesAr, "dafGridTooltip", errorInMethod);
+    dafTableBypassTooltipAr =
+        getNotNothingString(messagesAr, "dafTableBypassTooltip", errorInMethod);
+    dafTableTooltipAr = getNotNothingString(messagesAr, "dafTableTooltip", errorInMethod);
+    dasTitleAr = getNotNothingString(messagesAr, "dasTitle", errorInMethod);
+    dataAccessNotAllowedAr = getNotNothingString(messagesAr, "dataAccessNotAllowed", errorInMethod);
+    databaseUnableToConnectAr =
+        getNotNothingString(messagesAr, "databaseUnableToConnect", errorInMethod);
+    dataProviderFormAr = getNotNothingString(messagesAr, "dataProviderForm", errorInMethod);
+    dataProviderFormP1Ar = getNotNothingString(messagesAr, "dataProviderFormP1", errorInMethod);
+    dataProviderFormP2Ar = getNotNothingString(messagesAr, "dataProviderFormP2", errorInMethod);
+    dataProviderFormP3Ar = getNotNothingString(messagesAr, "dataProviderFormP3", errorInMethod);
+    dataProviderFormP4Ar = getNotNothingString(messagesAr, "dataProviderFormP4", errorInMethod);
+    dataProviderFormDoneAr = getNotNothingString(messagesAr, "dataProviderFormDone", errorInMethod);
+    dataProviderFormSuccessAr =
+        getNotNothingString(messagesAr, "dataProviderFormSuccess", errorInMethod);
+    dataProviderFormShortDescriptionAr =
+        getNotNothingString(messagesAr, "dataProviderFormShortDescription", errorInMethod);
+    dataProviderFormLongDescriptionHTMLAr =
+        getNotNothingString(messagesAr, "dataProviderFormLongDescriptionHTML", errorInMethod);
+    disabledAr = getNotNothingString(messagesAr, "disabled", errorInMethod);
+    dataProviderFormPart1Ar =
+        getNotNothingString(messagesAr, "dataProviderFormPart1", errorInMethod);
+    dataProviderFormPart2HeaderAr =
+        getNotNothingString(messagesAr, "dataProviderFormPart2Header", errorInMethod);
+    dataProviderFormPart2GlobalMetadataAr =
+        getNotNothingString(messagesAr, "dataProviderFormPart2GlobalMetadata", errorInMethod);
+    dataProviderContactInfoAr =
+        getNotNothingString(messagesAr, "dataProviderContactInfo", errorInMethod);
+    dataProviderDataAr = getNotNothingString(messagesAr, "dataProviderData", errorInMethod);
+    documentationAr = getNotNothingString(messagesAr, "documentation", errorInMethod);
+
+    dpf_submitAr = getNotNothingString(messagesAr, "dpf_submit", errorInMethod);
+    dpf_fixProblemAr = getNotNothingString(messagesAr, "dpf_fixProblem", errorInMethod);
+    dpf_yourNameAr = getNotNothingString(messagesAr, "dpf_yourName", errorInMethod);
+    dpf_emailAddressAr = getNotNothingString(messagesAr, "dpf_emailAddress", errorInMethod);
+    dpf_TimestampAr = getNotNothingString(messagesAr, "dpf_Timestamp", errorInMethod);
+    dpf_frequencyAr = getNotNothingString(messagesAr, "dpf_frequency", errorInMethod);
+    dpf_titleAr = getNotNothingString(messagesAr, "dpf_title", errorInMethod);
+    dpf_titleTooltipAr = getNotNothingString(messagesAr, "dpf_titleTooltip", errorInMethod);
+    dpf_summaryAr = getNotNothingString(messagesAr, "dpf_summary", errorInMethod);
+    dpf_summaryTooltipAr = getNotNothingString(messagesAr, "dpf_summaryTooltip", errorInMethod);
+    dpf_creatorNameAr = getNotNothingString(messagesAr, "dpf_creatorName", errorInMethod);
+    dpf_creatorNameTooltipAr =
+        getNotNothingString(messagesAr, "dpf_creatorNameTooltip", errorInMethod);
+    dpf_creatorTypeAr = getNotNothingString(messagesAr, "dpf_creatorType", errorInMethod);
+    dpf_creatorTypeTooltipAr =
+        getNotNothingString(messagesAr, "dpf_creatorTypeTooltip", errorInMethod);
+    dpf_creatorEmailAr = getNotNothingString(messagesAr, "dpf_creatorEmail", errorInMethod);
+    dpf_creatorEmailTooltipAr =
+        getNotNothingString(messagesAr, "dpf_creatorEmailTooltip", errorInMethod);
+    dpf_institutionAr = getNotNothingString(messagesAr, "dpf_institution", errorInMethod);
+    dpf_institutionTooltipAr =
+        getNotNothingString(messagesAr, "dpf_institutionTooltip", errorInMethod);
+    dpf_infoUrlAr = getNotNothingString(messagesAr, "dpf_infoUrl", errorInMethod);
+    dpf_infoUrlTooltipAr = getNotNothingString(messagesAr, "dpf_infoUrlTooltip", errorInMethod);
+    dpf_licenseAr = getNotNothingString(messagesAr, "dpf_license", errorInMethod);
+    dpf_licenseTooltipAr = getNotNothingString(messagesAr, "dpf_licenseTooltip", errorInMethod);
+    dpf_howYouStoreDataAr = getNotNothingString(messagesAr, "dpf_howYouStoreData", errorInMethod);
+    dpf_provideIfAvailableAr =
+        getNotNothingString(messagesAr, "dpf_provideIfAvailable", errorInMethod);
+    dpf_acknowledgementAr = getNotNothingString(messagesAr, "dpf_acknowledgement", errorInMethod);
+    dpf_acknowledgementTooltipAr =
+        getNotNothingString(messagesAr, "dpf_acknowledgementTooltip", errorInMethod);
+    dpf_historyAr = getNotNothingString(messagesAr, "dpf_history", errorInMethod);
+    dpf_historyTooltipAr = getNotNothingString(messagesAr, "dpf_historyTooltip", errorInMethod);
+    dpf_idTooltipAr = getNotNothingString(messagesAr, "dpf_idTooltip", errorInMethod);
+    dpf_namingAuthorityAr = getNotNothingString(messagesAr, "dpf_namingAuthority", errorInMethod);
+    dpf_namingAuthorityTooltipAr =
+        getNotNothingString(messagesAr, "dpf_namingAuthorityTooltip", errorInMethod);
+    dpf_productVersionAr = getNotNothingString(messagesAr, "dpf_productVersion", errorInMethod);
+    dpf_productVersionTooltipAr =
+        getNotNothingString(messagesAr, "dpf_productVersionTooltip", errorInMethod);
+    dpf_referencesAr = getNotNothingString(messagesAr, "dpf_references", errorInMethod);
+    dpf_referencesTooltipAr =
+        getNotNothingString(messagesAr, "dpf_referencesTooltip", errorInMethod);
+    dpf_commentAr = getNotNothingString(messagesAr, "dpf_comment", errorInMethod);
+    dpf_commentTooltipAr = getNotNothingString(messagesAr, "dpf_commentTooltip", errorInMethod);
+    dpf_dataTypeHelpAr = getNotNothingString(messagesAr, "dpf_dataTypeHelp", errorInMethod);
+    dpf_ioosCategoryAr = getNotNothingString(messagesAr, "dpf_ioosCategory", errorInMethod);
+    dpf_ioosCategoryHelpAr = getNotNothingString(messagesAr, "dpf_ioosCategoryHelp", errorInMethod);
+    dpf_part3HeaderAr = getNotNothingString(messagesAr, "dpf_part3Header", errorInMethod);
+    dpf_variableMetadataAr = getNotNothingString(messagesAr, "dpf_variableMetadata", errorInMethod);
+    dpf_sourceNameAr = getNotNothingString(messagesAr, "dpf_sourceName", errorInMethod);
+    dpf_sourceNameTooltipAr =
+        getNotNothingString(messagesAr, "dpf_sourceNameTooltip", errorInMethod);
+    dpf_destinationNameAr = getNotNothingString(messagesAr, "dpf_destinationName", errorInMethod);
+    dpf_destinationNameTooltipAr =
+        getNotNothingString(messagesAr, "dpf_destinationNameTooltip", errorInMethod);
+
+    dpf_longNameAr = getNotNothingString(messagesAr, "dpf_longName", errorInMethod);
+    dpf_longNameTooltipAr = getNotNothingString(messagesAr, "dpf_longNameTooltip", errorInMethod);
+    dpf_standardNameAr = getNotNothingString(messagesAr, "dpf_standardName", errorInMethod);
+    dpf_standardNameTooltipAr =
+        getNotNothingString(messagesAr, "dpf_standardNameTooltip", errorInMethod);
+    dpf_dataTypeAr = getNotNothingString(messagesAr, "dpf_dataType", errorInMethod);
+    dpf_fillValueAr = getNotNothingString(messagesAr, "dpf_fillValue", errorInMethod);
+    dpf_fillValueTooltipAr = getNotNothingString(messagesAr, "dpf_fillValueTooltip", errorInMethod);
+    dpf_unitsAr = getNotNothingString(messagesAr, "dpf_units", errorInMethod);
+    dpf_unitsTooltipAr = getNotNothingString(messagesAr, "dpf_unitsTooltip", errorInMethod);
+    dpf_rangeAr = getNotNothingString(messagesAr, "dpf_range", errorInMethod);
+    dpf_rangeTooltipAr = getNotNothingString(messagesAr, "dpf_rangeTooltip", errorInMethod);
+    dpf_part4HeaderAr = getNotNothingString(messagesAr, "dpf_part4Header", errorInMethod);
+    dpf_otherCommentAr = getNotNothingString(messagesAr, "dpf_otherComment", errorInMethod);
+    dpf_finishPart4Ar = getNotNothingString(messagesAr, "dpf_finishPart4", errorInMethod);
+    dpf_congratulationAr = getNotNothingString(messagesAr, "dpf_congratulation", errorInMethod);
+
+    distinctValuesTooltipAr =
+        getNotNothingString(messagesAr, "distinctValuesTooltip", errorInMethod);
+    doWithGraphsAr = getNotNothingString(messagesAr, "doWithGraphs", errorInMethod);
+
+    dtAccessibleAr = getNotNothingString(messagesAr, "dtAccessible", errorInMethod);
+    dtAccessiblePublicAr = getNotNothingString(messagesAr, "dtAccessiblePublic", errorInMethod);
+    dtAccessibleYesAr = getNotNothingString(messagesAr, "dtAccessibleYes", errorInMethod);
+    dtAccessibleGraphsAr = getNotNothingString(messagesAr, "dtAccessibleGraphs", errorInMethod);
+    dtAccessibleNoAr = getNotNothingString(messagesAr, "dtAccessibleNo", errorInMethod);
+    dtAccessibleLogInAr = getNotNothingString(messagesAr, "dtAccessibleLogIn", errorInMethod);
+    dtLogInAr = getNotNothingString(messagesAr, "dtLogIn", errorInMethod);
+    dtDAFAr = getNotNothingString(messagesAr, "dtDAF", errorInMethod);
+    dtFilesAr = getNotNothingString(messagesAr, "dtFiles", errorInMethod);
+    dtMAGAr = getNotNothingString(messagesAr, "dtMAG", errorInMethod);
+    dtSOSAr = getNotNothingString(messagesAr, "dtSOS", errorInMethod);
+    dtSubsetAr = getNotNothingString(messagesAr, "dtSubset", errorInMethod);
+    dtWCSAr = getNotNothingString(messagesAr, "dtWCS", errorInMethod);
+    dtWMSAr = getNotNothingString(messagesAr, "dtWMS", errorInMethod);
+
+    EasierAccessToScientificDataAr =
+        getNotNothingString(messagesAr, "EasierAccessToScientificData", errorInMethod);
+    EDDDatasetIDAr = getNotNothingString(messagesAr, "EDDDatasetID", errorInMethod);
+    EDDFgdc = messagesAr[0].getNotNothingString("EDDFgdc", errorInMethod);
+    EDDFgdcMetadataAr = getNotNothingString(messagesAr, "EDDFgdcMetadata", errorInMethod);
+    EDDFilesAr = getNotNothingString(messagesAr, "EDDFiles", errorInMethod);
+    EDDIso19115 = messagesAr[0].getNotNothingString("EDDIso19115", errorInMethod);
+    EDDIso19115MetadataAr = getNotNothingString(messagesAr, "EDDIso19115Metadata", errorInMethod);
+    EDDMetadataAr = getNotNothingString(messagesAr, "EDDMetadata", errorInMethod);
+    EDDBackgroundAr = getNotNothingString(messagesAr, "EDDBackground", errorInMethod);
+    EDDClickOnSubmitHtmlAr = getNotNothingString(messagesAr, "EDDClickOnSubmitHtml", errorInMethod);
+    EDDInformationAr = getNotNothingString(messagesAr, "EDDInformation", errorInMethod);
+    EDDInstitutionAr = getNotNothingString(messagesAr, "EDDInstitution", errorInMethod);
+    EDDSummaryAr = getNotNothingString(messagesAr, "EDDSummary", errorInMethod);
+    EDDDatasetTitleAr = getNotNothingString(messagesAr, "EDDDatasetTitle", errorInMethod);
+    EDDDownloadDataAr = getNotNothingString(messagesAr, "EDDDownloadData", errorInMethod);
+    EDDMakeAGraphAr = getNotNothingString(messagesAr, "EDDMakeAGraph", errorInMethod);
+    EDDMakeAMapAr = getNotNothingString(messagesAr, "EDDMakeAMap", errorInMethod);
+    EDDFileTypeAr = getNotNothingString(messagesAr, "EDDFileType", errorInMethod);
+    EDDFileTypeInformationAr =
+        getNotNothingString(messagesAr, "EDDFileTypeInformation", errorInMethod);
+    EDDSelectFileTypeAr = getNotNothingString(messagesAr, "EDDSelectFileType", errorInMethod);
+    EDDMinimumAr = getNotNothingString(messagesAr, "EDDMinimum", errorInMethod);
+    EDDMaximumAr = getNotNothingString(messagesAr, "EDDMaximum", errorInMethod);
+    EDDConstraintAr = getNotNothingString(messagesAr, "EDDConstraint", errorInMethod);
+
+    EDDChangedWasnt = messagesAr[0].getNotNothingString("EDDChangedWasnt", errorInMethod);
+    EDDChangedDifferentNVar =
+        messagesAr[0].getNotNothingString("EDDChangedDifferentNVar", errorInMethod);
+    EDDChanged2Different = messagesAr[0].getNotNothingString("EDDChanged2Different", errorInMethod);
+    EDDChanged1Different = messagesAr[0].getNotNothingString("EDDChanged1Different", errorInMethod);
+    EDDChangedCGADifferent =
+        messagesAr[0].getNotNothingString("EDDChangedCGADifferent", errorInMethod);
+    EDDChangedAxesDifferentNVar =
+        messagesAr[0].getNotNothingString("EDDChangedAxesDifferentNVar", errorInMethod);
+    EDDChangedAxes2Different =
+        messagesAr[0].getNotNothingString("EDDChangedAxes2Different", errorInMethod);
+    EDDChangedAxes1Different =
+        messagesAr[0].getNotNothingString("EDDChangedAxes1Different", errorInMethod);
+    EDDChangedNoValue = messagesAr[0].getNotNothingString("EDDChangedNoValue", errorInMethod);
+    EDDChangedTableToGrid =
+        messagesAr[0].getNotNothingString("EDDChangedTableToGrid", errorInMethod);
+
+    EDDSimilarDifferentNVar =
+        messagesAr[0].getNotNothingString("EDDSimilarDifferentNVar", errorInMethod);
+    EDDSimilarDifferent = messagesAr[0].getNotNothingString("EDDSimilarDifferent", errorInMethod);
+
+    EDDGridDownloadTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridDownloadTooltip", errorInMethod);
+    EDDGridDapDescriptionAr =
+        getNotNothingString(messagesAr, "EDDGridDapDescription", errorInMethod);
+    EDDGridDapLongDescriptionAr =
+        getNotNothingString(messagesAr, "EDDGridDapLongDescription", errorInMethod);
+    EDDGridDownloadDataTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridDownloadDataTooltip", errorInMethod);
+    EDDGridDimensionAr = getNotNothingString(messagesAr, "EDDGridDimension", errorInMethod);
+    EDDGridDimensionRangesAr =
+        getNotNothingString(messagesAr, "EDDGridDimensionRanges", errorInMethod);
+    EDDGridFirstAr = getNotNothingString(messagesAr, "EDDGridFirst", errorInMethod);
+    EDDGridLastAr = getNotNothingString(messagesAr, "EDDGridLast", errorInMethod);
+    EDDGridStartAr = getNotNothingString(messagesAr, "EDDGridStart", errorInMethod);
+    EDDGridStopAr = getNotNothingString(messagesAr, "EDDGridStop", errorInMethod);
+    EDDGridStartStopTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridStartStopTooltip", errorInMethod);
+    EDDGridStrideAr = getNotNothingString(messagesAr, "EDDGridStride", errorInMethod);
+    EDDGridNValuesAr = getNotNothingString(messagesAr, "EDDGridNValues", errorInMethod);
+    EDDGridNValuesHtmlAr = getNotNothingString(messagesAr, "EDDGridNValuesHtml", errorInMethod);
+    EDDGridSpacingAr = getNotNothingString(messagesAr, "EDDGridSpacing", errorInMethod);
+    EDDGridJustOneValueAr = getNotNothingString(messagesAr, "EDDGridJustOneValue", errorInMethod);
+    EDDGridEvenAr = getNotNothingString(messagesAr, "EDDGridEven", errorInMethod);
+    EDDGridUnevenAr = getNotNothingString(messagesAr, "EDDGridUneven", errorInMethod);
+    EDDGridDimensionTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridDimensionTooltip", errorInMethod);
+    EDDGridDimensionFirstTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridDimensionFirstTooltip", errorInMethod);
+    EDDGridDimensionLastTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridDimensionLastTooltip", errorInMethod);
+    EDDGridVarHasDimTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridVarHasDimTooltip", errorInMethod);
+    EDDGridSSSTooltipAr = getNotNothingString(messagesAr, "EDDGridSSSTooltip", errorInMethod);
+    EDDGridStartTooltipAr = getNotNothingString(messagesAr, "EDDGridStartTooltip", errorInMethod);
+    EDDGridStopTooltipAr = getNotNothingString(messagesAr, "EDDGridStopTooltip", errorInMethod);
+    EDDGridStrideTooltipAr = getNotNothingString(messagesAr, "EDDGridStrideTooltip", errorInMethod);
+    EDDGridSpacingTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridSpacingTooltip", errorInMethod);
+    EDDGridGridVariableHtmlAr =
+        getNotNothingString(messagesAr, "EDDGridGridVariableHtml", errorInMethod);
+    EDDGridCheckAllAr = getNotNothingString(messagesAr, "EDDGridCheckAll", errorInMethod);
+    EDDGridCheckAllTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridCheckAllTooltip", errorInMethod);
+    EDDGridUncheckAllAr = getNotNothingString(messagesAr, "EDDGridUncheckAll", errorInMethod);
+    EDDGridUncheckAllTooltipAr =
+        getNotNothingString(messagesAr, "EDDGridUncheckAllTooltip", errorInMethod);
+
+    // default EDDGrid...Example
+    EDDGridErddapUrlExample =
+        messagesAr[0].getNotNothingString("EDDGridErddapUrlExample", errorInMethod);
+    EDDGridIdExample = messagesAr[0].getNotNothingString("EDDGridIdExample", errorInMethod);
+    EDDGridDimensionExample =
+        messagesAr[0].getNotNothingString("EDDGridDimensionExample", errorInMethod);
+    EDDGridNoHyperExample =
+        messagesAr[0].getNotNothingString("EDDGridNoHyperExample", errorInMethod);
+    EDDGridDimNamesExample =
+        messagesAr[0].getNotNothingString("EDDGridDimNamesExample", errorInMethod);
+    EDDGridDataTimeExample =
+        messagesAr[0].getNotNothingString("EDDGridDataTimeExample", errorInMethod);
+    EDDGridDataValueExample =
+        messagesAr[0].getNotNothingString("EDDGridDataValueExample", errorInMethod);
+    EDDGridDataIndexExample =
+        messagesAr[0].getNotNothingString("EDDGridDataIndexExample", errorInMethod);
+    EDDGridGraphExample = messagesAr[0].getNotNothingString("EDDGridGraphExample", errorInMethod);
+    EDDGridMapExample = messagesAr[0].getNotNothingString("EDDGridMapExample", errorInMethod);
+    EDDGridMatlabPlotExample =
+        messagesAr[0].getNotNothingString("EDDGridMatlabPlotExample", errorInMethod);
+
+    // admin provides EDDGrid...Example
+    EDDGridErddapUrlExample =
+        getSetupEVString(setup, ev, "EDDGridErddapUrlExample", EDDGridErddapUrlExample);
+    EDDGridIdExample = getSetupEVString(setup, ev, "EDDGridIdExample", EDDGridIdExample);
+    EDDGridDimensionExample =
+        getSetupEVString(setup, ev, "EDDGridDimensionExample", EDDGridDimensionExample);
+    EDDGridNoHyperExample =
+        getSetupEVString(setup, ev, "EDDGridNoHyperExample", EDDGridNoHyperExample);
+    EDDGridDimNamesExample =
+        getSetupEVString(setup, ev, "EDDGridDimNamesExample", EDDGridDimNamesExample);
+    EDDGridDataIndexExample =
+        getSetupEVString(setup, ev, "EDDGridDataIndexExample", EDDGridDataIndexExample);
+    EDDGridDataValueExample =
+        getSetupEVString(setup, ev, "EDDGridDataValueExample", EDDGridDataValueExample);
+    EDDGridDataTimeExample =
+        getSetupEVString(setup, ev, "EDDGridDataTimeExample", EDDGridDataTimeExample);
+    EDDGridGraphExample = getSetupEVString(setup, ev, "EDDGridGraphExample", EDDGridGraphExample);
+    EDDGridMapExample = getSetupEVString(setup, ev, "EDDGridMapExample", EDDGridMapExample);
+    EDDGridMatlabPlotExample =
+        getSetupEVString(setup, ev, "EDDGridMatlabPlotExample", EDDGridMatlabPlotExample);
+
+    // variants encoded to be Html Examples
+    EDDGridDimensionExampleHE = XML.encodeAsHTML(EDDGridDimensionExample);
+    EDDGridDataIndexExampleHE = XML.encodeAsHTML(EDDGridDataIndexExample);
+    EDDGridDataValueExampleHE = XML.encodeAsHTML(EDDGridDataValueExample);
+    EDDGridDataTimeExampleHE = XML.encodeAsHTML(EDDGridDataTimeExample);
+    EDDGridGraphExampleHE = XML.encodeAsHTML(EDDGridGraphExample);
+    EDDGridMapExampleHE = XML.encodeAsHTML(EDDGridMapExample);
+
+    // variants encoded to be Html Attributes
+    try {
+      EDDGridDimensionExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDimensionExample));
+      EDDGridDataIndexExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataIndexExample));
+      EDDGridDataValueExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataValueExample));
+      EDDGridDataTimeExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataTimeExample));
+      EDDGridGraphExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridGraphExample));
+      EDDGridMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridMapExample));
+    } catch (Exception e) {
+      String2.log("EDMessages error percent encoding\n" + e.toString());
+    }
+
+    EDDTableConstraintsAr = getNotNothingString(messagesAr, "EDDTableConstraints", errorInMethod);
+    EDDTableDapDescriptionAr =
+        getNotNothingString(messagesAr, "EDDTableDapDescription", errorInMethod);
+    EDDTableDapLongDescriptionAr =
+        getNotNothingString(messagesAr, "EDDTableDapLongDescription", errorInMethod);
+    EDDTableDownloadDataTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableDownloadDataTooltip", errorInMethod);
+    EDDTableTabularDatasetTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableTabularDatasetTooltip", errorInMethod);
+    EDDTableVariableAr = getNotNothingString(messagesAr, "EDDTableVariable", errorInMethod);
+    EDDTableCheckAllAr = getNotNothingString(messagesAr, "EDDTableCheckAll", errorInMethod);
+    EDDTableCheckAllTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableCheckAllTooltip", errorInMethod);
+    EDDTableUncheckAllAr = getNotNothingString(messagesAr, "EDDTableUncheckAll", errorInMethod);
+    EDDTableUncheckAllTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableUncheckAllTooltip", errorInMethod);
+    EDDTableMinimumTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableMinimumTooltip", errorInMethod);
+    EDDTableMaximumTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableMaximumTooltip", errorInMethod);
+    EDDTableCheckTheVariablesAr =
+        getNotNothingString(messagesAr, "EDDTableCheckTheVariables", errorInMethod);
+    EDDTableSelectAnOperatorAr =
+        getNotNothingString(messagesAr, "EDDTableSelectAnOperator", errorInMethod);
+    EDDTableFromEDDGridSummaryAr =
+        getNotNothingString(messagesAr, "EDDTableFromEDDGridSummary", errorInMethod);
+    EDDTableOptConstraint1HtmlAr =
+        getNotNothingString(messagesAr, "EDDTableOptConstraint1Html", errorInMethod);
+    EDDTableOptConstraint2HtmlAr =
+        getNotNothingString(messagesAr, "EDDTableOptConstraint2Html", errorInMethod);
+    EDDTableOptConstraintVarAr =
+        getNotNothingString(messagesAr, "EDDTableOptConstraintVar", errorInMethod);
+    EDDTableNumericConstraintTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableNumericConstraintTooltip", errorInMethod);
+    EDDTableStringConstraintTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableStringConstraintTooltip", errorInMethod);
+    EDDTableTimeConstraintTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableTimeConstraintTooltip", errorInMethod);
+    EDDTableConstraintTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableConstraintTooltip", errorInMethod);
+    EDDTableSelectConstraintTooltipAr =
+        getNotNothingString(messagesAr, "EDDTableSelectConstraintTooltip", errorInMethod);
+
+    // default EDDGrid...Example
+    EDDTableErddapUrlExample =
+        messagesAr[0].getNotNothingString("EDDTableErddapUrlExample", errorInMethod);
+    EDDTableIdExample = messagesAr[0].getNotNothingString("EDDTableIdExample", errorInMethod);
+    EDDTableVariablesExample =
+        messagesAr[0].getNotNothingString("EDDTableVariablesExample", errorInMethod);
+    EDDTableConstraintsExample =
+        messagesAr[0].getNotNothingString("EDDTableConstraintsExample", errorInMethod);
+    EDDTableDataValueExample =
+        messagesAr[0].getNotNothingString("EDDTableDataValueExample", errorInMethod);
+    EDDTableDataTimeExample =
+        messagesAr[0].getNotNothingString("EDDTableDataTimeExample", errorInMethod);
+    EDDTableGraphExample = messagesAr[0].getNotNothingString("EDDTableGraphExample", errorInMethod);
+    EDDTableMapExample = messagesAr[0].getNotNothingString("EDDTableMapExample", errorInMethod);
+    EDDTableMatlabPlotExample =
+        messagesAr[0].getNotNothingString("EDDTableMatlabPlotExample", errorInMethod);
+
+    // admin provides EDDGrid...Example
+    EDDTableErddapUrlExample =
+        getSetupEVString(setup, ev, "EDDTableErddapUrlExample", EDDTableErddapUrlExample);
+    EDDTableIdExample = getSetupEVString(setup, ev, "EDDTableIdExample", EDDTableIdExample);
+    EDDTableVariablesExample =
+        getSetupEVString(setup, ev, "EDDTableVariablesExample", EDDTableVariablesExample);
+    EDDTableConstraintsExample =
+        getSetupEVString(setup, ev, "EDDTableConstraintsExample", EDDTableConstraintsExample);
+    EDDTableDataValueExample =
+        getSetupEVString(setup, ev, "EDDTableDataValueExample", EDDTableDataValueExample);
+    EDDTableDataTimeExample =
+        getSetupEVString(setup, ev, "EDDTableDataTimeExample", EDDTableDataTimeExample);
+    EDDTableGraphExample =
+        getSetupEVString(setup, ev, "EDDTableGraphExample", EDDTableGraphExample);
+    EDDTableMapExample = getSetupEVString(setup, ev, "EDDTableMapExample", EDDTableMapExample);
+    EDDTableMatlabPlotExample =
+        getSetupEVString(setup, ev, "EDDTableMatlabPlotExample", EDDTableMatlabPlotExample);
+
+    // variants encoded to be Html Examples
+    EDDTableConstraintsExampleHE = XML.encodeAsHTML(EDDTableConstraintsExample);
+    EDDTableDataTimeExampleHE = XML.encodeAsHTML(EDDTableDataTimeExample);
+    EDDTableDataValueExampleHE = XML.encodeAsHTML(EDDTableDataValueExample);
+    EDDTableGraphExampleHE = XML.encodeAsHTML(EDDTableGraphExample);
+    EDDTableMapExampleHE = XML.encodeAsHTML(EDDTableMapExample);
+
+    try {
+      // variants encoded to be Html Attributes
+      EDDTableConstraintsExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableConstraintsExample));
+      EDDTableDataTimeExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataTimeExample));
+      EDDTableDataValueExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataValueExample));
+      EDDTableGraphExampleHA =
+          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableGraphExample));
+      EDDTableMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableMapExample));
+    } catch (Exception e) {
+      String2.log("EDMessages error percent encoding\n" + e.toString());
+    }
+
+    EDDTableFromHttpGetDatasetDescription =
+        XML.decodeEntities( // because this is used as plain text
+            messagesAr[0].getNotNothingString(
+                "EDDTableFromHttpGetDatasetDescription", errorInMethod));
+    EDDTableFromHttpGetAuthorDescription =
+        messagesAr[0].getNotNothingString("EDDTableFromHttpGetAuthorDescription", errorInMethod);
+    EDDTableFromHttpGetTimestampDescription =
+        messagesAr[0].getNotNothingString("EDDTableFromHttpGetTimestampDescription", errorInMethod);
+
+    errorTitleAr = getNotNothingString(messagesAr, "errorTitle", errorInMethod);
+    erddapIsAr = getNotNothingString(messagesAr, "erddapIs", errorInMethod);
+    erddapVersionHTMLAr = getNotNothingString(messagesAr, "erddapVersionHTML", errorInMethod);
+    errorRequestUrlAr = getNotNothingString(messagesAr, "errorRequestUrl", errorInMethod);
+    errorRequestQueryAr = getNotNothingString(messagesAr, "errorRequestQuery", errorInMethod);
+    errorTheErrorAr = getNotNothingString(messagesAr, "errorTheError", errorInMethod);
+    errorCopyFromAr = getNotNothingString(messagesAr, "errorCopyFrom", errorInMethod);
+    errorFileNotFoundAr = getNotNothingString(messagesAr, "errorFileNotFound", errorInMethod);
+    errorFileNotFoundImageAr =
+        getNotNothingString(messagesAr, "errorFileNotFoundImage", errorInMethod);
+    errorInternalAr = getNotNothingString(messagesAr, "errorInternal", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) errorInternalAr[tl] += " ";
+
+    errorJsonpFunctionNameAr =
+        getNotNothingString(messagesAr, "errorJsonpFunctionName", errorInMethod);
+    errorJsonpNotAllowedAr = getNotNothingString(messagesAr, "errorJsonpNotAllowed", errorInMethod);
+    errorMoreThan2GBAr = getNotNothingString(messagesAr, "errorMoreThan2GB", errorInMethod);
+    errorNotFoundAr = getNotNothingString(messagesAr, "errorNotFound", errorInMethod);
+    errorNotFoundInAr = getNotNothingString(messagesAr, "errorNotFoundIn", errorInMethod);
+    errorOdvLLTGridAr = getNotNothingString(messagesAr, "errorOdvLLTGrid", errorInMethod);
+    errorOdvLLTTableAr = getNotNothingString(messagesAr, "errorOdvLLTTable", errorInMethod);
+    errorOnWebPageAr = getNotNothingString(messagesAr, "errorOnWebPage", errorInMethod);
+
+    extensionsNoRangeRequests =
+        StringArray.arrayFromCSV(
+            messagesAr[0].getNotNothingString("extensionsNoRangeRequests", errorInMethod),
+            ",",
+            true,
+            false); // trim, keepNothing
+
+    externalLinkAr = getNotNothingString(messagesAr, "externalLink", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) externalLinkAr[tl] = " " + externalLinkAr[tl];
+
+    externalWebSiteAr = getNotNothingString(messagesAr, "externalWebSite", errorInMethod);
+    fileHelp_ascAr = getNotNothingString(messagesAr, "fileHelp_asc", errorInMethod);
+    fileHelp_csvAr = getNotNothingString(messagesAr, "fileHelp_csv", errorInMethod);
+    fileHelp_csvpAr = getNotNothingString(messagesAr, "fileHelp_csvp", errorInMethod);
+    fileHelp_csv0Ar = getNotNothingString(messagesAr, "fileHelp_csv0", errorInMethod);
+    fileHelp_dataTableAr = getNotNothingString(messagesAr, "fileHelp_dataTable", errorInMethod);
+    fileHelp_dasAr = getNotNothingString(messagesAr, "fileHelp_das", errorInMethod);
+    fileHelp_ddsAr = getNotNothingString(messagesAr, "fileHelp_dds", errorInMethod);
+    fileHelp_dodsAr = getNotNothingString(messagesAr, "fileHelp_dods", errorInMethod);
+    fileHelpGrid_esriAsciiAr =
+        getNotNothingString(messagesAr, "fileHelpGrid_esriAscii", errorInMethod);
+    fileHelpTable_esriCsvAr =
+        getNotNothingString(messagesAr, "fileHelpTable_esriCsv", errorInMethod);
+    fileHelp_fgdcAr = getNotNothingString(messagesAr, "fileHelp_fgdc", errorInMethod);
+    fileHelp_geoJsonAr = getNotNothingString(messagesAr, "fileHelp_geoJson", errorInMethod);
+    fileHelp_graphAr = getNotNothingString(messagesAr, "fileHelp_graph", errorInMethod);
+    fileHelpGrid_helpAr = getNotNothingString(messagesAr, "fileHelpGrid_help", errorInMethod);
+    fileHelpTable_helpAr = getNotNothingString(messagesAr, "fileHelpTable_help", errorInMethod);
+    fileHelp_htmlAr = getNotNothingString(messagesAr, "fileHelp_html", errorInMethod);
+    fileHelp_htmlTableAr = getNotNothingString(messagesAr, "fileHelp_htmlTable", errorInMethod);
+    fileHelp_iso19115Ar = getNotNothingString(messagesAr, "fileHelp_iso19115", errorInMethod);
+    fileHelp_itxGridAr = getNotNothingString(messagesAr, "fileHelp_itxGrid", errorInMethod);
+    fileHelp_itxTableAr = getNotNothingString(messagesAr, "fileHelp_itxTable", errorInMethod);
+    fileHelp_jsonAr = getNotNothingString(messagesAr, "fileHelp_json", errorInMethod);
+    fileHelp_jsonlCSV1Ar = getNotNothingString(messagesAr, "fileHelp_jsonlCSV1", errorInMethod);
+    fileHelp_jsonlCSVAr = getNotNothingString(messagesAr, "fileHelp_jsonlCSV", errorInMethod);
+    fileHelp_jsonlKVPAr = getNotNothingString(messagesAr, "fileHelp_jsonlKVP", errorInMethod);
+    fileHelp_matAr = getNotNothingString(messagesAr, "fileHelp_mat", errorInMethod);
+    fileHelpGrid_nc3Ar = getNotNothingString(messagesAr, "fileHelpGrid_nc3", errorInMethod);
+    fileHelpGrid_nc4Ar = getNotNothingString(messagesAr, "fileHelpGrid_nc4", errorInMethod);
+    fileHelpTable_nc3Ar = getNotNothingString(messagesAr, "fileHelpTable_nc3", errorInMethod);
+    fileHelpTable_nc4Ar = getNotNothingString(messagesAr, "fileHelpTable_nc4", errorInMethod);
+    fileHelp_nc3HeaderAr = getNotNothingString(messagesAr, "fileHelp_nc3Header", errorInMethod);
+    fileHelp_nc4HeaderAr = getNotNothingString(messagesAr, "fileHelp_nc4Header", errorInMethod);
+    fileHelp_nccsvAr = getNotNothingString(messagesAr, "fileHelp_nccsv", errorInMethod);
+    fileHelp_nccsvMetadataAr =
+        getNotNothingString(messagesAr, "fileHelp_nccsvMetadata", errorInMethod);
+    fileHelp_ncCFAr = getNotNothingString(messagesAr, "fileHelp_ncCF", errorInMethod);
+    fileHelp_ncCFHeaderAr = getNotNothingString(messagesAr, "fileHelp_ncCFHeader", errorInMethod);
+    fileHelp_ncCFMAAr = getNotNothingString(messagesAr, "fileHelp_ncCFMA", errorInMethod);
+    fileHelp_ncCFMAHeaderAr =
+        getNotNothingString(messagesAr, "fileHelp_ncCFMAHeader", errorInMethod);
+    fileHelp_ncmlAr = getNotNothingString(messagesAr, "fileHelp_ncml", errorInMethod);
+    fileHelp_ncoJsonAr = getNotNothingString(messagesAr, "fileHelp_ncoJson", errorInMethod);
+    fileHelpGrid_odvTxtAr = getNotNothingString(messagesAr, "fileHelpGrid_odvTxt", errorInMethod);
+    fileHelpTable_odvTxtAr = getNotNothingString(messagesAr, "fileHelpTable_odvTxt", errorInMethod);
+    fileHelp_parquetAr = getNotNothingString(messagesAr, "fileHelp_parquet", errorInMethod);
+    fileHelp_parquet_with_metaAr =
+        getNotNothingString(messagesAr, "fileHelp_parquet_with_meta", errorInMethod);
+    fileHelp_subsetAr = getNotNothingString(messagesAr, "fileHelp_subset", errorInMethod);
+    fileHelp_timeGapsAr = getNotNothingString(messagesAr, "fileHelp_timeGaps", errorInMethod);
+    fileHelp_tsvAr = getNotNothingString(messagesAr, "fileHelp_tsv", errorInMethod);
+    fileHelp_tsvpAr = getNotNothingString(messagesAr, "fileHelp_tsvp", errorInMethod);
+    fileHelp_tsv0Ar = getNotNothingString(messagesAr, "fileHelp_tsv0", errorInMethod);
+    fileHelp_wavAr = getNotNothingString(messagesAr, "fileHelp_wav", errorInMethod);
+    fileHelp_xhtmlAr = getNotNothingString(messagesAr, "fileHelp_xhtml", errorInMethod);
+    fileHelp_geotifAr = getNotNothingString(messagesAr, "fileHelp_geotif", errorInMethod);
+    fileHelpGrid_kmlAr = getNotNothingString(messagesAr, "fileHelpGrid_kml", errorInMethod);
+    fileHelpTable_kmlAr = getNotNothingString(messagesAr, "fileHelpTable_kml", errorInMethod);
+    fileHelp_smallPdfAr = getNotNothingString(messagesAr, "fileHelp_smallPdf", errorInMethod);
+    fileHelp_pdfAr = getNotNothingString(messagesAr, "fileHelp_pdf", errorInMethod);
+    fileHelp_largePdfAr = getNotNothingString(messagesAr, "fileHelp_largePdf", errorInMethod);
+    fileHelp_smallPngAr = getNotNothingString(messagesAr, "fileHelp_smallPng", errorInMethod);
+    fileHelp_pngAr = getNotNothingString(messagesAr, "fileHelp_png", errorInMethod);
+    fileHelp_largePngAr = getNotNothingString(messagesAr, "fileHelp_largePng", errorInMethod);
+    fileHelp_transparentPngAr =
+        getNotNothingString(messagesAr, "fileHelp_transparentPng", errorInMethod);
+    filesDescriptionAr = getNotNothingString(messagesAr, "filesDescription", errorInMethod);
+    filesDocumentationAr = getNotNothingString(messagesAr, "filesDocumentation", errorInMethod);
+    filesSortAr = getNotNothingString(messagesAr, "filesSort", errorInMethod);
+    filesWarningAr = getNotNothingString(messagesAr, "filesWarning", errorInMethod);
+    findOutChangeAr = getNotNothingString(messagesAr, "findOutChange", errorInMethod);
+    FIPSCountyCodesAr = getNotNothingString(messagesAr, "FIPSCountyCodes", errorInMethod);
+    forSOSUseAr = getNotNothingString(messagesAr, "forSOSUse", errorInMethod);
+    forWCSUseAr = getNotNothingString(messagesAr, "forWCSUse", errorInMethod);
+    forWMSUseAr = getNotNothingString(messagesAr, "forWMSUse", errorInMethod);
+    functionsAr = getNotNothingString(messagesAr, "functions", errorInMethod);
+    functionTooltipAr = getNotNothingString(messagesAr, "functionTooltip", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++)
+      functionTooltipAr[tl] = MessageFormat.format(functionTooltipAr[tl], "distinct()");
+
+    functionDistinctCheckAr =
+        getNotNothingString(messagesAr, "functionDistinctCheck", errorInMethod);
+    functionDistinctTooltipAr =
+        getNotNothingString(messagesAr, "functionDistinctTooltip", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++)
+      functionDistinctTooltipAr[tl] =
+          MessageFormat.format(functionDistinctTooltipAr[tl], "distinct()");
+
+    functionOrderByExtraAr = getNotNothingString(messagesAr, "functionOrderByExtra", errorInMethod);
+    functionOrderByTooltipAr =
+        getNotNothingString(messagesAr, "functionOrderByTooltip", errorInMethod);
+    functionOrderBySortAr = getNotNothingString(messagesAr, "functionOrderBySort", errorInMethod);
+    functionOrderBySort1Ar = getNotNothingString(messagesAr, "functionOrderBySort1", errorInMethod);
+    functionOrderBySort2Ar = getNotNothingString(messagesAr, "functionOrderBySort2", errorInMethod);
+    functionOrderBySort3Ar = getNotNothingString(messagesAr, "functionOrderBySort3", errorInMethod);
+    functionOrderBySort4Ar = getNotNothingString(messagesAr, "functionOrderBySort4", errorInMethod);
+    functionOrderBySortLeastAr =
+        getNotNothingString(messagesAr, "functionOrderBySortLeast", errorInMethod);
+    functionOrderBySortRowMaxAr =
+        getNotNothingString(messagesAr, "functionOrderBySortRowMax", errorInMethod);
+    generatedAtAr = getNotNothingString(messagesAr, "generatedAt", errorInMethod);
+    geoServicesDescriptionAr =
+        getNotNothingString(messagesAr, "geoServicesDescription", errorInMethod);
+    getStartedHtmlAr = getNotNothingString(messagesAr, "getStartedHtml", errorInMethod);
+    helpAr = getNotNothingString(messagesAr, "help", errorInMethod);
+    htmlTableMaxMessageAr = getNotNothingString(messagesAr, "htmlTableMaxMessage", errorInMethod);
+
+    imageDataCourtesyOfAr = getNotNothingString(messagesAr, "imageDataCourtesyOf", errorInMethod);
+    imageWidths =
+        String2.toIntArray(
+            String2.split(messagesAr[0].getNotNothingString("imageWidths", errorInMethod), ','));
+    imageHeights =
+        String2.toIntArray(
+            String2.split(messagesAr[0].getNotNothingString("imageHeights", errorInMethod), ','));
+    imagesEmbedAr = getNotNothingString(messagesAr, "imagesEmbed", errorInMethod);
+    indexViewAllAr = getNotNothingString(messagesAr, "indexViewAll", errorInMethod);
+    indexSearchWithAr = getNotNothingString(messagesAr, "indexSearchWith", errorInMethod);
+    indexDevelopersSearchAr =
+        getNotNothingString(messagesAr, "indexDevelopersSearch", errorInMethod);
+    indexProtocolAr = getNotNothingString(messagesAr, "indexProtocol", errorInMethod);
+    indexDescriptionAr = getNotNothingString(messagesAr, "indexDescription", errorInMethod);
+    indexDatasetsAr = getNotNothingString(messagesAr, "indexDatasets", errorInMethod);
+    indexDocumentationAr = getNotNothingString(messagesAr, "indexDocumentation", errorInMethod);
+    indexRESTfulSearchAr = getNotNothingString(messagesAr, "indexRESTfulSearch", errorInMethod);
+    indexAllDatasetsSearchAr =
+        getNotNothingString(messagesAr, "indexAllDatasetsSearch", errorInMethod);
+    indexOpenSearchAr = getNotNothingString(messagesAr, "indexOpenSearch", errorInMethod);
+    indexServicesAr = getNotNothingString(messagesAr, "indexServices", errorInMethod);
+    indexDescribeServicesAr =
+        getNotNothingString(messagesAr, "indexDescribeServices", errorInMethod);
+    indexMetadataAr = getNotNothingString(messagesAr, "indexMetadata", errorInMethod);
+    indexWAF1Ar = getNotNothingString(messagesAr, "indexWAF1", errorInMethod);
+    indexWAF2Ar = getNotNothingString(messagesAr, "indexWAF2", errorInMethod);
+    indexConvertersAr = getNotNothingString(messagesAr, "indexConverters", errorInMethod);
+    indexDescribeConvertersAr =
+        getNotNothingString(messagesAr, "indexDescribeConverters", errorInMethod);
+    infoAboutFromAr = getNotNothingString(messagesAr, "infoAboutFrom", errorInMethod);
+    infoTableTitleHtmlAr = getNotNothingString(messagesAr, "infoTableTitleHtml", errorInMethod);
+    infoRequestFormAr = getNotNothingString(messagesAr, "infoRequestForm", errorInMethod);
+    informationAr = getNotNothingString(messagesAr, "information", errorInMethod);
+    inotifyFixAr = getNotNothingString(messagesAr, "inotifyFix", errorInMethod);
+    inotifyFixCommands = messagesAr[0].getNotNothingString("inotifyFixCommands", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++)
+      inotifyFixAr[tl] = MessageFormat.format(inotifyFixAr[tl], inotifyFixCommands);
+    interpolateAr = getNotNothingString(messagesAr, "interpolate", errorInMethod);
+    javaProgramsHTMLAr = getNotNothingString(messagesAr, "javaProgramsHTML", errorInMethod);
+    justGenerateAndViewAr = getNotNothingString(messagesAr, "justGenerateAndView", errorInMethod);
+    justGenerateAndViewTooltipAr =
+        getNotNothingString(messagesAr, "justGenerateAndViewTooltip", errorInMethod);
+    justGenerateAndViewUrlAr =
+        getNotNothingString(messagesAr, "justGenerateAndViewUrl", errorInMethod);
+    justGenerateAndViewGraphUrlTooltipAr =
+        getNotNothingString(messagesAr, "justGenerateAndViewGraphUrlTooltip", errorInMethod);
+    keywordsAr = getNotNothingString(messagesAr, "keywords", errorInMethod);
+    langCodeAr = getNotNothingString(messagesAr, "langCode", errorInMethod);
+
+    legal = messagesAr[0].getNotNothingString("legal", errorInMethod);
+    legal = getSetupEVString(setup, ev, "legal", legal); // optionally in setup.xml
+    legalNoticesAr = getNotNothingString(messagesAr, "legalNotices", errorInMethod);
+    legalNoticesTitleAr = getNotNothingString(messagesAr, "legalNoticesTitle", errorInMethod);
+
+    legendTitle1 = messagesAr[0].getString("legendTitle1", "");
+    legendTitle2 = messagesAr[0].getString("legendTitle2", "");
+    legendTitle1 =
+        getSetupEVString(setup, ev, "legendTitle1", legendTitle1); // optionally in setup.xml
+    legendTitle2 =
+        getSetupEVString(setup, ev, "legendTitle2", legendTitle2); // optionally in setup.xml
+
+    licenseAr = getNotNothingString(messagesAr, "license", errorInMethod);
+    likeThisAr = getNotNothingString(messagesAr, "likeThis", errorInMethod);
+    listAllAr = getNotNothingString(messagesAr, "listAll", errorInMethod);
+    listOfDatasetsAr = getNotNothingString(messagesAr, "listOfDatasets", errorInMethod);
+    LogInAr = getNotNothingString(messagesAr, "LogIn", errorInMethod);
+    loginAr = getNotNothingString(messagesAr, "login", errorInMethod);
+    loginHTMLAr = getNotNothingString(messagesAr, "loginHTML", errorInMethod);
+    loginAttemptBlockedAr = getNotNothingString(messagesAr, "loginAttemptBlocked", errorInMethod);
+    loginDescribeCustomAr = getNotNothingString(messagesAr, "loginDescribeCustom", errorInMethod);
+    loginDescribeEmailAr = getNotNothingString(messagesAr, "loginDescribeEmail", errorInMethod);
+    loginDescribeGoogleAr = getNotNothingString(messagesAr, "loginDescribeGoogle", errorInMethod);
+    loginDescribeOrcidAr = getNotNothingString(messagesAr, "loginDescribeOrcid", errorInMethod);
+    loginDescribeOauth2Ar = getNotNothingString(messagesAr, "loginDescribeOauth2", errorInMethod);
+    loginCanNotAr = getNotNothingString(messagesAr, "loginCanNot", errorInMethod);
+    loginAreNotAr = getNotNothingString(messagesAr, "loginAreNot", errorInMethod);
+    loginToLogInAr = getNotNothingString(messagesAr, "loginToLogIn", errorInMethod);
+    loginEmailAddressAr = getNotNothingString(messagesAr, "loginEmailAddress", errorInMethod);
+    loginYourEmailAddressAr =
+        getNotNothingString(messagesAr, "loginYourEmailAddress", errorInMethod);
+    loginUserNameAr = getNotNothingString(messagesAr, "loginUserName", errorInMethod);
+    loginPasswordAr = getNotNothingString(messagesAr, "loginPassword", errorInMethod);
+    loginUserNameAndPasswordAr =
+        getNotNothingString(messagesAr, "loginUserNameAndPassword", errorInMethod);
+    loginGoogleSignInAr = getNotNothingString(messagesAr, "loginGoogleSignIn", errorInMethod);
+    loginOrcidSignInAr = getNotNothingString(messagesAr, "loginOrcidSignIn", errorInMethod);
+    loginErddapAr = getNotNothingString(messagesAr, "loginErddap", errorInMethod);
+    loginOpenIDAr = getNotNothingString(messagesAr, "loginOpenID", errorInMethod);
+    loginOpenIDOrAr = getNotNothingString(messagesAr, "loginOpenIDOr", errorInMethod);
+    loginOpenIDCreateAr = getNotNothingString(messagesAr, "loginOpenIDCreate", errorInMethod);
+    loginOpenIDFreeAr = getNotNothingString(messagesAr, "loginOpenIDFree", errorInMethod);
+    loginOpenIDSameAr = getNotNothingString(messagesAr, "loginOpenIDSame", errorInMethod);
+    loginAsAr = getNotNothingString(messagesAr, "loginAs", errorInMethod);
+    loginPartwayAsAr = getNotNothingString(messagesAr, "loginPartwayAs", errorInMethod);
+    loginFailedAr = getNotNothingString(messagesAr, "loginFailed", errorInMethod);
+    loginSucceededAr = getNotNothingString(messagesAr, "loginSucceeded", errorInMethod);
+    loginInvalidAr = getNotNothingString(messagesAr, "loginInvalid", errorInMethod);
+    loginNotAr = getNotNothingString(messagesAr, "loginNot", errorInMethod);
+    loginBackAr = getNotNothingString(messagesAr, "loginBack", errorInMethod);
+    loginProblemExactAr = getNotNothingString(messagesAr, "loginProblemExact", errorInMethod);
+    loginProblemExpireAr = getNotNothingString(messagesAr, "loginProblemExpire", errorInMethod);
+    loginProblemGoogleAgainAr =
+        getNotNothingString(messagesAr, "loginProblemGoogleAgain", errorInMethod);
+    loginProblemOrcidAgainAr =
+        getNotNothingString(messagesAr, "loginProblemOrcidAgain", errorInMethod);
+    loginProblemOauth2AgainAr =
+        getNotNothingString(messagesAr, "loginProblemOauth2Again", errorInMethod);
+    loginProblemSameBrowserAr =
+        getNotNothingString(messagesAr, "loginProblemSameBrowser", errorInMethod);
+    loginProblem3TimesAr = getNotNothingString(messagesAr, "loginProblem3Times", errorInMethod);
+    loginProblemsAr = getNotNothingString(messagesAr, "loginProblems", errorInMethod);
+    loginProblemsAfterAr = getNotNothingString(messagesAr, "loginProblemsAfter", errorInMethod);
+    loginPublicAccessAr = getNotNothingString(messagesAr, "loginPublicAccess", errorInMethod);
+    LogOutAr = getNotNothingString(messagesAr, "LogOut", errorInMethod);
+    logoutAr = getNotNothingString(messagesAr, "logout", errorInMethod);
+    logoutOpenIDAr = getNotNothingString(messagesAr, "logoutOpenID", errorInMethod);
+    logoutSuccessAr = getNotNothingString(messagesAr, "logoutSuccess", errorInMethod);
+    magAr = getNotNothingString(messagesAr, "mag", errorInMethod);
+    magAxisXAr = getNotNothingString(messagesAr, "magAxisX", errorInMethod);
+    magAxisYAr = getNotNothingString(messagesAr, "magAxisY", errorInMethod);
+    magAxisColorAr = getNotNothingString(messagesAr, "magAxisColor", errorInMethod);
+    magAxisStickXAr = getNotNothingString(messagesAr, "magAxisStickX", errorInMethod);
+    magAxisStickYAr = getNotNothingString(messagesAr, "magAxisStickY", errorInMethod);
+    magAxisVectorXAr = getNotNothingString(messagesAr, "magAxisVectorX", errorInMethod);
+    magAxisVectorYAr = getNotNothingString(messagesAr, "magAxisVectorY", errorInMethod);
+    magAxisHelpGraphXAr = getNotNothingString(messagesAr, "magAxisHelpGraphX", errorInMethod);
+    magAxisHelpGraphYAr = getNotNothingString(messagesAr, "magAxisHelpGraphY", errorInMethod);
+    magAxisHelpMarkerColorAr =
+        getNotNothingString(messagesAr, "magAxisHelpMarkerColor", errorInMethod);
+    magAxisHelpSurfaceColorAr =
+        getNotNothingString(messagesAr, "magAxisHelpSurfaceColor", errorInMethod);
+    magAxisHelpStickXAr = getNotNothingString(messagesAr, "magAxisHelpStickX", errorInMethod);
+    magAxisHelpStickYAr = getNotNothingString(messagesAr, "magAxisHelpStickY", errorInMethod);
+    magAxisHelpMapXAr = getNotNothingString(messagesAr, "magAxisHelpMapX", errorInMethod);
+    magAxisHelpMapYAr = getNotNothingString(messagesAr, "magAxisHelpMapY", errorInMethod);
+    magAxisHelpVectorXAr = getNotNothingString(messagesAr, "magAxisHelpVectorX", errorInMethod);
+    magAxisHelpVectorYAr = getNotNothingString(messagesAr, "magAxisHelpVectorY", errorInMethod);
+    magAxisVarHelpAr = getNotNothingString(messagesAr, "magAxisVarHelp", errorInMethod);
+    magAxisVarHelpGridAr = getNotNothingString(messagesAr, "magAxisVarHelpGrid", errorInMethod);
+    magConstraintHelpAr = getNotNothingString(messagesAr, "magConstraintHelp", errorInMethod);
+    magDocumentationAr = getNotNothingString(messagesAr, "magDocumentation", errorInMethod);
+    magDownloadAr = getNotNothingString(messagesAr, "magDownload", errorInMethod);
+    magDownloadTooltipAr = getNotNothingString(messagesAr, "magDownloadTooltip", errorInMethod);
+    magFileTypeAr = getNotNothingString(messagesAr, "magFileType", errorInMethod);
+    magGraphTypeAr = getNotNothingString(messagesAr, "magGraphType", errorInMethod);
+    magGraphTypeTooltipGridAr =
+        getNotNothingString(messagesAr, "magGraphTypeTooltipGrid", errorInMethod);
+    magGraphTypeTooltipTableAr =
+        getNotNothingString(messagesAr, "magGraphTypeTooltipTable", errorInMethod);
+    magGSAr = getNotNothingString(messagesAr, "magGS", errorInMethod);
+    magGSMarkerTypeAr = getNotNothingString(messagesAr, "magGSMarkerType", errorInMethod);
+    magGSSizeAr = getNotNothingString(messagesAr, "magGSSize", errorInMethod);
+    magGSColorAr = getNotNothingString(messagesAr, "magGSColor", errorInMethod);
+    magGSColorBarAr = getNotNothingString(messagesAr, "magGSColorBar", errorInMethod);
+    magGSColorBarTooltipAr = getNotNothingString(messagesAr, "magGSColorBarTooltip", errorInMethod);
+    magGSContinuityAr = getNotNothingString(messagesAr, "magGSContinuity", errorInMethod);
+    magGSContinuityTooltipAr =
+        getNotNothingString(messagesAr, "magGSContinuityTooltip", errorInMethod);
+    magGSScaleAr = getNotNothingString(messagesAr, "magGSScale", errorInMethod);
+    magGSScaleTooltipAr = getNotNothingString(messagesAr, "magGSScaleTooltip", errorInMethod);
+    magGSMinAr = getNotNothingString(messagesAr, "magGSMin", errorInMethod);
+    magGSMinTooltipAr = getNotNothingString(messagesAr, "magGSMinTooltip", errorInMethod);
+    magGSMaxAr = getNotNothingString(messagesAr, "magGSMax", errorInMethod);
+    magGSMaxTooltipAr = getNotNothingString(messagesAr, "magGSMaxTooltip", errorInMethod);
+    magGSNSectionsAr = getNotNothingString(messagesAr, "magGSNSections", errorInMethod);
+    magGSNSectionsTooltipAr =
+        getNotNothingString(messagesAr, "magGSNSectionsTooltip", errorInMethod);
+    magGSLandMaskAr = getNotNothingString(messagesAr, "magGSLandMask", errorInMethod);
+    magGSLandMaskTooltipGridAr =
+        getNotNothingString(messagesAr, "magGSLandMaskTooltipGrid", errorInMethod);
+    magGSLandMaskTooltipTableAr =
+        getNotNothingString(messagesAr, "magGSLandMaskTooltipTable", errorInMethod);
+    magGSVectorStandardAr = getNotNothingString(messagesAr, "magGSVectorStandard", errorInMethod);
+    magGSVectorStandardTooltipAr =
+        getNotNothingString(messagesAr, "magGSVectorStandardTooltip", errorInMethod);
+    magGSYAscendingTooltipAr =
+        getNotNothingString(messagesAr, "magGSYAscendingTooltip", errorInMethod);
+    magGSYAxisMinAr = getNotNothingString(messagesAr, "magGSYAxisMin", errorInMethod);
+    magGSYAxisMaxAr = getNotNothingString(messagesAr, "magGSYAxisMax", errorInMethod);
+    magGSYRangeMinTooltipAr =
+        getNotNothingString(messagesAr, "magGSYRangeMinTooltip", errorInMethod);
+    magGSYRangeMaxTooltipAr =
+        getNotNothingString(messagesAr, "magGSYRangeMaxTooltip", errorInMethod);
+    magGSYRangeTooltipAr = getNotNothingString(messagesAr, "magGSYRangeTooltip", errorInMethod);
+    magGSYScaleTooltipAr = getNotNothingString(messagesAr, "magGSYScaleTooltip", errorInMethod);
+    magItemFirstAr = getNotNothingString(messagesAr, "magItemFirst", errorInMethod);
+    magItemPreviousAr = getNotNothingString(messagesAr, "magItemPrevious", errorInMethod);
+    magItemNextAr = getNotNothingString(messagesAr, "magItemNext", errorInMethod);
+    magItemLastAr = getNotNothingString(messagesAr, "magItemLast", errorInMethod);
+    magJust1ValueAr = getNotNothingString(messagesAr, "magJust1Value", errorInMethod);
+    magRangeAr = getNotNothingString(messagesAr, "magRange", errorInMethod);
+    magRangeToAr = getNotNothingString(messagesAr, "magRangeTo", errorInMethod);
+    magRedrawAr = getNotNothingString(messagesAr, "magRedraw", errorInMethod);
+    magRedrawTooltipAr = getNotNothingString(messagesAr, "magRedrawTooltip", errorInMethod);
+    magTimeRangeAr = getNotNothingString(messagesAr, "magTimeRange", errorInMethod);
+    magTimeRangeFirstAr = getNotNothingString(messagesAr, "magTimeRangeFirst", errorInMethod);
+    magTimeRangeBackAr = getNotNothingString(messagesAr, "magTimeRangeBack", errorInMethod);
+    magTimeRangeForwardAr = getNotNothingString(messagesAr, "magTimeRangeForward", errorInMethod);
+    magTimeRangeLastAr = getNotNothingString(messagesAr, "magTimeRangeLast", errorInMethod);
+    magTimeRangeTooltipAr = getNotNothingString(messagesAr, "magTimeRangeTooltip", errorInMethod);
+    magTimeRangeTooltip2Ar = getNotNothingString(messagesAr, "magTimeRangeTooltip2", errorInMethod);
+    magTimesVaryAr = getNotNothingString(messagesAr, "magTimesVary", errorInMethod);
+    magViewUrlAr = getNotNothingString(messagesAr, "magViewUrl", errorInMethod);
+    magZoomAr = getNotNothingString(messagesAr, "magZoom", errorInMethod);
+    magZoomCenterAr = getNotNothingString(messagesAr, "magZoomCenter", errorInMethod);
+    magZoomCenterTooltipAr = getNotNothingString(messagesAr, "magZoomCenterTooltip", errorInMethod);
+    magZoomInAr = getNotNothingString(messagesAr, "magZoomIn", errorInMethod);
+    magZoomInTooltipAr = getNotNothingString(messagesAr, "magZoomInTooltip", errorInMethod);
+    magZoomOutAr = getNotNothingString(messagesAr, "magZoomOut", errorInMethod);
+    magZoomOutTooltipAr = getNotNothingString(messagesAr, "magZoomOutTooltip", errorInMethod);
+    magZoomALittleAr = getNotNothingString(messagesAr, "magZoomALittle", errorInMethod);
+    magZoomDataAr = getNotNothingString(messagesAr, "magZoomData", errorInMethod);
+    magZoomOutDataAr = getNotNothingString(messagesAr, "magZoomOutData", errorInMethod);
+    magGridTooltipAr = getNotNothingString(messagesAr, "magGridTooltip", errorInMethod);
+    magTableTooltipAr = getNotNothingString(messagesAr, "magTableTooltip", errorInMethod);
+
+    metadataDownloadAr = getNotNothingString(messagesAr, "metadataDownload", errorInMethod);
+    moreInformationAr = getNotNothingString(messagesAr, "moreInformation", errorInMethod);
+
+    nMatching1Ar = getNotNothingString(messagesAr, "nMatching1", errorInMethod);
+    nMatchingAr = getNotNothingString(messagesAr, "nMatching", errorInMethod);
+    nMatchingAlphabeticalAr =
+        getNotNothingString(messagesAr, "nMatchingAlphabetical", errorInMethod);
+    nMatchingMostRelevantAr =
+        getNotNothingString(messagesAr, "nMatchingMostRelevant", errorInMethod);
+    nMatchingPageAr = getNotNothingString(messagesAr, "nMatchingPage", errorInMethod);
+    nMatchingCurrentAr = getNotNothingString(messagesAr, "nMatchingCurrent", errorInMethod);
+    noDataFixedValueAr = getNotNothingString(messagesAr, "noDataFixedValue", errorInMethod);
+    noDataNoLLAr = getNotNothingString(messagesAr, "noDataNoLL", errorInMethod);
+    noDatasetWithAr = getNotNothingString(messagesAr, "noDatasetWith", errorInMethod);
+    noPage1Ar = getNotNothingString(messagesAr, "noPage1", errorInMethod);
+    noPage2Ar = getNotNothingString(messagesAr, "noPage2", errorInMethod);
+    notAllowedAr = getNotNothingString(messagesAr, "notAllowed", errorInMethod);
+    notAuthorizedAr = getNotNothingString(messagesAr, "notAuthorized", errorInMethod);
+    notAuthorizedForDataAr = getNotNothingString(messagesAr, "notAuthorizedForData", errorInMethod);
+    notAvailableAr = getNotNothingString(messagesAr, "notAvailable", errorInMethod);
+    noteAr = getNotNothingString(messagesAr, "note", errorInMethod);
+    noXxxAr = getNotNothingString(messagesAr, "noXxx", errorInMethod);
+    noXxxBecauseAr = getNotNothingString(messagesAr, "noXxxBecause", errorInMethod);
+    noXxxBecause2Ar = getNotNothingString(messagesAr, "noXxxBecause2", errorInMethod);
+    noXxxNotActiveAr = getNotNothingString(messagesAr, "noXxxNotActive", errorInMethod);
+    noXxxNoAxis1Ar = getNotNothingString(messagesAr, "noXxxNoAxis1", errorInMethod);
+    noXxxNoCdmDataTypeAr = getNotNothingString(messagesAr, "noXxxNoCdmDataType", errorInMethod);
+    noXxxNoColorBarAr = getNotNothingString(messagesAr, "noXxxNoColorBar", errorInMethod);
+    noXxxNoLLAr = getNotNothingString(messagesAr, "noXxxNoLL", errorInMethod);
+    noXxxNoLLEvenlySpacedAr =
+        getNotNothingString(messagesAr, "noXxxNoLLEvenlySpaced", errorInMethod);
+    noXxxNoLLGt1Ar = getNotNothingString(messagesAr, "noXxxNoLLGt1", errorInMethod);
+    noXxxNoLLTAr = getNotNothingString(messagesAr, "noXxxNoLLT", errorInMethod);
+    noXxxNoLonIn180Ar = getNotNothingString(messagesAr, "noXxxNoLonIn180", errorInMethod);
+    noXxxNoNonStringAr = getNotNothingString(messagesAr, "noXxxNoNonString", errorInMethod);
+    noXxxNo2NonStringAr = getNotNothingString(messagesAr, "noXxxNo2NonString", errorInMethod);
+    noXxxNoStationAr = getNotNothingString(messagesAr, "noXxxNoStation", errorInMethod);
+    noXxxNoStationIDAr = getNotNothingString(messagesAr, "noXxxNoStationID", errorInMethod);
+    noXxxNoSubsetVariablesAr =
+        getNotNothingString(messagesAr, "noXxxNoSubsetVariables", errorInMethod);
+    noXxxNoOLLSubsetVariablesAr =
+        getNotNothingString(messagesAr, "noXxxNoOLLSubsetVariables", errorInMethod);
+    noXxxNoMinMaxAr = getNotNothingString(messagesAr, "noXxxNoMinMax", errorInMethod);
+    noXxxItsGriddedAr = getNotNothingString(messagesAr, "noXxxItsGridded", errorInMethod);
+    noXxxItsTabularAr = getNotNothingString(messagesAr, "noXxxItsTabular", errorInMethod);
+    oneRequestAtATimeAr = getNotNothingString(messagesAr, "oneRequestAtATime", errorInMethod);
+    openSearchDescriptionAr =
+        getNotNothingString(messagesAr, "openSearchDescription", errorInMethod);
+    optionalAr = getNotNothingString(messagesAr, "optional", errorInMethod);
+    optionsAr = getNotNothingString(messagesAr, "options", errorInMethod);
+    orAListOfValuesAr = getNotNothingString(messagesAr, "orAListOfValues", errorInMethod);
+    orRefineSearchWithAr = getNotNothingString(messagesAr, "orRefineSearchWith", errorInMethod);
+    orSearchWithAr = getNotNothingString(messagesAr, "orSearchWith", errorInMethod);
+    orCommaAr = getNotNothingString(messagesAr, "orComma", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) {
+      orRefineSearchWithAr[tl] += " ";
+      orSearchWithAr[tl] += " ";
+      orCommaAr[tl] += " ";
+    }
+    otherFeaturesAr = getNotNothingString(messagesAr, "otherFeatures", errorInMethod);
+    outOfDateDatasetsAr = getNotNothingString(messagesAr, "outOfDateDatasets", errorInMethod);
+    outOfDateHtmlAr = getNotNothingString(messagesAr, "outOfDateHtml", errorInMethod);
+    outOfDateKeepTrackAr = getNotNothingString(messagesAr, "outOfDateKeepTrack", errorInMethod);
+
+    // just one set of palettes info (from messagesAr[0])
+    palettes = String2.split(messagesAr[0].getNotNothingString("palettes", errorInMethod), ',');
+    DEFAULT_palettes = palettes; // used by LoadDatasets if palettes tag is empty
+    DEFAULT_palettes_set = String2.stringArrayToSet(palettes);
+    palettes0 = new String[palettes.length + 1];
+    palettes0[0] = "";
+    System.arraycopy(palettes, 0, palettes0, 1, palettes.length);
+
+    patientDataAr = getNotNothingString(messagesAr, "patientData", errorInMethod);
+    patientYourGraphAr = getNotNothingString(messagesAr, "patientYourGraph", errorInMethod);
+
+    pdfWidths =
+        String2.toIntArray(
+            String2.split(messagesAr[0].getNotNothingString("pdfWidths", errorInMethod), ','));
+    pdfHeights =
+        String2.toIntArray(
+            String2.split(messagesAr[0].getNotNothingString("pdfHeights", errorInMethod), ','));
+
+    percentEncodeAr = getNotNothingString(messagesAr, "percentEncode", errorInMethod);
+    pickADatasetAr = getNotNothingString(messagesAr, "pickADataset", errorInMethod);
+    protocolSearchHtmlAr = getNotNothingString(messagesAr, "protocolSearchHtml", errorInMethod);
+    protocolSearch2HtmlAr = getNotNothingString(messagesAr, "protocolSearch2Html", errorInMethod);
+    protocolClickAr = getNotNothingString(messagesAr, "protocolClick", errorInMethod);
+    queryErrorAr = getNotNothingString(messagesAr, "queryError", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) queryErrorAr[tl] += " ";
+    queryError180Ar = getNotNothingString(messagesAr, "queryError180", errorInMethod);
+    queryError1ValueAr = getNotNothingString(messagesAr, "queryError1Value", errorInMethod);
+    queryError1VarAr = getNotNothingString(messagesAr, "queryError1Var", errorInMethod);
+    queryError2VarAr = getNotNothingString(messagesAr, "queryError2Var", errorInMethod);
+    queryErrorActualRangeAr =
+        getNotNothingString(messagesAr, "queryErrorActualRange", errorInMethod);
+    queryErrorAdjustedAr = getNotNothingString(messagesAr, "queryErrorAdjusted", errorInMethod);
+    queryErrorAscendingAr = getNotNothingString(messagesAr, "queryErrorAscending", errorInMethod);
+    queryErrorConstraintNaNAr =
+        getNotNothingString(messagesAr, "queryErrorConstraintNaN", errorInMethod);
+    queryErrorEqualSpacingAr =
+        getNotNothingString(messagesAr, "queryErrorEqualSpacing", errorInMethod);
+    queryErrorExpectedAtAr = getNotNothingString(messagesAr, "queryErrorExpectedAt", errorInMethod);
+    queryErrorFileTypeAr = getNotNothingString(messagesAr, "queryErrorFileType", errorInMethod);
+    queryErrorInvalidAr = getNotNothingString(messagesAr, "queryErrorInvalid", errorInMethod);
+    queryErrorLLAr = getNotNothingString(messagesAr, "queryErrorLL", errorInMethod);
+    queryErrorLLGt1Ar = getNotNothingString(messagesAr, "queryErrorLLGt1", errorInMethod);
+    queryErrorLLTAr = getNotNothingString(messagesAr, "queryErrorLLT", errorInMethod);
+    queryErrorNeverTrueAr = getNotNothingString(messagesAr, "queryErrorNeverTrue", errorInMethod);
+    queryErrorNeverBothTrueAr =
+        getNotNothingString(messagesAr, "queryErrorNeverBothTrue", errorInMethod);
+    queryErrorNotAxisAr = getNotNothingString(messagesAr, "queryErrorNotAxis", errorInMethod);
+    queryErrorNotExpectedAtAr =
+        getNotNothingString(messagesAr, "queryErrorNotExpectedAt", errorInMethod);
+    queryErrorNotFoundAfterAr =
+        getNotNothingString(messagesAr, "queryErrorNotFoundAfter", errorInMethod);
+    queryErrorOccursTwiceAr =
+        getNotNothingString(messagesAr, "queryErrorOccursTwice", errorInMethod);
+
+    queryErrorOrderByClosestAr =
+        getNotNothingString(messagesAr, "queryErrorOrderByClosest", errorInMethod);
+    queryErrorOrderByLimitAr =
+        getNotNothingString(messagesAr, "queryErrorOrderByLimit", errorInMethod);
+    queryErrorOrderByMeanAr =
+        getNotNothingString(messagesAr, "queryErrorOrderByMean", errorInMethod);
+    queryErrorOrderBySumAr = getNotNothingString(messagesAr, "queryErrorOrderBySum", errorInMethod);
+
+    queryErrorOrderByVariableAr =
+        getNotNothingString(messagesAr, "queryErrorOrderByVariable", errorInMethod);
+    queryErrorUnknownVariableAr =
+        getNotNothingString(messagesAr, "queryErrorUnknownVariable", errorInMethod);
+
+    queryErrorGrid1AxisAr = getNotNothingString(messagesAr, "queryErrorGrid1Axis", errorInMethod);
+    queryErrorGridAmpAr = getNotNothingString(messagesAr, "queryErrorGridAmp", errorInMethod);
+    queryErrorGridDiagnosticAr =
+        getNotNothingString(messagesAr, "queryErrorGridDiagnostic", errorInMethod);
+    queryErrorGridBetweenAr =
+        getNotNothingString(messagesAr, "queryErrorGridBetween", errorInMethod);
+    queryErrorGridLessMinAr =
+        getNotNothingString(messagesAr, "queryErrorGridLessMin", errorInMethod);
+    queryErrorGridGreaterMaxAr =
+        getNotNothingString(messagesAr, "queryErrorGridGreaterMax", errorInMethod);
+    queryErrorGridMissingAr =
+        getNotNothingString(messagesAr, "queryErrorGridMissing", errorInMethod);
+    queryErrorGridNoAxisVarAr =
+        getNotNothingString(messagesAr, "queryErrorGridNoAxisVar", errorInMethod);
+    queryErrorGridNoDataVarAr =
+        getNotNothingString(messagesAr, "queryErrorGridNoDataVar", errorInMethod);
+    queryErrorGridNotIdenticalAr =
+        getNotNothingString(messagesAr, "queryErrorGridNotIdentical", errorInMethod);
+    queryErrorGridSLessSAr = getNotNothingString(messagesAr, "queryErrorGridSLessS", errorInMethod);
+    queryErrorLastEndPAr = getNotNothingString(messagesAr, "queryErrorLastEndP", errorInMethod);
+    queryErrorLastExpectedAr =
+        getNotNothingString(messagesAr, "queryErrorLastExpected", errorInMethod);
+    queryErrorLastUnexpectedAr =
+        getNotNothingString(messagesAr, "queryErrorLastUnexpected", errorInMethod);
+    queryErrorLastPMInvalidAr =
+        getNotNothingString(messagesAr, "queryErrorLastPMInvalid", errorInMethod);
+    queryErrorLastPMIntegerAr =
+        getNotNothingString(messagesAr, "queryErrorLastPMInteger", errorInMethod);
+
+    questionMarkImageFile =
+        messagesAr[0].getNotNothingString("questionMarkImageFile", errorInMethod);
+    questionMarkImageFile =
+        getSetupEVString(setup, ev, "questionMarkImageFile", questionMarkImageFile); // optional
+
+    rangesFromToAr = getNotNothingString(messagesAr, "rangesFromTo", errorInMethod);
+    requiredAr = getNotNothingString(messagesAr, "required", errorInMethod);
+    requestFormatExamplesHtmlAr =
+        getNotNothingString(messagesAr, "requestFormatExamplesHtml", errorInMethod);
+    resetTheFormAr = getNotNothingString(messagesAr, "resetTheForm", errorInMethod);
+    resetTheFormWasAr = getNotNothingString(messagesAr, "resetTheFormWas", errorInMethod);
+    resourceNotFoundAr = getNotNothingString(messagesAr, "resourceNotFound", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) resourceNotFoundAr[tl] += " ";
+    restfulWebServicesAr = getNotNothingString(messagesAr, "restfulWebServices", errorInMethod);
+    restfulHTMLAr = getNotNothingString(messagesAr, "restfulHTML", errorInMethod);
+    restfulHTMLContinuedAr = getNotNothingString(messagesAr, "restfulHTMLContinued", errorInMethod);
+    restfulGetAllDatasetAr = getNotNothingString(messagesAr, "restfulGetAllDataset", errorInMethod);
+    restfulProtocolsAr = getNotNothingString(messagesAr, "restfulProtocols", errorInMethod);
+    SOSDocumentationAr = getNotNothingString(messagesAr, "SOSDocumentation", errorInMethod);
+    WCSDocumentationAr = getNotNothingString(messagesAr, "WCSDocumentation", errorInMethod);
+    WMSDocumentationAr = getNotNothingString(messagesAr, "WMSDocumentation", errorInMethod);
+    resultsFormatExamplesHtmlAr =
+        getNotNothingString(messagesAr, "resultsFormatExamplesHtml", errorInMethod);
+    resultsOfSearchForAr = getNotNothingString(messagesAr, "resultsOfSearchFor", errorInMethod);
+    restfulInformationFormatsAr =
+        getNotNothingString(messagesAr, "restfulInformationFormats", errorInMethod);
+    restfulViaServiceAr = getNotNothingString(messagesAr, "restfulViaService", errorInMethod);
+    rowsAr = getNotNothingString(messagesAr, "rows", errorInMethod);
+    rssNoAr = getNotNothingString(messagesAr, "rssNo", errorInMethod);
+    searchTitleAr = getNotNothingString(messagesAr, "searchTitle", errorInMethod);
+    searchDoFullTextHtmlAr = getNotNothingString(messagesAr, "searchDoFullTextHtml", errorInMethod);
+    searchFullTextHtmlAr = getNotNothingString(messagesAr, "searchFullTextHtml", errorInMethod);
+    searchButtonAr = getNotNothingString(messagesAr, "searchButton", errorInMethod);
+    searchClickTipAr = getNotNothingString(messagesAr, "searchClickTip", errorInMethod);
+    searchHintsLuceneTooltipAr =
+        getNotNothingString(messagesAr, "searchHintsLuceneTooltip", errorInMethod);
+    searchHintsOriginalTooltipAr =
+        getNotNothingString(messagesAr, "searchHintsOriginalTooltip", errorInMethod);
+    searchHintsTooltipAr = getNotNothingString(messagesAr, "searchHintsTooltip", errorInMethod);
+    searchMultipleERDDAPsAr =
+        getNotNothingString(messagesAr, "searchMultipleERDDAPs", errorInMethod);
+    searchMultipleERDDAPsDescriptionAr =
+        getNotNothingString(messagesAr, "searchMultipleERDDAPsDescription", errorInMethod);
+    searchNotAvailableAr = getNotNothingString(messagesAr, "searchNotAvailable", errorInMethod);
+    searchTipAr = getNotNothingString(messagesAr, "searchTip", errorInMethod);
+    searchSpellingAr = getNotNothingString(messagesAr, "searchSpelling", errorInMethod);
+    searchFewerWordsAr = getNotNothingString(messagesAr, "searchFewerWords", errorInMethod);
+    searchWithQueryAr = getNotNothingString(messagesAr, "searchWithQuery", errorInMethod);
+    selectNextAr = getNotNothingString(messagesAr, "selectNext", errorInMethod);
+    selectPreviousAr = getNotNothingString(messagesAr, "selectPrevious", errorInMethod);
+    shiftXAllTheWayLeftAr = getNotNothingString(messagesAr, "shiftXAllTheWayLeft", errorInMethod);
+    shiftXLeftAr = getNotNothingString(messagesAr, "shiftXLeft", errorInMethod);
+    shiftXRightAr = getNotNothingString(messagesAr, "shiftXRight", errorInMethod);
+    shiftXAllTheWayRightAr = getNotNothingString(messagesAr, "shiftXAllTheWayRight", errorInMethod);
+
+    seeProtocolDocumentationAr =
+        getNotNothingString(messagesAr, "seeProtocolDocumentation", errorInMethod);
+
+    slideSorterAr = getNotNothingString(messagesAr, "slideSorter", errorInMethod);
+    SOSAr = getNotNothingString(messagesAr, "SOS", errorInMethod);
+    sosDescriptionHtmlAr = getNotNothingString(messagesAr, "sosDescriptionHtml", errorInMethod);
+    sosLongDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "sosLongDescriptionHtml", errorInMethod);
+    sosOverview1Ar = getNotNothingString(messagesAr, "sosOverview1", errorInMethod);
+    sosOverview2Ar = getNotNothingString(messagesAr, "sosOverview2", errorInMethod);
+    sparqlP01toP02pre = messagesAr[0].getNotNothingString("sparqlP01toP02pre", errorInMethod);
+    sparqlP01toP02post = messagesAr[0].getNotNothingString("sparqlP01toP02post", errorInMethod);
+    ssUseAr = getNotNothingString(messagesAr, "ssUse", errorInMethod);
+    ssUsePlainAr = getNotNothingString(messagesAr, "ssUse", errorInMethod); // start with this
+    for (int tl = 0; tl < nLanguages; tl++) ssUsePlainAr[tl] = XML.removeHTMLTags(ssUsePlainAr[tl]);
+
+    ssBePatientAr = getNotNothingString(messagesAr, "ssBePatient", errorInMethod);
+    ssInstructionsHtmlAr = getNotNothingString(messagesAr, "ssInstructionsHtml", errorInMethod);
+
+    statusAr = getNotNothingString(messagesAr, "status", errorInMethod);
+    statusHtmlAr = getNotNothingString(messagesAr, "statusHtml", errorInMethod);
+    submitAr = getNotNothingString(messagesAr, "submit", errorInMethod);
+    submitTooltipAr = getNotNothingString(messagesAr, "submitTooltip", errorInMethod);
+    subscriptionOfferRssAr = getNotNothingString(messagesAr, "subscriptionOfferRss", errorInMethod);
+    subscriptionOfferUrlAr = getNotNothingString(messagesAr, "subscriptionOfferUrl", errorInMethod);
+    subscriptionsTitleAr = getNotNothingString(messagesAr, "subscriptionsTitle", errorInMethod);
+    subscriptionEmailListAr =
+        getNotNothingString(messagesAr, "subscriptionEmailList", errorInMethod);
+    subscriptionAddAr = getNotNothingString(messagesAr, "subscriptionAdd", errorInMethod);
+    subscriptionValidateAr = getNotNothingString(messagesAr, "subscriptionValidate", errorInMethod);
+    subscriptionListAr = getNotNothingString(messagesAr, "subscriptionList", errorInMethod);
+    subscriptionRemoveAr = getNotNothingString(messagesAr, "subscriptionRemove", errorInMethod);
+    subscription0HtmlAr = getNotNothingString(messagesAr, "subscription0Html", errorInMethod);
+    subscription1HtmlAr = getNotNothingString(messagesAr, "subscription1Html", errorInMethod);
+    subscription2HtmlAr = getNotNothingString(messagesAr, "subscription2Html", errorInMethod);
+    subscriptionAbuseAr = getNotNothingString(messagesAr, "subscriptionAbuse", errorInMethod);
+    subscriptionAddErrorAr = getNotNothingString(messagesAr, "subscriptionAddError", errorInMethod);
+    subscriptionAddHtmlAr = getNotNothingString(messagesAr, "subscriptionAddHtml", errorInMethod);
+    subscriptionAdd2Ar = getNotNothingString(messagesAr, "subscriptionAdd2", errorInMethod);
+    subscriptionAddSuccessAr =
+        getNotNothingString(messagesAr, "subscriptionAddSuccess", errorInMethod);
+    subscriptionEmailAr = getNotNothingString(messagesAr, "subscriptionEmail", errorInMethod);
+    subscriptionEmailOnBlacklistAr =
+        getNotNothingString(messagesAr, "subscriptionEmailOnBlacklist", errorInMethod);
+    subscriptionEmailInvalidAr =
+        getNotNothingString(messagesAr, "subscriptionEmailInvalid", errorInMethod);
+    subscriptionEmailTooLongAr =
+        getNotNothingString(messagesAr, "subscriptionEmailTooLong", errorInMethod);
+    subscriptionEmailUnspecifiedAr =
+        getNotNothingString(messagesAr, "subscriptionEmailUnspecified", errorInMethod);
+    subscriptionIDInvalidAr =
+        getNotNothingString(messagesAr, "subscriptionIDInvalid", errorInMethod);
+    subscriptionIDTooLongAr =
+        getNotNothingString(messagesAr, "subscriptionIDTooLong", errorInMethod);
+    subscriptionIDUnspecifiedAr =
+        getNotNothingString(messagesAr, "subscriptionIDUnspecified", errorInMethod);
+    subscriptionKeyInvalidAr =
+        getNotNothingString(messagesAr, "subscriptionKeyInvalid", errorInMethod);
+    subscriptionKeyUnspecifiedAr =
+        getNotNothingString(messagesAr, "subscriptionKeyUnspecified", errorInMethod);
+    subscriptionListErrorAr =
+        getNotNothingString(messagesAr, "subscriptionListError", errorInMethod);
+    subscriptionListHtmlAr = getNotNothingString(messagesAr, "subscriptionListHtml", errorInMethod);
+    subscriptionListSuccessAr =
+        getNotNothingString(messagesAr, "subscriptionListSuccess", errorInMethod);
+    subscriptionRemoveErrorAr =
+        getNotNothingString(messagesAr, "subscriptionRemoveError", errorInMethod);
+    subscriptionRemoveHtmlAr =
+        getNotNothingString(messagesAr, "subscriptionRemoveHtml", errorInMethod);
+    subscriptionRemove2Ar = getNotNothingString(messagesAr, "subscriptionRemove2", errorInMethod);
+    subscriptionRemoveSuccessAr =
+        getNotNothingString(messagesAr, "subscriptionRemoveSuccess", errorInMethod);
+    subscriptionRSSAr = getNotNothingString(messagesAr, "subscriptionRSS", errorInMethod);
+    subscriptionsNotAvailableAr =
+        getNotNothingString(messagesAr, "subscriptionsNotAvailable", errorInMethod);
+    subscriptionUrlHtmlAr = getNotNothingString(messagesAr, "subscriptionUrlHtml", errorInMethod);
+    subscriptionUrlInvalidAr =
+        getNotNothingString(messagesAr, "subscriptionUrlInvalid", errorInMethod);
+    subscriptionUrlTooLongAr =
+        getNotNothingString(messagesAr, "subscriptionUrlTooLong", errorInMethod);
+    subscriptionValidateErrorAr =
+        getNotNothingString(messagesAr, "subscriptionValidateError", errorInMethod);
+    subscriptionValidateHtmlAr =
+        getNotNothingString(messagesAr, "subscriptionValidateHtml", errorInMethod);
+    subscriptionValidateSuccessAr =
+        getNotNothingString(messagesAr, "subscriptionValidateSuccess", errorInMethod);
+    subsetAr = getNotNothingString(messagesAr, "subset", errorInMethod);
+    subsetSelectAr = getNotNothingString(messagesAr, "subsetSelect", errorInMethod);
+    subsetNMatchingAr = getNotNothingString(messagesAr, "subsetNMatching", errorInMethod);
+    subsetInstructionsAr = getNotNothingString(messagesAr, "subsetInstructions", errorInMethod);
+    subsetOptionAr = getNotNothingString(messagesAr, "subsetOption", errorInMethod);
+    subsetOptionsAr = getNotNothingString(messagesAr, "subsetOptions", errorInMethod);
+    subsetRefineMapDownloadAr =
+        getNotNothingString(messagesAr, "subsetRefineMapDownload", errorInMethod);
+    subsetRefineSubsetDownloadAr =
+        getNotNothingString(messagesAr, "subsetRefineSubsetDownload", errorInMethod);
+    subsetClickResetClosestAr =
+        getNotNothingString(messagesAr, "subsetClickResetClosest", errorInMethod);
+    subsetClickResetLLAr = getNotNothingString(messagesAr, "subsetClickResetLL", errorInMethod);
+    subsetMetadataAr = getNotNothingString(messagesAr, "subsetMetadata", errorInMethod);
+    subsetCountAr = getNotNothingString(messagesAr, "subsetCount", errorInMethod);
+    subsetPercentAr = getNotNothingString(messagesAr, "subsetPercent", errorInMethod);
+    subsetViewSelectAr = getNotNothingString(messagesAr, "subsetViewSelect", errorInMethod);
+    subsetViewSelectDistinctCombosAr =
+        getNotNothingString(messagesAr, "subsetViewSelectDistinctCombos", errorInMethod);
+    subsetViewSelectRelatedCountsAr =
+        getNotNothingString(messagesAr, "subsetViewSelectRelatedCounts", errorInMethod);
+    subsetWhenAr = getNotNothingString(messagesAr, "subsetWhen", errorInMethod);
+    subsetWhenNoConstraintsAr =
+        getNotNothingString(messagesAr, "subsetWhenNoConstraints", errorInMethod);
+    subsetWhenCountsAr = getNotNothingString(messagesAr, "subsetWhenCounts", errorInMethod);
+    subsetComboClickSelectAr =
+        getNotNothingString(messagesAr, "subsetComboClickSelect", errorInMethod);
+    subsetNVariableCombosAr =
+        getNotNothingString(messagesAr, "subsetNVariableCombos", errorInMethod);
+    subsetShowingAllRowsAr = getNotNothingString(messagesAr, "subsetShowingAllRows", errorInMethod);
+    subsetShowingNRowsAr = getNotNothingString(messagesAr, "subsetShowingNRows", errorInMethod);
+    subsetChangeShowingAr = getNotNothingString(messagesAr, "subsetChangeShowing", errorInMethod);
+    subsetNRowsRelatedDataAr =
+        getNotNothingString(messagesAr, "subsetNRowsRelatedData", errorInMethod);
+    subsetViewRelatedChangeAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedChange", errorInMethod);
+    subsetTotalCountAr = getNotNothingString(messagesAr, "subsetTotalCount", errorInMethod);
+    subsetViewAr = getNotNothingString(messagesAr, "subsetView", errorInMethod);
+    subsetViewCheckAr = getNotNothingString(messagesAr, "subsetViewCheck", errorInMethod);
+    subsetViewCheck1Ar = getNotNothingString(messagesAr, "subsetViewCheck1", errorInMethod);
+    subsetViewDistinctMapAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctMap", errorInMethod);
+    subsetViewRelatedMapAr = getNotNothingString(messagesAr, "subsetViewRelatedMap", errorInMethod);
+    subsetViewDistinctDataCountsAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctDataCounts", errorInMethod);
+    subsetViewDistinctDataAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctData", errorInMethod);
+    subsetViewRelatedDataCountsAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedDataCounts", errorInMethod);
+    subsetViewRelatedDataAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedData", errorInMethod);
+    subsetViewDistinctMapTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctMapTooltip", errorInMethod);
+    subsetViewRelatedMapTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedMapTooltip", errorInMethod);
+    subsetViewDistinctDataCountsTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctDataCountsTooltip", errorInMethod);
+    subsetViewDistinctDataTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewDistinctDataTooltip", errorInMethod);
+    subsetViewRelatedDataCountsTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedDataCountsTooltip", errorInMethod);
+    subsetViewRelatedDataTooltipAr =
+        getNotNothingString(messagesAr, "subsetViewRelatedDataTooltip", errorInMethod);
+    subsetWarnAr = getNotNothingString(messagesAr, "subsetWarn", errorInMethod);
+    subsetWarn10000Ar = getNotNothingString(messagesAr, "subsetWarn10000", errorInMethod);
+    subsetTooltipAr = getNotNothingString(messagesAr, "subsetTooltip", errorInMethod);
+    subsetNotSetUpAr = getNotNothingString(messagesAr, "subsetNotSetUp", errorInMethod);
+    subsetLongNotShownAr = getNotNothingString(messagesAr, "subsetLongNotShown", errorInMethod);
+
+    tabledapVideoIntroAr = getNotNothingString(messagesAr, "tabledapVideoIntro", errorInMethod);
+    theDatasetIDAr = getNotNothingString(messagesAr, "theDatasetID", errorInMethod);
+    theKeyAr = getNotNothingString(messagesAr, "theKey", errorInMethod);
+    theSubscriptionIDAr = getNotNothingString(messagesAr, "theSubscriptionID", errorInMethod);
+    theUrlActionAr = getNotNothingString(messagesAr, "theUrlAction", errorInMethod);
+    theLongDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "theLongDescriptionHtml", errorInMethod);
+    timeAr = getNotNothingString(messagesAr, "time", errorInMethod);
+    ThenAr = getNotNothingString(messagesAr, "Then", errorInMethod);
+    thisParticularErddapAr = getNotNothingString(messagesAr, "thisParticularErddap", errorInMethod);
+    timeoutOtherRequestsAr = getNotNothingString(messagesAr, "timeoutOtherRequests", errorInMethod);
+
+    unitsAr = getNotNothingString(messagesAr, "units", errorInMethod);
+    unknownDatasetIDAr = getNotNothingString(messagesAr, "unknownDatasetID", errorInMethod);
+    unknownProtocolAr = getNotNothingString(messagesAr, "unknownProtocol", errorInMethod);
+    unsupportedFileTypeAr = getNotNothingString(messagesAr, "unsupportedFileType", errorInMethod);
+    String tStandardizeUdunits[] =
+        String2.split(
+            messagesAr[0].getNotNothingString("standardizeUdunits", errorInMethod) + "\n",
+            '\n'); // +\n\n since xml content is trimmed.
+    String tUcumToUdunits[] =
+        String2.split(
+            messagesAr[0].getNotNothingString("ucumToUdunits", errorInMethod) + "\n",
+            '\n'); // +\n\n since xml content is trimmed.
+    String tUdunitsToUcum[] =
+        String2.split(
+            messagesAr[0].getNotNothingString("udunitsToUcum", errorInMethod) + "\n",
+            '\n'); // +\n\n since xml content is trimmed.
+    String tUpdateUrls[] =
+        String2.split(
+            messagesAr[0].getNotNothingString("updateUrls", errorInMethod) + "\n",
+            '\n'); // +\n\n since xml content is trimmed.
+
+    updateUrlsSkipAttributes =
+        StringArray.arrayFromCSV(
+            messagesAr[0].getNotNothingString("updateUrlsSkipAttributes", errorInMethod));
+
+    usingGriddapAr = getNotNothingString(messagesAr, "usingGriddap", errorInMethod);
+    usingTabledapAr = getNotNothingString(messagesAr, "usingTabledap", errorInMethod);
+    variableNamesAr = getNotNothingString(messagesAr, "variableNames", errorInMethod);
+    viewAllDatasetsHtmlAr = getNotNothingString(messagesAr, "viewAllDatasetsHtml", errorInMethod);
+    waitThenTryAgainAr = getNotNothingString(messagesAr, "waitThenTryAgain", errorInMethod);
+    warningAr = getNotNothingString(messagesAr, "warning", errorInMethod);
+    WCSAr = getNotNothingString(messagesAr, "WCS", errorInMethod);
+    wcsDescriptionHtmlAr = getNotNothingString(messagesAr, "wcsDescriptionHtml", errorInMethod);
+    wcsLongDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "wcsLongDescriptionHtml", errorInMethod);
+    wcsOverview1Ar = getNotNothingString(messagesAr, "wcsOverview1", errorInMethod);
+    wcsOverview2Ar = getNotNothingString(messagesAr, "wcsOverview2", errorInMethod);
+    wmsDescriptionHtmlAr = getNotNothingString(messagesAr, "wmsDescriptionHtml", errorInMethod);
+    wmsInstructionsAr = getNotNothingString(messagesAr, "wmsInstructions", errorInMethod);
+    wmsLongDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "wmsLongDescriptionHtml", errorInMethod);
+    wmsManyDatasetsAr = getNotNothingString(messagesAr, "wmsManyDatasets", errorInMethod);
+    WMSDocumentation1Ar = getNotNothingString(messagesAr, "WMSDocumentation1", errorInMethod);
+    WMSGetCapabilitiesAr = getNotNothingString(messagesAr, "WMSGetCapabilities", errorInMethod);
+    WMSGetMapAr = getNotNothingString(messagesAr, "WMSGetMap", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) {
+      WMSGetCapabilitiesAr[tl] =
+          WMSGetCapabilitiesAr[tl] // some things should stay in English
+              .replaceAll("&serviceWMS;", "service=WMS")
+              .replaceAll("&version;", "version")
+              .replaceAll("&requestGetCapabilities;", "request=GetCapabilities");
+      WMSGetMapAr[tl] =
+          WMSGetMapAr[tl] // lots of things should stay in English
+              .replaceAll("&WMSSERVER;", EDD.WMS_SERVER)
+              .replaceAll("&WMSSEPARATOR;", Character.toString(EDD.WMS_SEPARATOR))
+              .replaceAll("&serviceWMS;", "service=WMS")
+              .replaceAll("&version;", "version")
+              .replaceAll("&requestGetMap;", "request=GetMap")
+              .replaceAll("&TRUE;", "TRUE")
+              .replaceAll("&FALSE;", "FALSE")
+              .replaceAll("&layers;", "layers")
+              .replaceAll("&styles;", "styles")
+              .replaceAll("&width;", "width")
+              .replaceAll("&height;", "height")
+              .replaceAll("&format;", "format")
+              .replaceAll("&transparentTRUEFALSE;", "transparent=<i>TRUE|FALSE</i>")
+              .replaceAll("&bgcolor;", "bgcolor")
+              .replaceAll("&exceptions;", "exceptions")
+              .replaceAll("&time;", "time")
+              .replaceAll("&elevation;", "elevation");
+    }
+
+    WMSNotesAr = getNotNothingString(messagesAr, "WMSNotes", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++)
+      WMSNotesAr[tl] =
+          WMSNotesAr[tl].replace("&WMSSEPARATOR;", Character.toString(EDD.WMS_SEPARATOR));
+
+    yourEmailAddressAr = getNotNothingString(messagesAr, "yourEmailAddress", errorInMethod);
+    zoomInAr = getNotNothingString(messagesAr, "zoomIn", errorInMethod);
+    zoomOutAr = getNotNothingString(messagesAr, "zoomOut", errorInMethod);
+
+    lazyInitializeStatics(errorInMethod, messagesAr);
+
+    for (int tl = 0; tl < nLanguages; tl++) {
+      blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], EDStatic.adminEmail);
+    }
+
+    standardShortDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "standardShortDescriptionHtml", errorInMethod);
+    for (int tl = 0; tl < nLanguages; tl++) {
+      standardShortDescriptionHtmlAr[tl] =
+          String2.replaceAll(
+              standardShortDescriptionHtmlAr[tl],
+              "&convertTimeReference;",
+              EDStatic.convertersActive ? convertTimeReferenceAr[tl] : "");
+      standardShortDescriptionHtmlAr[tl] =
+          String2.replaceAll(
+              standardShortDescriptionHtmlAr[tl],
+              "&wmsManyDatasets;",
+              EDStatic.wmsActive ? wmsManyDatasetsAr[tl] : "");
+    }
+
+    // just one
+    DEFAULT_commonStandardNames =
+        String2.canonical(
+            StringArray.arrayFromCSV(
+                messagesAr[0].getNotNothingString("DEFAULT_commonStandardNames", errorInMethod)));
+    commonStandardNames = DEFAULT_commonStandardNames;
+    DEFAULT_standardLicense = messagesAr[0].getNotNothingString("standardLicense", errorInMethod);
+    standardLicense = getSetupEVString(setup, ev, "standardLicense", DEFAULT_standardLicense);
+
+    // [language]
+    DEFAULT_standardContactAr = getNotNothingString(messagesAr, "standardContact", errorInMethod);
+    standardContactAr = getSetupEVString(setup, ev, "standardContact", DEFAULT_standardContactAr);
+    DEFAULT_standardDataLicensesAr =
+        getNotNothingString(messagesAr, "standardDataLicenses", errorInMethod);
+    standardDataLicensesAr =
+        getSetupEVString(setup, ev, "standardDataLicenses", DEFAULT_standardDataLicensesAr);
+    DEFAULT_standardDisclaimerOfExternalLinksAr =
+        getNotNothingString(messagesAr, "standardDisclaimerOfExternalLinks", errorInMethod);
+    standardDisclaimerOfExternalLinksAr =
+        getSetupEVString(
+            setup,
+            ev,
+            "standardDisclaimerOfExternalLinks",
+            DEFAULT_standardDisclaimerOfExternalLinksAr);
+    DEFAULT_standardDisclaimerOfEndorsementAr =
+        getNotNothingString(messagesAr, "standardDisclaimerOfEndorsement", errorInMethod);
+    standardDisclaimerOfEndorsementAr =
+        getSetupEVString(
+            setup,
+            ev,
+            "standardDisclaimerOfEndorsement",
+            DEFAULT_standardDisclaimerOfEndorsementAr);
+    DEFAULT_standardGeneralDisclaimerAr =
+        getNotNothingString(messagesAr, "standardGeneralDisclaimer", errorInMethod);
+    standardGeneralDisclaimerAr =
+        getSetupEVString(
+            setup, ev, "standardGeneralDisclaimer", DEFAULT_standardGeneralDisclaimerAr);
+    DEFAULT_standardPrivacyPolicyAr =
+        getNotNothingString(messagesAr, "standardPrivacyPolicy", errorInMethod);
+    standardPrivacyPolicyAr =
+        getSetupEVString(setup, ev, "standardPrivacyPolicy", DEFAULT_standardPrivacyPolicyAr);
+
+    DEFAULT_startHeadHtml = messagesAr[0].getNotNothingString("startHeadHtml5", errorInMethod);
+    startHeadHtml = getSetupEVString(setup, ev, "startHeadHtml5", DEFAULT_startHeadHtml);
+    DEFAULT_startBodyHtmlAr = getNotNothingString(messagesAr, "startBodyHtml5", errorInMethod);
+    startBodyHtmlAr = getSetupEVString(setup, ev, "startBodyHtml5", DEFAULT_startBodyHtmlAr);
+    DEFAULT_theShortDescriptionHtmlAr =
+        getNotNothingString(messagesAr, "theShortDescriptionHtml", errorInMethod);
+    theShortDescriptionHtmlAr =
+        getSetupEVString(setup, ev, "theShortDescriptionHtml", DEFAULT_theShortDescriptionHtmlAr);
+    DEFAULT_endBodyHtmlAr = getNotNothingString(messagesAr, "endBodyHtml5", errorInMethod);
+    endBodyHtmlAr = getSetupEVString(setup, ev, "endBodyHtml5", DEFAULT_endBodyHtmlAr);
+
+    // ensure HTML5
+    Test.ensureTrue(
+        startHeadHtml.startsWith("<!DOCTYPE html>"),
+        "<startHeadHtml5> must start with \"<!DOCTYPE html>\".");
+    for (int tl = 0; tl < nLanguages; tl++) {
+      DEFAULT_standardDataLicensesAr[tl] =
+          String2.replaceAll(
+              DEFAULT_standardDataLicensesAr[tl],
+              "&license;",
+              "<kbd>license</kbd>"); // so not translated
+      standardDataLicensesAr[tl] =
+          String2.replaceAll(standardDataLicensesAr[tl], "&license;", "<kbd>license</kbd>");
+      standardContactAr[tl] =
+          String2.replaceAll(
+              standardContactAr[tl], "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.adminEmail));
+      startBodyHtmlAr[tl] =
+          String2.replaceAll(startBodyHtmlAr[tl], "&erddapVersion;", EDStatic.erddapVersion);
+      endBodyHtmlAr[tl] =
+          String2.replaceAll(endBodyHtmlAr[tl], "&erddapVersion;", EDStatic.erddapVersion);
+    }
+
+    Test.ensureEqual(imageWidths.length, 3, "imageWidths.length must be 3.");
+    Test.ensureEqual(imageHeights.length, 3, "imageHeights.length must be 3.");
+    Test.ensureEqual(pdfWidths.length, 3, "pdfWidths.length must be 3.");
+    Test.ensureEqual(pdfHeights.length, 3, "pdfHeights.length must be 3.");
+
+    int nStandardizeUdunits = tStandardizeUdunits.length / 3;
+    for (int i = 0; i < nStandardizeUdunits; i++) {
+      int i3 = i * 3;
+      Test.ensureTrue(
+          String2.isSomething(tStandardizeUdunits[i3]),
+          "standardizeUdunits line #" + (i3 + 0) + " is empty.");
+      Test.ensureTrue(
+          String2.isSomething(tStandardizeUdunits[i3 + 1]),
+          "standardizeUdunits line #" + (i3 + 1) + " is empty.");
+      Test.ensureEqual(
+          tStandardizeUdunits[i3 + 2].trim(),
+          "",
+          "standardizeUdunits line #" + (i3 + 2) + " isn't empty.");
+      Units2.standardizeUdunitsHM.put(
+          String2.canonical(tStandardizeUdunits[i3].trim()),
+          String2.canonical(tStandardizeUdunits[i3 + 1].trim()));
+    }
+
+    int nUcumToUdunits = tUcumToUdunits.length / 3;
+    for (int i = 0; i < nUcumToUdunits; i++) {
+      int i3 = i * 3;
+      Test.ensureTrue(
+          String2.isSomething(tUcumToUdunits[i3]),
+          "ucumToUdunits line #" + (i3 + 0) + " is empty.");
+      Test.ensureTrue(
+          String2.isSomething(tUcumToUdunits[i3 + 1]),
+          "ucumToUdunits line #" + (i3 + 1) + " is empty.");
+      Test.ensureEqual(
+          tUcumToUdunits[i3 + 2].trim(), "", "ucumToUdunits line #" + (i3 + 2) + " isn't empty.");
+      Units2.ucumToUdunitsHM.put(
+          String2.canonical(tUcumToUdunits[i3].trim()),
+          String2.canonical(tUcumToUdunits[i3 + 1].trim()));
+    }
+
+    int nUdunitsToUcum = tUdunitsToUcum.length / 3;
+    for (int i = 0; i < nUdunitsToUcum; i++) {
+      int i3 = i * 3;
+      Test.ensureTrue(
+          String2.isSomething(tUdunitsToUcum[i3]),
+          "udunitsToUcum line #" + (i3 + 0) + " is empty.");
+      Test.ensureTrue(
+          String2.isSomething(tUdunitsToUcum[i3 + 1]),
+          "udunitsToUcum line #" + (i3 + 1) + " is empty.");
+      Test.ensureEqual(
+          tUdunitsToUcum[i3 + 2].trim(), "", "udunitsToUcum line #" + (i3 + 2) + " isn't empty.");
+      Units2.udunitsToUcumHM.put(
+          String2.canonical(tUdunitsToUcum[i3].trim()),
+          String2.canonical(tUdunitsToUcum[i3 + 1].trim()));
+    }
+
+    int nUpdateUrls = tUpdateUrls.length / 3;
+    updateUrlsFrom = new String[nUpdateUrls];
+    updateUrlsTo = new String[nUpdateUrls];
+    for (int i = 0; i < nUpdateUrls; i++) {
+      int i3 = i * 3;
+      updateUrlsFrom[i] = String2.canonical(tUpdateUrls[i3].trim());
+      updateUrlsTo[i] = String2.canonical(tUpdateUrls[i3 + 1].trim());
+      Test.ensureTrue(
+          String2.isSomething(tUpdateUrls[i3]), "updateUrls line #" + (i3 + 0) + " is empty.");
+      Test.ensureTrue(
+          String2.isSomething(tUpdateUrls[i3 + 1]), "updateUrls line #" + (i3 + 1) + " is empty.");
+      Test.ensureEqual(
+          tUpdateUrls[i3 + 2].trim(), "", "updateUrls line #" + (i3 + 0) + " isn't empty.");
+    }
+
+    for (String palette : palettes) {
+      String tName = EDStatic.fullPaletteDirectory + palette + ".cpt";
+      Test.ensureTrue(
+          File2.isFile(tName),
+          "\"" + palette + "\" is listed in <palettes>, but there is no file " + tName);
+    }
+
+    String tEmail = SSR.getSafeEmailAddress(EDStatic.adminEmail);
+    for (int tl = 0; tl < nLanguages; tl++) {
+      searchHintsTooltipAr[tl] =
+          "<div class=\"standard_max_width\">"
+              + searchHintsTooltipAr[tl]
+              + "\n"
+              + (EDStatic.useLuceneSearchEngine
+                  ? searchHintsLuceneTooltipAr[tl]
+                  : searchHintsOriginalTooltipAr[tl])
+              + "</div>";
+      advancedSearchDirectionsAr[tl] =
+          String2.replaceAll(advancedSearchDirectionsAr[tl], "&searchButton;", searchButtonAr[tl]);
+
+      loginProblemsAr[tl] =
+          String2.replaceAll(loginProblemsAr[tl], "&cookiesHelp;", cookiesHelpAr[tl]);
+      loginProblemsAr[tl] =
+          String2.replaceAll(loginProblemsAr[tl], "&adminContact;", EDStatic.adminContact())
+              + "\n\n";
+      loginProblemsAfterAr[tl] =
+          String2.replaceAll(loginProblemsAfterAr[tl], "&adminContact;", EDStatic.adminContact())
+              + "\n\n";
+      loginPublicAccessAr[tl] += "\n";
+      logoutSuccessAr[tl] += "\n";
+
+      filesDocumentationAr[tl] =
+          String2.replaceAll(filesDocumentationAr[tl], "&adminEmail;", tEmail);
+
+      doWithGraphsAr[tl] =
+          String2.replaceAll(
+              doWithGraphsAr[tl], "&ssUse;", EDStatic.slideSorterActive ? ssUseAr[tl] : "");
+
+      theLongDescriptionHtmlAr[tl] =
+          String2.replaceAll(
+              theLongDescriptionHtmlAr[tl],
+              "&ssUse;",
+              EDStatic.slideSorterActive ? ssUseAr[tl] : "");
+      theLongDescriptionHtmlAr[tl] =
+          String2.replaceAll(
+              theLongDescriptionHtmlAr[tl],
+              "&requestFormatExamplesHtml;",
+              requestFormatExamplesHtmlAr[tl]);
+      theLongDescriptionHtmlAr[tl] =
+          String2.replaceAll(
+              theLongDescriptionHtmlAr[tl],
+              "&resultsFormatExamplesHtml;",
+              resultsFormatExamplesHtmlAr[tl]);
+    }
+  }
+
+  private void lazyInitializeStatics(String errorInMethod, ResourceBundle2[] messagesAr) {
+    PrimitiveArray.ArrayAddN = messagesAr[0].getNotNothingString("ArrayAddN", errorInMethod);
+    PrimitiveArray.ArrayAppendTables =
+        messagesAr[0].getNotNothingString("ArrayAppendTables", errorInMethod);
+    PrimitiveArray.ArrayAtInsert =
+        messagesAr[0].getNotNothingString("ArrayAtInsert", errorInMethod);
+    PrimitiveArray.ArrayDiff = messagesAr[0].getNotNothingString("ArrayDiff", errorInMethod);
+    PrimitiveArray.ArrayDifferentSize =
+        messagesAr[0].getNotNothingString("ArrayDifferentSize", errorInMethod);
+    PrimitiveArray.ArrayDifferentValue =
+        messagesAr[0].getNotNothingString("ArrayDifferentValue", errorInMethod);
+    PrimitiveArray.ArrayDiffString =
+        messagesAr[0].getNotNothingString("ArrayDiffString", errorInMethod);
+    PrimitiveArray.ArrayMissingValue =
+        messagesAr[0].getNotNothingString("ArrayMissingValue", errorInMethod);
+    PrimitiveArray.ArrayNotAscending =
+        messagesAr[0].getNotNothingString("ArrayNotAscending", errorInMethod);
+    PrimitiveArray.ArrayNotDescending =
+        messagesAr[0].getNotNothingString("ArrayNotDescending", errorInMethod);
+    PrimitiveArray.ArrayNotEvenlySpaced =
+        messagesAr[0].getNotNothingString("ArrayNotEvenlySpaced", errorInMethod);
+    PrimitiveArray.ArrayRemove = messagesAr[0].getNotNothingString("ArrayRemove", errorInMethod);
+    PrimitiveArray.ArraySubsetStart =
+        messagesAr[0].getNotNothingString("ArraySubsetStart", errorInMethod);
+    PrimitiveArray.ArraySubsetStride =
+        messagesAr[0].getNotNothingString("ArraySubsetStride", errorInMethod);
+
+    HtmlWidgets.comboBoxAltAr = getNotNothingString(messagesAr, "comboBoxAlt", errorInMethod);
+    HtmlWidgets.errorXWasntSpecifiedAr =
+        getNotNothingString(messagesAr, "errorXWasntSpecified", errorInMethod);
+    HtmlWidgets.errorXWasTooLongAr =
+        getNotNothingString(messagesAr, "errorXWasTooLong", errorInMethod);
+    TableWriterHtmlTable.htmlTableMaxMB =
+        messagesAr[0].getInt("htmlTableMaxMB", TableWriterHtmlTable.htmlTableMaxMB);
+    Math2.memory = messagesAr[0].getNotNothingString("memory", errorInMethod);
+    Math2.memoryTooMuchData = messagesAr[0].getNotNothingString("memoryTooMuchData", errorInMethod);
+    Math2.memoryArraySize = messagesAr[0].getNotNothingString("memoryArraySize", errorInMethod);
+    Math2.memoryThanCurrentlySafe =
+        messagesAr[0].getNotNothingString("memoryThanCurrentlySafe", errorInMethod);
+    Math2.memoryThanSafe = messagesAr[0].getNotNothingString("memoryThanSafe", errorInMethod);
+    MustBe.THERE_IS_NO_DATA =
+        messagesAr[0].getNotNothingString("MustBeThereIsNoData", errorInMethod);
+    MustBe.NotNull = messagesAr[0].getNotNothingString("MustBeNotNull", errorInMethod);
+    MustBe.NotEmpty = messagesAr[0].getNotNothingString("MustBeNotEmpty", errorInMethod);
+    MustBe.InternalError = messagesAr[0].getNotNothingString("MustBeInternalError", errorInMethod);
+    MustBe.OutOfMemoryError =
+        messagesAr[0].getNotNothingString("MustBeOutOfMemoryError", errorInMethod);
+
+    Attributes.signedToUnsignedAttNames =
+        StringArray.arrayFromCSV(
+            messagesAr[0].getNotNothingString("signedToUnsignedAttNames", errorInMethod));
+    HtmlWidgets.twoClickMapDefaultTooltipAr =
+        getNotNothingString(messagesAr, "twoClickMapDefaultTooltip", errorInMethod);
+    gov.noaa.pfel.erddap.dataset.WaitThenTryAgainException.waitThenTryAgain = waitThenTryAgainAr[0];
+  }
+
+  /**
+   * A variant of getSetupEVString that works with an array of tDefault.
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param tDefault the default value
+   * @return the desired value (or the default if it isn't defined anywhere)
+   */
+  private String[] getSetupEVString(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, String tDefault[]) {
+    String value = ev.get("ERDDAP_" + paramName);
+    int n = tDefault.length;
+    if (String2.isSomething(value)) {
+      String2.log("got " + paramName + " from ERDDAP_" + paramName);
+      for (int i = 0; i < n; i++) tDefault[i] = value;
+      return tDefault;
+    }
+    for (int i = 0; i < n; i++) tDefault[i] = setup.getString(paramName, tDefault[i]);
+    return tDefault;
+  }
+
+  /**
+   * This gets a string from setup.xml or environmentalVariables (preferred).
+   *
+   * @param setup from setup.xml
+   * @param ev from System.getenv()
+   * @param paramName If present in ev, it will be ERDDAP_paramName.
+   * @param tDefault the default value
+   * @return the desired value (or the default if it isn't defined anywhere)
+   */
+  private String getSetupEVString(
+      ResourceBundle2 setup, Map<String, String> ev, String paramName, String tDefault) {
+    String value = ev.get("ERDDAP_" + paramName);
+    if (String2.isSomething(value)) {
+      String2.log("got " + paramName + " from ERDDAP_" + paramName);
+      return value;
+    }
+    return setup.getString(paramName, tDefault);
+  }
+
+  /** This does getNotNothingString for each messages[]. */
+  private String[] getNotNothingString(
+      ResourceBundle2 messages[], String name, String errorInMethod) {
+
+    int nMessages = messages.length;
+    String ar[] = new String[nMessages];
+    for (int i = 0; i < nMessages; i++)
+      ar[i] = messages[i].getNotNothingString(name, errorInMethod + "When language=" + i + ", ");
+    return ar;
+  }
+
+  /**
+   * This returns the html documentation for acceptEncoding.
+   *
+   * @param language the index of the selected language
+   * @param headingType e.g., h2 or h3
+   * @param tErddapUrl
+   * @return the html needed to document acceptEncodig.
+   */
+  public String acceptEncodingHtml(int language, String headingType, String tErddapUrl) {
+    String s =
+        String2.replaceAll(
+            acceptEncodingHtmlAr[language], "&headingType;", "<" + headingType + ">");
+    s = String2.replaceAll(s, "&sheadingType;", "</" + headingType + ">");
+    return String2.replaceAll(s, "&externalLinkHtml;", externalLinkHtml(language, tErddapUrl));
+  }
+
+  /**
+   * This returns the html documentation for the /files/ system.
+   *
+   * @param language the index of the selected language
+   * @param tErddapUrl
+   * @return the html needed to document acceptEncodig.
+   */
+  public String filesDocumentation(int language, String tErddapUrl) {
+    return String2.replaceAll(
+        filesDocumentationAr[language],
+        "&acceptEncodingHtml;",
+        acceptEncodingHtml(language, "h3", tErddapUrl));
+  }
+
+  /**
+   * This returns the html needed to display the external.png image with the warning that the link
+   * is to an external website.
+   *
+   * @param language the index of the selected language
+   * @param tErddapUrl
+   * @return the html needed to display the external.png image and messages.
+   */
+  public String externalLinkHtml(int language, String tErddapUrl) {
+    return "<img\n"
+        + "    src=\""
+        + tErddapUrl
+        + "/images/external.png\" "
+        + "alt=\""
+        + externalLinkAr[language]
+        + "\"\n"
+        + "    title=\""
+        + externalWebSiteAr[language]
+        + "\">";
+  }
+
+  public String theLongDescriptionHtml(int language, String tErddapUrl) {
+    return String2.replaceAll(theLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl);
+  }
+
+  public String theShortDescriptionHtml(int language, String tErddapUrl) {
+    String s =
+        theShortDescriptionHtmlAr[
+            0]; // from datasets.xml or messages.xml.  Always use English, but parts (most) will be
+    // translated.
+    s = String2.replaceAll(s, "&erddapIs;", erddapIsAr[language]);
+    s = String2.replaceAll(s, "&thisParticularErddap;", thisParticularErddapAr[language]);
+    s =
+        String2.replaceAll(
+            s, "[standardShortDescriptionHtml]", standardShortDescriptionHtmlAr[language]);
+    s = String2.replaceAll(s, "&requestFormatExamplesHtml;", requestFormatExamplesHtmlAr[language]);
+    s = String2.replaceAll(s, "&erddapUrl;", tErddapUrl); // do last
+    return s;
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
@@ -1077,37 +1077,37 @@ public class EDMessages {
   public final String errorFromDataSource = String2.ERROR + " from data source: ";
   public final int nLanguages = TranslateMessages.languageList.size();
 
-  public EDMessages(String contentDirectory, ResourceBundle2 setup, Map<String, String> ev) {
+  public EDMessages(String contentDirectory) throws Exception {
+    String setupFileName =
+        contentDirectory + "setup" + (EDStatic.config.developmentMode ? "2" : "") + ".xml";
+    String errorInMethod;
+    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false));
+    Map<String, String> ev = System.getenv();
     // **** messages.xml *************************************************************
     // This is read AFTER setup.xml. If that is a problem for something, defer reading it in setup
     // and add it below.
     // Read static messages from messages(2).xml in contentDirectory.
-    String errorInMethod;
     ResourceBundle2[] messagesAr = new ResourceBundle2[nLanguages];
     String messagesFileName = contentDirectory + "messages.xml";
-    try {
-      if (File2.isFile(messagesFileName)) {
-        String2.log("Using custom messages.xml from " + messagesFileName);
-        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
-        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false));
-      } else {
-        // use default messages.xml
-        String2.log("Custom messages.xml not found at " + messagesFileName);
-        // use String2.getClass(), not ClassLoader.getSystemResource (which fails in Tomcat)
-        URL messagesResourceFile = Resources.getResource("gov/noaa/pfel/erddap/util/messages.xml");
-        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
-        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesResourceFile, false));
-        String2.log("Using default messages.xml from  " + messagesFileName);
-      }
+    if (File2.isFile(messagesFileName)) {
+      String2.log("Using custom messages.xml from " + messagesFileName);
+      // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
+      messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false));
+    } else {
+      // use default messages.xml
+      String2.log("Custom messages.xml not found at " + messagesFileName);
+      // use String2.getClass(), not ClassLoader.getSystemResource (which fails in Tomcat)
+      URL messagesResourceFile = Resources.getResource("gov/noaa/pfel/erddap/util/messages.xml");
+      // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
+      messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesResourceFile, false));
+      String2.log("Using default messages.xml from  " + messagesFileName);
+    }
 
-      for (int tl = 1; tl < nLanguages; tl++) {
-        String tName = "messages-" + TranslateMessages.languageCodeList.get(tl) + ".xml";
-        errorInMethod = "ERROR while reading " + tName + ": ";
-        URL messageFile = new URL(TranslateMessages.translatedMessagesDir + tName);
-        messagesAr[tl] = ResourceBundle2.fromXml(XML.parseXml(messageFile, false));
-      }
-    } catch (Exception e) {
-      String2.log("EDMessages error loading files\n" + e.toString());
+    for (int tl = 1; tl < nLanguages; tl++) {
+      String tName = "messages-" + TranslateMessages.languageCodeList.get(tl) + ".xml";
+      errorInMethod = "ERROR while reading " + tName + ": ";
+      URL messageFile = new URL(TranslateMessages.translatedMessagesDir + tName);
+      messagesAr[tl] = ResourceBundle2.fromXml(XML.parseXml(messageFile, false));
     }
     // read all the static Strings from messages.xml
     errorInMethod = "ERROR while reading from all the messages.xml files: ";
@@ -1372,7 +1372,7 @@ public class EDMessages {
     convertUnitsNotesAr = getNotNothingString(messagesAr, "convertUnitsNotes", errorInMethod);
     for (int tl = 0; tl < nLanguages; tl++)
       convertUnitsNotesAr[tl] =
-          convertUnitsNotesAr[tl].replace("&unitsStandard;", EDStatic.units_standard);
+          convertUnitsNotesAr[tl].replace("&unitsStandard;", EDStatic.config.units_standard);
     convertUnitsServiceAr = getNotNothingString(messagesAr, "convertUnitsService", errorInMethod);
     convertURLsAr = getNotNothingString(messagesAr, "convertURLs", errorInMethod);
     convertURLsIntroAr = getNotNothingString(messagesAr, "convertURLsIntro", errorInMethod);
@@ -1657,21 +1657,16 @@ public class EDMessages {
     EDDGridMapExampleHE = XML.encodeAsHTML(EDDGridMapExample);
 
     // variants encoded to be Html Attributes
-    try {
-      EDDGridDimensionExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDimensionExample));
-      EDDGridDataIndexExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataIndexExample));
-      EDDGridDataValueExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataValueExample));
-      EDDGridDataTimeExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataTimeExample));
-      EDDGridGraphExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridGraphExample));
-      EDDGridMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridMapExample));
-    } catch (Exception e) {
-      String2.log("EDMessages error percent encoding\n" + e.toString());
-    }
+    EDDGridDimensionExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDimensionExample));
+    EDDGridDataIndexExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataIndexExample));
+    EDDGridDataValueExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataValueExample));
+    EDDGridDataTimeExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataTimeExample));
+    EDDGridGraphExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridGraphExample));
+    EDDGridMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridMapExample));
 
     EDDTableConstraintsAr = getNotNothingString(messagesAr, "EDDTableConstraints", errorInMethod);
     EDDTableDapDescriptionAr =
@@ -1758,20 +1753,16 @@ public class EDMessages {
     EDDTableGraphExampleHE = XML.encodeAsHTML(EDDTableGraphExample);
     EDDTableMapExampleHE = XML.encodeAsHTML(EDDTableMapExample);
 
-    try {
-      // variants encoded to be Html Attributes
-      EDDTableConstraintsExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableConstraintsExample));
-      EDDTableDataTimeExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataTimeExample));
-      EDDTableDataValueExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataValueExample));
-      EDDTableGraphExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableGraphExample));
-      EDDTableMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableMapExample));
-    } catch (Exception e) {
-      String2.log("EDMessages error percent encoding\n" + e.toString());
-    }
+    // variants encoded to be Html Attributes
+    EDDTableConstraintsExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableConstraintsExample));
+    EDDTableDataTimeExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataTimeExample));
+    EDDTableDataValueExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataValueExample));
+    EDDTableGraphExampleHA =
+        XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableGraphExample));
+    EDDTableMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableMapExample));
 
     EDDTableFromHttpGetDatasetDescription =
         XML.decodeEntities( // because this is used as plain text
@@ -2605,7 +2596,7 @@ public class EDMessages {
     lazyInitializeStatics(errorInMethod, messagesAr);
 
     for (int tl = 0; tl < nLanguages; tl++) {
-      blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], EDStatic.adminEmail);
+      blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], EDStatic.config.adminEmail);
     }
 
     standardShortDescriptionHtmlAr =
@@ -2615,12 +2606,12 @@ public class EDMessages {
           String2.replaceAll(
               standardShortDescriptionHtmlAr[tl],
               "&convertTimeReference;",
-              EDStatic.convertersActive ? convertTimeReferenceAr[tl] : "");
+              EDStatic.config.convertersActive ? convertTimeReferenceAr[tl] : "");
       standardShortDescriptionHtmlAr[tl] =
           String2.replaceAll(
               standardShortDescriptionHtmlAr[tl],
               "&wmsManyDatasets;",
-              EDStatic.wmsActive ? wmsManyDatasetsAr[tl] : "");
+              EDStatic.config.wmsActive ? wmsManyDatasetsAr[tl] : "");
     }
 
     // just one
@@ -2690,7 +2681,9 @@ public class EDMessages {
           String2.replaceAll(standardDataLicensesAr[tl], "&license;", "<kbd>license</kbd>");
       standardContactAr[tl] =
           String2.replaceAll(
-              standardContactAr[tl], "&adminEmail;", SSR.getSafeEmailAddress(EDStatic.adminEmail));
+              standardContactAr[tl],
+              "&adminEmail;",
+              SSR.getSafeEmailAddress(EDStatic.config.adminEmail));
       startBodyHtmlAr[tl] =
           String2.replaceAll(startBodyHtmlAr[tl], "&erddapVersion;", EDStatic.erddapVersion);
       endBodyHtmlAr[tl] =
@@ -2768,19 +2761,19 @@ public class EDMessages {
     }
 
     for (String palette : palettes) {
-      String tName = EDStatic.fullPaletteDirectory + palette + ".cpt";
+      String tName = EDStatic.config.fullPaletteDirectory + palette + ".cpt";
       Test.ensureTrue(
           File2.isFile(tName),
           "\"" + palette + "\" is listed in <palettes>, but there is no file " + tName);
     }
 
-    String tEmail = SSR.getSafeEmailAddress(EDStatic.adminEmail);
+    String tEmail = SSR.getSafeEmailAddress(EDStatic.config.adminEmail);
     for (int tl = 0; tl < nLanguages; tl++) {
       searchHintsTooltipAr[tl] =
           "<div class=\"standard_max_width\">"
               + searchHintsTooltipAr[tl]
               + "\n"
-              + (EDStatic.useLuceneSearchEngine
+              + (EDStatic.config.useLuceneSearchEngine
                   ? searchHintsLuceneTooltipAr[tl]
                   : searchHintsOriginalTooltipAr[tl])
               + "</div>";
@@ -2803,13 +2796,13 @@ public class EDMessages {
 
       doWithGraphsAr[tl] =
           String2.replaceAll(
-              doWithGraphsAr[tl], "&ssUse;", EDStatic.slideSorterActive ? ssUseAr[tl] : "");
+              doWithGraphsAr[tl], "&ssUse;", EDStatic.config.slideSorterActive ? ssUseAr[tl] : "");
 
       theLongDescriptionHtmlAr[tl] =
           String2.replaceAll(
               theLongDescriptionHtmlAr[tl],
               "&ssUse;",
-              EDStatic.slideSorterActive ? ssUseAr[tl] : "");
+              EDStatic.config.slideSorterActive ? ssUseAr[tl] : "");
       theLongDescriptionHtmlAr[tl] =
           String2.replaceAll(
               theLongDescriptionHtmlAr[tl],

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -50,7 +50,6 @@ import gov.noaa.pfel.erddap.dataset.EDDTable;
 import gov.noaa.pfel.erddap.dataset.EDDTableFromCassandra;
 import gov.noaa.pfel.erddap.dataset.GridDataAccessor;
 import gov.noaa.pfel.erddap.dataset.OutputStreamFromHttpResponse;
-import gov.noaa.pfel.erddap.dataset.TableWriterHtmlTable;
 import gov.noaa.pfel.erddap.http.CorsResponseFilter;
 import gov.noaa.pfel.erddap.variable.EDV;
 import gov.noaa.pfel.erddap.variable.EDVGridAxis;
@@ -248,7 +247,6 @@ public class EDStatic {
   public static final String PUBLIC_DIR = "public/";
   public static final String fullPaletteDirectory;
   public static final String fullPublicDirectory;
-  public static final String downloadDir; // local directory on this computer
   public static final String imageDir; // local directory on this computer
   public static final Metrics metrics;
   public static final Tally tally = new Tally();
@@ -381,8 +379,6 @@ public class EDStatic {
   public static final int DEFAULT_decompressedCacheMaxMinutesOld = 15;
   public static final int DEFAULT_nGridThreads = 1;
   public static final int DEFAULT_nTableThreads = 1;
-  public static String DEFAULT_palettes[] = null; // set when messages.xml is read
-  public static Set<String> DEFAULT_palettes_set = null; // set when messages.xml is read
   public static int decompressedCacheMaxGB = DEFAULT_decompressedCacheMaxGB;
   public static int decompressedCacheMaxMinutesOld = DEFAULT_decompressedCacheMaxMinutesOld;
   public static int nGridThreads = DEFAULT_nGridThreads; // will be a valid number 1+
@@ -422,40 +418,6 @@ public class EDStatic {
   public static int updateMaxEvents = DEFAULT_updateMaxEvents;
   public static int unusualActivityFailPercent = DEFAULT_unusualActivityFailPercent;
   public static boolean showLoadErrorsOnStatusPage = DEFAULT_showLoadErrorsOnStatusPage;
-
-  // not translated
-  public static final
-  String // these are set by setup.xml (deprecated) and/or messages.xml and/or datasets.xml (v2.00+)
-      DEFAULT_standardLicense;
-  public static String standardLicense;
-  public static final String DEFAULT_startHeadHtml; // see xxx() methods
-  public static String startHeadHtml; // see xxx() methods
-
-  // translated
-  public static final String
-          [] // these are set by setup.xml (deprecated) and/or messages.xml and/or datasets.xml
-      // (v2.00+)
-      DEFAULT_standardContactAr;
-  public static final String[] DEFAULT_standardDataLicensesAr;
-  public static final String[] DEFAULT_standardDisclaimerOfEndorsementAr;
-  public static final String[] DEFAULT_standardDisclaimerOfExternalLinksAr;
-  public static final String[] DEFAULT_standardGeneralDisclaimerAr;
-  public static final String[] DEFAULT_standardPrivacyPolicyAr;
-  public static final String[] DEFAULT_startBodyHtmlAr;
-  public static final String[] DEFAULT_theShortDescriptionHtmlAr;
-  public static final String[] DEFAULT_endBodyHtmlAr;
-  public static final String[] standardContactAr;
-  public static final String[] standardDataLicensesAr;
-  public static final String[] standardDisclaimerOfEndorsementAr;
-  public static final String[] standardDisclaimerOfExternalLinksAr;
-  public static final String[] standardGeneralDisclaimerAr;
-  public static final String[] standardPrivacyPolicyAr;
-  public static final String[] startBodyHtmlAr;
-  public static final String[] theShortDescriptionHtmlAr;
-  public static final String[] endBodyHtmlAr;
-  public static String // in messages.xml and perhaps in datasets.xml (v2.00+)
-      commonStandardNames[];
-  public static final String[] DEFAULT_commonStandardNames;
 
   // Default max of 25 copy tasks at a time, so different datasets have a chance.
   // Otherwise, some datasets could take months to do all the tasks.
@@ -639,63 +601,6 @@ public class EDStatic {
   public static final String keywords;
   public static final String units_standard;
 
-  public static String // the unencoded EDDGrid...Example attributes
-      EDDGridErddapUrlExample;
-  public static String EDDGridIdExample;
-  public static String EDDGridDimensionExample;
-  public static String EDDGridNoHyperExample;
-  public static String EDDGridDimNamesExample;
-  public static String EDDGridDataTimeExample;
-  public static String EDDGridDataValueExample;
-  public static String EDDGridDataIndexExample;
-  public static String EDDGridGraphExample;
-  public static String EDDGridMapExample;
-  public static String EDDGridMatlabPlotExample;
-
-  public static final String // variants encoded to be Html Examples
-      EDDGridDimensionExampleHE;
-  public static final String EDDGridDataIndexExampleHE;
-  public static final String EDDGridDataValueExampleHE;
-  public static final String EDDGridDataTimeExampleHE;
-  public static final String EDDGridGraphExampleHE;
-  public static final String EDDGridMapExampleHE;
-
-  public static final String // variants encoded to be Html Attributes
-      EDDGridDimensionExampleHA;
-  public static final String EDDGridDataIndexExampleHA;
-  public static final String EDDGridDataValueExampleHA;
-  public static final String EDDGridDataTimeExampleHA;
-  public static final String EDDGridGraphExampleHA;
-  public static final String EDDGridMapExampleHA;
-  public static final String EDDTableFromHttpGetDatasetDescription;
-  public static final String EDDTableFromHttpGetAuthorDescription;
-  public static final String EDDTableFromHttpGetTimestampDescription;
-
-  public static String // the unencoded EDDTable...Example attributes
-      EDDTableErddapUrlExample;
-  public static String EDDTableIdExample;
-  public static String EDDTableVariablesExample;
-  public static String EDDTableConstraintsExample;
-  public static String EDDTableDataTimeExample;
-  public static String EDDTableDataValueExample;
-  public static String EDDTableGraphExample;
-  public static String EDDTableMapExample;
-  public static String EDDTableMatlabPlotExample;
-
-  public static final String // variants encoded to be Html Examples
-      EDDTableConstraintsExampleHE;
-  public static final String EDDTableDataTimeExampleHE;
-  public static final String EDDTableDataValueExampleHE;
-  public static final String EDDTableGraphExampleHE;
-  public static final String EDDTableMapExampleHE;
-
-  public static final String // variants encoded to be Html Attributes
-      EDDTableConstraintsExampleHA;
-  public static final String EDDTableDataTimeExampleHA;
-  public static final String EDDTableDataValueExampleHA;
-  public static final String EDDTableGraphExampleHA;
-  public static final String EDDTableMapExampleHA;
-
   public static
   String /* For the wcs examples, pick one of your grid datasets that has longitude and latitude axes.
          The sample variable must be a variable in the sample grid dataset.
@@ -741,12 +646,9 @@ public class EDStatic {
       orcidClientSecret; // if authentication=orcid  or oauth2, this will be something
   public static final String googleEarthLogoFile;
   public static final String highResLogoImageFile;
-  public static String legendTitle1;
-  public static String legendTitle2;
   public static final String lowResLogoImageFile;
   public static final String
       passwordEncoding; // will be one of "MD5", "UEPMD5", "SHA256", "UEPSHA256"
-  public static String questionMarkImageFile;
   public static final String searchEngine;
   public static final String warName;
 
@@ -866,970 +768,13 @@ public class EDStatic {
    * These values are loaded from the [contentDirectory]messages.xml file (if present) or
    * .../classes/gov/noaapfel/erddap/util/messages.xml.
    */
+  public static final EDMessages messages;
 
-  // NOT TRANSLATED
-  public static final String admKeywords;
-
-  public static final String admSubsetVariables;
-  public static final String advl_datasetID;
-  public static final String advr_cdm_data_type;
-  public static final String advr_class;
-  public static final String advr_dataStructure;
-  public static final String EDDChangedWasnt;
-  public static final String EDDChangedDifferentNVar;
-  public static final String EDDChanged2Different;
-  public static final String EDDChanged1Different;
-  public static final String EDDChangedCGADifferent;
-  public static final String EDDChangedAxesDifferentNVar;
-  public static final String EDDChangedAxes2Different;
-  public static final String EDDChangedAxes1Different;
-  public static final String EDDChangedNoValue;
-  public static final String EDDChangedTableToGrid;
-  public static final String EDDFgdc;
-  public static final String EDDIso19115;
-  public static final String EDDSimilarDifferentNVar;
-  public static final String EDDSimilarDifferent;
-  public static final String[] extensionsNoRangeRequests; // an array of extensions (not translated)
-  public static final String inotifyFixCommands;
-  public static String legal;
-  public static String palettes[]; // an array of palettes
-  public static String palettes0[]; // the array of palettes with a blank [0] item inserted
   public static final ImmutableList<String> paletteSections =
       ImmutableList.of(
           "", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
           "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
           "32", "33", "34", "35", "36", "37", "38", "39", "40");
-  public static final String sparqlP01toP02pre;
-  public static final String sparqlP01toP02post;
-
-  // TRANSLATED
-  private static final String[] // private to force use via methods, e.g., acceptEncodingHtml()
-      acceptEncodingHtmlAr;
-  private static final String[] filesDocumentationAr;
-  public static final String[] accessRESTFULAr;
-  public static final String[] acronymsAr;
-  public static final String[] addConstraintsAr;
-  public static final String[] addVarWhereAttNameAr;
-  public static final String[] addVarWhereAttValueAr;
-  public static final String[] addVarWhereAr;
-  public static final String[] additionalLinksAr;
-  public static final String[] admSummaryAr;
-  public static final String[] admTitleAr;
-  public static final String[] advc_accessibleAr;
-  public static final String[] advl_accessibleAr;
-  public static final String[] advl_institutionAr;
-  public static final String[] advc_dataStructureAr;
-  public static final String[] advl_dataStructureAr;
-  public static final String[] advl_cdm_data_typeAr;
-  public static final String[] advl_classAr;
-  public static final String[] advl_titleAr;
-  public static final String[] advl_minLongitudeAr;
-  public static final String[] advl_maxLongitudeAr;
-  public static final String[] advl_longitudeSpacingAr;
-  public static final String[] advl_minLatitudeAr;
-  public static final String[] advl_maxLatitudeAr;
-  public static final String[] advl_latitudeSpacingAr;
-  public static final String[] advl_minAltitudeAr;
-  public static final String[] advl_maxAltitudeAr;
-  public static final String[] advl_minTimeAr;
-  public static final String[] advc_maxTimeAr;
-  public static final String[] advl_maxTimeAr;
-  public static final String[] advl_timeSpacingAr;
-  public static final String[] advc_griddapAr;
-  public static final String[] advl_griddapAr;
-  public static final String[] advl_subsetAr;
-  public static final String[] advc_tabledapAr;
-  public static final String[] advl_tabledapAr;
-  public static final String[] advl_MakeAGraphAr;
-  public static final String[] advc_sosAr;
-  public static final String[] advl_sosAr;
-  public static final String[] advl_wcsAr;
-  public static final String[] advl_wmsAr;
-  public static final String[] advc_filesAr;
-  public static final String[] advl_filesAr;
-  public static final String[] advc_fgdcAr;
-  public static final String[] advl_fgdcAr;
-  public static final String[] advc_iso19115Ar;
-  public static final String[] advl_iso19115Ar;
-  public static final String[] advc_metadataAr;
-  public static final String[] advl_metadataAr;
-  public static final String[] advl_sourceUrlAr;
-  public static final String[] advl_infoUrlAr;
-  public static final String[] advl_rssAr;
-  public static final String[] advc_emailAr;
-  public static final String[] advl_emailAr;
-  public static final String[] advl_summaryAr;
-  public static final String[] advc_testOutOfDateAr;
-  public static final String[] advl_testOutOfDateAr;
-  public static final String[] advc_outOfDateAr;
-  public static final String[] advl_outOfDateAr;
-  public static final String[] advn_outOfDateAr;
-  public static final String[] advancedSearchAr;
-  public static final String[] advancedSearchResultsAr;
-  public static final String[] advancedSearchDirectionsAr;
-  public static final String[] advancedSearchTooltipAr;
-  public static final String[] advancedSearchBoundsAr;
-  public static final String[] advancedSearchMinLatAr;
-  public static final String[] advancedSearchMaxLatAr;
-  public static final String[] advancedSearchMinLonAr;
-  public static final String[] advancedSearchMaxLonAr;
-  public static final String[] advancedSearchMinMaxLonAr;
-  public static final String[] advancedSearchMinTimeAr;
-  public static final String[] advancedSearchMaxTimeAr;
-  public static final String[] advancedSearchClearAr;
-  public static final String[] advancedSearchClearHelpAr;
-  public static final String[] advancedSearchCategoryTooltipAr;
-  public static final String[] advancedSearchRangeTooltipAr;
-  public static final String[] advancedSearchMapTooltipAr;
-  public static final String[] advancedSearchLonTooltipAr;
-  public static final String[] advancedSearchTimeTooltipAr;
-  public static final String[] advancedSearchWithCriteriaAr;
-  public static final String[] advancedSearchFewerCriteriaAr;
-  public static final String[] advancedSearchNoCriteriaAr;
-  public static final String[] advancedSearchErrorHandlingAr;
-  public static final String[] autoRefreshAr;
-  public static final String[] blacklistMsgAr;
-  public static final String[] BroughtToYouByAr;
-  public static final String[] categoryTitleHtmlAr;
-  public static final String[] categoryHtmlAr;
-  public static final String[] category3HtmlAr;
-  public static final String[] categoryPickAttributeAr;
-  public static final String[] categorySearchHtmlAr;
-  public static final String[] categorySearchDifferentHtmlAr;
-  public static final String[] categoryClickHtmlAr;
-  public static final String[] categoryNotAnOptionAr;
-  public static final String[] caughtInterruptedAr;
-  public static final String[] cdmDataTypeHelpAr;
-  public static final String[] clickAccessAr;
-  public static final String[] clickBackgroundInfoAr;
-  public static final String[] clickERDDAPAr;
-  public static final String[] clickInfoAr;
-  public static final String[] clickToSubmitAr;
-  public static final String[] convertAr;
-  public static final String[] convertBypassAr;
-  public static final String[] convertToAFullNameAr;
-  public static final String[] convertToAnAcronymAr;
-  public static final String[] convertToACountyNameAr;
-  public static final String[] convertToAFIPSCodeAr;
-  public static final String[] convertToGCMDAr;
-  public static final String[] convertToCFStandardNamesAr;
-  public static final String[] convertToNumericTimeAr;
-  public static final String[] convertToStringTimeAr;
-  public static final String[] convertAnyStringTimeAr;
-  public static final String[] convertToProperTimeUnitsAr;
-  public static final String[] convertFromUDUNITSToUCUMAr;
-  public static final String[] convertFromUCUMToUDUNITSAr;
-  public static final String[] convertToUCUMAr;
-  public static final String[] convertToUDUNITSAr;
-  public static final String[] convertStandardizeUDUNITSAr;
-  public static final String[] convertToFullNameAr;
-  public static final String[] convertToVariableNameAr;
-  public static final String[] converterWebServiceAr;
-  public static final String[] convertOAAcronymsAr;
-  public static final String[] convertOAAcronymsToFromAr;
-  public static final String[] convertOAAcronymsIntroAr;
-  public static final String[] convertOAAcronymsNotesAr;
-  public static final String[] convertOAAcronymsServiceAr;
-  public static final String[] convertOAVariableNamesAr;
-  public static final String[] convertOAVariableNamesToFromAr;
-  public static final String[] convertOAVariableNamesIntroAr;
-  public static final String[] convertOAVariableNamesNotesAr;
-  public static final String[] convertOAVariableNamesServiceAr;
-  public static final String[] convertFipsCountyAr;
-  public static final String[] convertFipsCountyIntroAr;
-  public static final String[] convertFipsCountyNotesAr;
-  public static final String[] convertFipsCountyServiceAr;
-  public static final String[] convertHtmlAr;
-  public static final String[] convertInterpolateAr;
-  public static final String[] convertInterpolateIntroAr;
-  public static final String[] convertInterpolateTLLTableAr;
-  public static final String[] convertInterpolateTLLTableHelpAr;
-  public static final String[] convertInterpolateDatasetIDVariableAr;
-  public static final String[] convertInterpolateDatasetIDVariableHelpAr;
-  public static final String[] convertInterpolateNotesAr;
-  public static final String[] convertInterpolateServiceAr;
-  public static final String[] convertKeywordsAr;
-  public static final String[] convertKeywordsCfTooltipAr;
-  public static final String[] convertKeywordsGcmdTooltipAr;
-  public static final String[] convertKeywordsIntroAr;
-  public static final String[] convertKeywordsNotesAr;
-  public static final String[] convertKeywordsServiceAr;
-  public static final String[] convertTimeAr;
-  public static final String[] convertTimeReferenceAr;
-  public static final String[] convertTimeIntroAr;
-  public static final String[] convertTimeNotesAr;
-  public static final String[] convertTimeServiceAr;
-  public static final String[] convertTimeNumberTooltipAr;
-  public static final String[] convertTimeStringTimeTooltipAr;
-  public static final String[] convertTimeUnitsTooltipAr;
-  public static final String[] convertTimeUnitsHelpAr;
-  public static final String[] convertTimeIsoFormatErrorAr;
-  public static final String[] convertTimeNoSinceErrorAr;
-  public static final String[] convertTimeNumberErrorAr;
-  public static final String[] convertTimeNumericTimeErrorAr;
-  public static final String[] convertTimeParametersErrorAr;
-  public static final String[] convertTimeStringFormatErrorAr;
-  public static final String[] convertTimeTwoTimeErrorAr;
-  public static final String[] convertTimeUnitsErrorAr;
-  public static final String[] convertUnitsAr;
-  public static final String[] convertUnitsComparisonAr;
-  public static final String[] convertUnitsFilterAr;
-  public static final String[] convertUnitsIntroAr;
-  public static final String[] convertUnitsNotesAr;
-  public static final String[] convertUnitsServiceAr;
-  public static final String[] convertURLsAr;
-  public static final String[] convertURLsIntroAr;
-  public static final String[] convertURLsNotesAr;
-  public static final String[] convertURLsServiceAr;
-  public static final String[] cookiesHelpAr;
-  public static final String[] copyImageToClipboardAr;
-  public static final String[] copyTextToClipboardAr;
-  public static final String[] copyToClipboardNotAvailableAr;
-  public static final String[] dafAr;
-  public static final String[] dafGridBypassTooltipAr;
-  public static final String[] dafGridTooltipAr;
-  public static final String[] dafTableBypassTooltipAr;
-  public static final String[] dafTableTooltipAr;
-  public static final String[] dasTitleAr;
-  public static final String[] dataAccessNotAllowedAr;
-  public static final String[] databaseUnableToConnectAr;
-  public static final String[] dataProviderFormAr;
-  public static final String[] dataProviderFormP1Ar;
-  public static final String[] dataProviderFormP2Ar;
-  public static final String[] dataProviderFormP3Ar;
-  public static final String[] dataProviderFormP4Ar;
-  public static final String[] dataProviderFormDoneAr;
-  public static final String[] dataProviderFormSuccessAr;
-  public static final String[] dataProviderFormShortDescriptionAr;
-  public static final String[] dataProviderFormLongDescriptionHTMLAr;
-  public static final String[] dataProviderFormPart1Ar;
-  public static final String[] dataProviderFormPart2HeaderAr;
-  public static final String[] dataProviderFormPart2GlobalMetadataAr;
-  public static final String[] dataProviderContactInfoAr;
-  public static final String[] dataProviderDataAr;
-  public static final String[] documentationAr;
-  public static final String[] dpf_submitAr;
-  public static final String[] dpf_fixProblemAr;
-  public static final String[] dpf_yourNameAr;
-  public static final String[] dpf_emailAddressAr;
-  public static final String[] dpf_TimestampAr;
-  public static final String[] dpf_frequencyAr;
-  public static final String[] dpf_titleAr;
-  public static final String[] dpf_titleTooltipAr;
-  public static final String[] dpf_summaryAr;
-  public static final String[] dpf_summaryTooltipAr;
-  public static final String[] dpf_creatorNameAr;
-  public static final String[] dpf_creatorNameTooltipAr;
-  public static final String[] dpf_creatorTypeAr;
-  public static final String[] dpf_creatorTypeTooltipAr;
-  public static final String[] dpf_creatorEmailAr;
-  public static final String[] dpf_creatorEmailTooltipAr;
-  public static final String[] dpf_institutionAr;
-  public static final String[] dpf_institutionTooltipAr;
-  public static final String[] dpf_infoUrlAr;
-  public static final String[] dpf_infoUrlTooltipAr;
-  public static final String[] dpf_licenseAr;
-  public static final String[] dpf_licenseTooltipAr;
-  public static final String[] dpf_howYouStoreDataAr;
-  public static final String[] dpf_provideIfAvailableAr;
-  public static final String[] dpf_acknowledgementAr;
-  public static final String[] dpf_acknowledgementTooltipAr;
-  public static final String[] dpf_historyAr;
-  public static final String[] dpf_historyTooltipAr;
-  public static final String[] dpf_idTooltipAr;
-  public static final String[] dpf_namingAuthorityAr;
-  public static final String[] dpf_namingAuthorityTooltipAr;
-  public static final String[] dpf_productVersionAr;
-  public static final String[] dpf_productVersionTooltipAr;
-  public static final String[] dpf_referencesAr;
-  public static final String[] dpf_referencesTooltipAr;
-  public static final String[] dpf_commentAr;
-  public static final String[] dpf_commentTooltipAr;
-  public static final String[] dpf_dataTypeHelpAr;
-  public static final String[] dpf_ioosCategoryAr;
-  public static final String[] dpf_ioosCategoryHelpAr;
-  public static final String[] dpf_part3HeaderAr;
-  public static final String[] dpf_variableMetadataAr;
-  public static final String[] dpf_sourceNameAr;
-  public static final String[] dpf_sourceNameTooltipAr;
-  public static final String[] dpf_destinationNameAr;
-  public static final String[] dpf_destinationNameTooltipAr;
-  public static final String[] dpf_longNameAr;
-  public static final String[] dpf_longNameTooltipAr;
-  public static final String[] dpf_standardNameAr;
-  public static final String[] dpf_standardNameTooltipAr;
-  public static final String[] dpf_dataTypeAr;
-  public static final String[] dpf_fillValueAr;
-  public static final String[] dpf_fillValueTooltipAr;
-  public static final String[] dpf_unitsAr;
-  public static final String[] dpf_unitsTooltipAr;
-  public static final String[] dpf_rangeAr;
-  public static final String[] dpf_rangeTooltipAr;
-  public static final String[] dpf_part4HeaderAr;
-  public static final String[] dpf_otherCommentAr;
-  public static final String[] dpf_finishPart4Ar;
-  public static final String[] dpf_congratulationAr;
-  public static final String[] disabledAr;
-  public static final String[] distinctValuesTooltipAr;
-  public static final String[] doWithGraphsAr;
-  public static final String[] dtAccessibleAr;
-  public static final String[] dtAccessiblePublicAr;
-  public static final String[] dtAccessibleYesAr;
-  public static final String[] dtAccessibleGraphsAr;
-  public static final String[] dtAccessibleNoAr;
-  public static final String[] dtAccessibleLogInAr;
-  public static final String[] dtLogInAr;
-  public static final String[] dtDAFAr;
-  public static final String[] dtFilesAr;
-  public static final String[] dtMAGAr;
-  public static final String[] dtSOSAr;
-  public static final String[] dtSubsetAr;
-  public static final String[] dtWCSAr;
-  public static final String[] dtWMSAr;
-  public static final String[] EasierAccessToScientificDataAr;
-  public static final String[] EDDDatasetIDAr;
-  public static final String[] EDDFgdcMetadataAr;
-  public static final String[] EDDFilesAr;
-  public static final String[] EDDIso19115MetadataAr;
-  public static final String[] EDDMetadataAr;
-  public static final String[] EDDBackgroundAr;
-  public static final String[] EDDClickOnSubmitHtmlAr;
-  public static final String[] EDDInstitutionAr;
-  public static final String[] EDDInformationAr;
-  public static final String[] EDDSummaryAr;
-  public static final String[] EDDDatasetTitleAr;
-  public static final String[] EDDDownloadDataAr;
-  public static final String[] EDDMakeAGraphAr;
-  public static final String[] EDDMakeAMapAr;
-  public static final String[] EDDFileTypeAr;
-  public static final String[] EDDFileTypeInformationAr;
-  public static final String[] EDDSelectFileTypeAr;
-  public static final String[] EDDMinimumAr;
-  public static final String[] EDDMaximumAr;
-  public static final String[] EDDConstraintAr;
-  public static final String[] EDDGridDapDescriptionAr;
-  public static final String[] EDDGridDapLongDescriptionAr;
-  public static final String[] EDDGridDownloadDataTooltipAr;
-  public static final String[] EDDGridDimensionAr;
-  public static final String[] EDDGridDimensionRangesAr;
-  public static final String[] EDDGridFirstAr;
-  public static final String[] EDDGridLastAr;
-  public static final String[] EDDGridStartAr;
-  public static final String[] EDDGridStopAr;
-  public static final String[] EDDGridStartStopTooltipAr;
-  public static final String[] EDDGridStrideAr;
-  public static final String[] EDDGridNValuesAr;
-  public static final String[] EDDGridNValuesHtmlAr;
-  public static final String[] EDDGridSpacingAr;
-  public static final String[] EDDGridJustOneValueAr;
-  public static final String[] EDDGridEvenAr;
-  public static final String[] EDDGridUnevenAr;
-  public static final String[] EDDGridDimensionTooltipAr;
-  public static final String[] EDDGridDimensionFirstTooltipAr;
-  public static final String[] EDDGridDimensionLastTooltipAr;
-  public static final String[] EDDGridVarHasDimTooltipAr;
-  public static final String[] EDDGridSSSTooltipAr;
-  public static final String[] EDDGridStartTooltipAr;
-  public static final String[] EDDGridStopTooltipAr;
-  public static final String[] EDDGridStrideTooltipAr;
-  public static final String[] EDDGridSpacingTooltipAr;
-  public static final String[] EDDGridDownloadTooltipAr;
-  public static final String[] EDDGridGridVariableHtmlAr;
-  public static final String[] EDDGridCheckAllAr;
-  public static final String[] EDDGridCheckAllTooltipAr;
-  public static final String[] EDDGridUncheckAllAr;
-  public static final String[] EDDGridUncheckAllTooltipAr;
-  public static final String[] EDDTableConstraintsAr;
-  public static final String[] EDDTableTabularDatasetTooltipAr;
-  public static final String[] EDDTableVariableAr;
-  public static final String[] EDDTableCheckAllAr;
-  public static final String[] EDDTableCheckAllTooltipAr;
-  public static final String[] EDDTableUncheckAllAr;
-  public static final String[] EDDTableUncheckAllTooltipAr;
-  public static final String[] EDDTableMinimumTooltipAr;
-  public static final String[] EDDTableMaximumTooltipAr;
-  public static final String[] EDDTableCheckTheVariablesAr;
-  public static final String[] EDDTableSelectAnOperatorAr;
-  public static final String[] EDDTableFromEDDGridSummaryAr;
-  public static final String[] EDDTableOptConstraint1HtmlAr;
-  public static final String[] EDDTableOptConstraint2HtmlAr;
-  public static final String[] EDDTableOptConstraintVarAr;
-  public static final String[] EDDTableNumericConstraintTooltipAr;
-  public static final String[] EDDTableStringConstraintTooltipAr;
-  public static final String[] EDDTableTimeConstraintTooltipAr;
-  public static final String[] EDDTableConstraintTooltipAr;
-  public static final String[] EDDTableSelectConstraintTooltipAr;
-  public static final String[] EDDTableDapDescriptionAr;
-  public static final String[] EDDTableDapLongDescriptionAr;
-  public static final String[] EDDTableDownloadDataTooltipAr;
-  public static final String[] erddapIsAr;
-  public static final String[] erddapVersionHTMLAr;
-  public static final String[] errorTitleAr;
-  public static final String[] errorRequestUrlAr;
-  public static final String[] errorRequestQueryAr;
-  public static final String[] errorTheErrorAr;
-  public static final String[] errorCopyFromAr;
-  public static final String[] errorFileNotFoundAr;
-  public static final String[] errorFileNotFoundImageAr;
-  public static final String[] errorInternalAr;
-  public static final String[] errorJsonpFunctionNameAr;
-  public static final String[] errorJsonpNotAllowedAr;
-  public static final String[] errorMoreThan2GBAr;
-  public static final String[] errorNotFoundAr;
-  public static final String[] errorNotFoundInAr;
-  public static final String[] errorOdvLLTGridAr;
-  public static final String[] errorOdvLLTTableAr;
-  public static final String[] errorOnWebPageAr;
-  public static final String[] externalLinkAr;
-  public static final String[] externalWebSiteAr;
-  public static final String[] fileHelp_ascAr;
-  public static final String[] fileHelp_csvAr;
-  public static final String[] fileHelp_csvpAr;
-  public static final String[] fileHelp_csv0Ar;
-  public static final String[] fileHelp_dataTableAr;
-  public static final String[] fileHelp_dasAr;
-  public static final String[] fileHelp_ddsAr;
-  public static final String[] fileHelp_dodsAr;
-  public static final String[] fileHelpGrid_esriAsciiAr;
-  public static final String[] fileHelpTable_esriCsvAr;
-  public static final String[] fileHelp_fgdcAr;
-  public static final String[] fileHelp_geoJsonAr;
-  public static final String[] fileHelp_graphAr;
-  public static final String[] fileHelpGrid_helpAr;
-  public static final String[] fileHelpTable_helpAr;
-  public static final String[] fileHelp_htmlAr;
-  public static final String[] fileHelp_htmlTableAr;
-  public static final String[] fileHelp_iso19115Ar;
-  public static final String[] fileHelp_itxGridAr;
-  public static final String[] fileHelp_itxTableAr;
-  public static final String[] fileHelp_jsonAr;
-  public static final String[] fileHelp_jsonlCSV1Ar;
-  public static final String[] fileHelp_jsonlCSVAr;
-  public static final String[] fileHelp_jsonlKVPAr;
-  public static final String[] fileHelp_matAr;
-  public static final String[] fileHelpGrid_nc3Ar;
-  public static final String[] fileHelpGrid_nc4Ar;
-  public static final String[] fileHelpTable_nc3Ar;
-  public static final String[] fileHelpTable_nc4Ar;
-  public static final String[] fileHelp_nc3HeaderAr;
-  public static final String[] fileHelp_nc4HeaderAr;
-  public static final String[] fileHelp_nccsvAr;
-  public static final String[] fileHelp_nccsvMetadataAr;
-  public static final String[] fileHelp_ncCFAr;
-  public static final String[] fileHelp_ncCFHeaderAr;
-  public static final String[] fileHelp_ncCFMAAr;
-  public static final String[] fileHelp_ncCFMAHeaderAr;
-  public static final String[] fileHelp_ncmlAr;
-  public static final String[] fileHelp_ncoJsonAr;
-  public static final String[] fileHelpGrid_odvTxtAr;
-  public static final String[] fileHelpTable_odvTxtAr;
-  public static final String[] fileHelp_parquetAr;
-  public static final String[] fileHelp_parquet_with_metaAr;
-  public static final String[] fileHelp_subsetAr;
-  public static final String[] fileHelp_timeGapsAr;
-  public static final String[] fileHelp_tsvAr;
-  public static final String[] fileHelp_tsvpAr;
-  public static final String[] fileHelp_tsv0Ar;
-  public static final String[] fileHelp_wavAr;
-  public static final String[] fileHelp_xhtmlAr;
-  public static final String[] fileHelp_geotifAr; // graphical
-  public static final String[] fileHelpGrid_kmlAr;
-  public static final String[] fileHelpTable_kmlAr;
-  public static final String[] fileHelp_smallPdfAr;
-  public static final String[] fileHelp_pdfAr;
-  public static final String[] fileHelp_largePdfAr;
-  public static final String[] fileHelp_smallPngAr;
-  public static final String[] fileHelp_pngAr;
-  public static final String[] fileHelp_largePngAr;
-  public static final String[] fileHelp_transparentPngAr;
-  public static final String[] filesDescriptionAr;
-  public static final String[] filesSortAr;
-  public static final String[] filesWarningAr;
-  public static final String[] findOutChangeAr;
-  public static final String[] FIPSCountyCodesAr;
-  public static final String[] forSOSUseAr;
-  public static final String[] forWCSUseAr;
-  public static final String[] forWMSUseAr;
-  public static final String[] functionsAr;
-  public static final String[] functionTooltipAr;
-  public static final String[] functionDistinctCheckAr;
-  public static final String[] functionDistinctTooltipAr;
-  public static final String[] functionOrderByExtraAr;
-  public static final String[] functionOrderByTooltipAr;
-  public static final String[] functionOrderBySortAr;
-  public static final String[] functionOrderBySort1Ar;
-  public static final String[] functionOrderBySort2Ar;
-  public static final String[] functionOrderBySort3Ar;
-  public static final String[] functionOrderBySort4Ar;
-  public static final String[] functionOrderBySortLeastAr;
-  public static final String[] functionOrderBySortRowMaxAr;
-  public static final String[] generatedAtAr;
-  public static final String[] geoServicesDescriptionAr;
-  public static final String[] getStartedHtmlAr;
-  public static final String[] helpAr;
-  public static final String[] htmlTableMaxMessageAr;
-  public static final String[] imageDataCourtesyOfAr;
-  public static final String[] imagesEmbedAr;
-  public static final String[] indexViewAllAr;
-  public static final String[] indexSearchWithAr;
-  public static final String[] indexDevelopersSearchAr;
-  public static final String[] indexProtocolAr;
-  public static final String[] indexDescriptionAr;
-  public static final String[] indexDatasetsAr;
-  public static final String[] indexDocumentationAr;
-  public static final String[] indexRESTfulSearchAr;
-  public static final String[] indexAllDatasetsSearchAr;
-  public static final String[] indexOpenSearchAr;
-  public static final String[] indexServicesAr;
-  public static final String[] indexDescribeServicesAr;
-  public static final String[] indexMetadataAr;
-  public static final String[] indexWAF1Ar;
-  public static final String[] indexWAF2Ar;
-  public static final String[] indexConvertersAr;
-  public static final String[] indexDescribeConvertersAr;
-  public static final String[] infoAboutFromAr;
-  public static final String[] infoTableTitleHtmlAr;
-  public static final String[] infoRequestFormAr;
-  public static final String[] informationAr;
-  public static final String[] inotifyFixAr;
-  public static final String[] interpolateAr;
-  public static final String[] javaProgramsHTMLAr;
-  public static final String[] justGenerateAndViewAr;
-  public static final String[] justGenerateAndViewTooltipAr;
-  public static final String[] justGenerateAndViewUrlAr;
-  public static final String[] justGenerateAndViewGraphUrlTooltipAr;
-  public static final String[] keywordsAr;
-  public static final String[] langCodeAr;
-  public static final String[] legalNoticesAr;
-  public static final String[] legalNoticesTitleAr;
-  public static final String[] licenseAr;
-  public static final String[] likeThisAr;
-  public static final String[] listAllAr;
-  public static final String[] listOfDatasetsAr;
-  public static final String[] LogInAr;
-  public static final String[] loginAr;
-  public static final String[] loginHTMLAr;
-  public static final String[] loginAttemptBlockedAr;
-  public static final String[] loginDescribeCustomAr;
-  public static final String[] loginDescribeEmailAr;
-  public static final String[] loginDescribeGoogleAr;
-  public static final String[] loginDescribeOrcidAr;
-  public static final String[] loginDescribeOauth2Ar;
-  public static final String[] loginErddapAr;
-  public static final String[] loginCanNotAr;
-  public static final String[] loginAreNotAr;
-  public static final String[] loginToLogInAr;
-  public static final String[] loginEmailAddressAr;
-  public static final String[] loginYourEmailAddressAr;
-  public static final String[] loginUserNameAr;
-  public static final String[] loginPasswordAr;
-  public static final String[] loginUserNameAndPasswordAr;
-  public static final String[] loginGoogleSignInAr;
-  public static final String[] loginOrcidSignInAr;
-  public static final String[] loginOpenIDAr;
-  public static final String[] loginOpenIDOrAr;
-  public static final String[] loginOpenIDCreateAr;
-  public static final String[] loginOpenIDFreeAr;
-  public static final String[] loginOpenIDSameAr;
-  public static final String[] loginAsAr;
-  public static final String[] loginPartwayAsAr;
-  public static final String[] loginFailedAr;
-  public static final String[] loginSucceededAr;
-  public static final String[] loginInvalidAr;
-  public static final String[] loginNotAr;
-  public static final String[] loginBackAr;
-  public static final String[] loginProblemExactAr;
-  public static final String[] loginProblemExpireAr;
-  public static final String[] loginProblemGoogleAgainAr;
-  public static final String[] loginProblemOrcidAgainAr;
-  public static final String[] loginProblemOauth2AgainAr;
-  public static final String[] loginProblemSameBrowserAr;
-  public static final String[] loginProblem3TimesAr;
-  public static final String[] loginProblemsAr;
-  public static final String[] loginProblemsAfterAr;
-  public static final String[] loginPublicAccessAr;
-  public static final String[] LogOutAr;
-  public static final String[] logoutAr;
-  public static final String[] logoutOpenIDAr;
-  public static final String[] logoutSuccessAr;
-  public static final String[] magAr;
-  public static final String[] magAxisXAr;
-  public static final String[] magAxisYAr;
-  public static final String[] magAxisColorAr;
-  public static final String[] magAxisStickXAr;
-  public static final String[] magAxisStickYAr;
-  public static final String[] magAxisVectorXAr;
-  public static final String[] magAxisVectorYAr;
-  public static final String[] magAxisHelpGraphXAr;
-  public static final String[] magAxisHelpGraphYAr;
-  public static final String[] magAxisHelpMarkerColorAr;
-  public static final String[] magAxisHelpSurfaceColorAr;
-  public static final String[] magAxisHelpStickXAr;
-  public static final String[] magAxisHelpStickYAr;
-  public static final String[] magAxisHelpMapXAr;
-  public static final String[] magAxisHelpMapYAr;
-  public static final String[] magAxisHelpVectorXAr;
-  public static final String[] magAxisHelpVectorYAr;
-  public static final String[] magAxisVarHelpAr;
-  public static final String[] magAxisVarHelpGridAr;
-  public static final String[] magConstraintHelpAr;
-  public static final String[] magDocumentationAr;
-  public static final String[] magDownloadAr;
-  public static final String[] magDownloadTooltipAr;
-  public static final String[] magFileTypeAr;
-  public static final String[] magGraphTypeAr;
-  public static final String[] magGraphTypeTooltipGridAr;
-  public static final String[] magGraphTypeTooltipTableAr;
-  public static final String[] magGSAr;
-  public static final String[] magGSMarkerTypeAr;
-  public static final String[] magGSSizeAr;
-  public static final String[] magGSColorAr;
-  public static final String[] magGSColorBarAr;
-  public static final String[] magGSColorBarTooltipAr;
-  public static final String[] magGSContinuityAr;
-  public static final String[] magGSContinuityTooltipAr;
-  public static final String[] magGSScaleAr;
-  public static final String[] magGSScaleTooltipAr;
-  public static final String[] magGSMinAr;
-  public static final String[] magGSMinTooltipAr;
-  public static final String[] magGSMaxAr;
-  public static final String[] magGSMaxTooltipAr;
-  public static final String[] magGSNSectionsAr;
-  public static final String[] magGSNSectionsTooltipAr;
-  public static final String[] magGSLandMaskAr;
-  public static final String[] magGSLandMaskTooltipGridAr;
-  public static final String[] magGSLandMaskTooltipTableAr;
-  public static final String[] magGSVectorStandardAr;
-  public static final String[] magGSVectorStandardTooltipAr;
-  public static final String[] magGSYAscendingTooltipAr;
-  public static final String[] magGSYAxisMinAr;
-  public static final String[] magGSYAxisMaxAr;
-  public static final String[] magGSYRangeMinTooltipAr;
-  public static final String[] magGSYRangeMaxTooltipAr;
-  public static final String[] magGSYRangeTooltipAr;
-  public static final String[] magGSYScaleTooltipAr;
-  public static final String[] magItemFirstAr;
-  public static final String[] magItemPreviousAr;
-  public static final String[] magItemNextAr;
-  public static final String[] magItemLastAr;
-  public static final String[] magJust1ValueAr;
-  public static final String[] magRangeAr;
-  public static final String[] magRangeToAr;
-  public static final String[] magRedrawAr;
-  public static final String[] magRedrawTooltipAr;
-  public static final String[] magTimeRangeAr;
-  public static final String[] magTimeRangeFirstAr;
-  public static final String[] magTimeRangeBackAr;
-  public static final String[] magTimeRangeForwardAr;
-  public static final String[] magTimeRangeLastAr;
-  public static final String[] magTimeRangeTooltipAr;
-  public static final String[] magTimeRangeTooltip2Ar;
-  public static final String[] magTimesVaryAr;
-  public static final String[] magViewUrlAr;
-  public static final String[] magZoomAr;
-  public static final String[] magZoomCenterAr;
-  public static final String[] magZoomCenterTooltipAr;
-  public static final String[] magZoomInAr;
-  public static final String[] magZoomInTooltipAr;
-  public static final String[] magZoomOutAr;
-  public static final String[] magZoomOutTooltipAr;
-  public static final String[] magZoomALittleAr;
-  public static final String[] magZoomDataAr;
-  public static final String[] magZoomOutDataAr;
-  public static final String[] magGridTooltipAr;
-  public static final String[] magTableTooltipAr;
-  public static final String[] metadataDownloadAr;
-  public static final String[] moreInformationAr;
-  public static final String[] nMatching1Ar;
-  public static final String[] nMatchingAr;
-  public static final String[] nMatchingAlphabeticalAr;
-  public static final String[] nMatchingMostRelevantAr;
-  public static final String[] nMatchingPageAr;
-  public static final String[] nMatchingCurrentAr;
-  public static final String[] noDataFixedValueAr;
-  public static final String[] noDataNoLLAr;
-  public static final String[] noDatasetWithAr;
-  public static final String[] noPage1Ar;
-  public static final String[] noPage2Ar;
-  public static final String[] notAllowedAr;
-  public static final String[] notAuthorizedAr;
-  public static final String[] notAuthorizedForDataAr;
-  public static final String[] notAvailableAr;
-  public static final String[] noteAr;
-  public static final String[] noXxxAr;
-  public static final String[] noXxxBecauseAr;
-  public static final String[] noXxxBecause2Ar;
-  public static final String[] noXxxNotActiveAr;
-  public static final String[] noXxxNoAxis1Ar;
-  public static final String[] noXxxNoColorBarAr;
-  public static final String[] noXxxNoCdmDataTypeAr;
-  public static final String[] noXxxNoLLAr;
-  public static final String[] noXxxNoLLEvenlySpacedAr;
-  public static final String[] noXxxNoLLGt1Ar;
-  public static final String[] noXxxNoLLTAr;
-  public static final String[] noXxxNoLonIn180Ar;
-  public static final String[] noXxxNoNonStringAr;
-  public static final String[] noXxxNo2NonStringAr;
-  public static final String[] noXxxNoStationAr;
-  public static final String[] noXxxNoStationIDAr;
-  public static final String[] noXxxNoSubsetVariablesAr;
-  public static final String[] noXxxNoOLLSubsetVariablesAr;
-  public static final String[] noXxxNoMinMaxAr;
-  public static final String[] noXxxItsGriddedAr;
-  public static final String[] noXxxItsTabularAr;
-  public static final String[] oneRequestAtATimeAr;
-  public static final String[] openSearchDescriptionAr;
-  public static final String[] optionalAr;
-  public static final String[] optionsAr;
-  public static final String[] orAListOfValuesAr;
-  public static final String[] orRefineSearchWithAr;
-  public static final String[] orSearchWithAr;
-  public static final String[] orCommaAr;
-  public static final String[] otherFeaturesAr;
-  public static final String[] outOfDateDatasetsAr;
-  public static final String[] outOfDateKeepTrackAr;
-  public static final String[] outOfDateHtmlAr;
-  public static final String[] patientDataAr;
-  public static final String[] patientYourGraphAr;
-  public static final String[] percentEncodeAr;
-  public static final String[] pickADatasetAr;
-  public static final String[] protocolSearchHtmlAr;
-  public static final String[] protocolSearch2HtmlAr;
-  public static final String[] protocolClickAr;
-  public static final String[] queryErrorAr;
-  public static final String[] queryError180Ar;
-  public static final String[] queryError1ValueAr;
-  public static final String[] queryError1VarAr;
-  public static final String[] queryError2VarAr;
-  public static final String[] queryErrorActualRangeAr;
-  public static final String[] queryErrorAdjustedAr;
-  public static final String[] queryErrorAscendingAr;
-  public static final String[] queryErrorConstraintNaNAr;
-  public static final String[] queryErrorEqualSpacingAr;
-  public static final String[] queryErrorExpectedAtAr;
-  public static final String[] queryErrorFileTypeAr;
-  public static final String[] queryErrorInvalidAr;
-  public static final String[] queryErrorLLAr;
-  public static final String[] queryErrorLLGt1Ar;
-  public static final String[] queryErrorLLTAr;
-  public static final String[] queryErrorNeverTrueAr;
-  public static final String[] queryErrorNeverBothTrueAr;
-  public static final String[] queryErrorNotAxisAr;
-  public static final String[] queryErrorNotExpectedAtAr;
-  public static final String[] queryErrorNotFoundAfterAr;
-  public static final String[] queryErrorOccursTwiceAr;
-  public static final String[] queryErrorOrderByClosestAr;
-  public static final String[] queryErrorOrderByLimitAr;
-  public static final String[] queryErrorOrderByMeanAr;
-  public static final String[] queryErrorOrderBySumAr;
-  public static final String[] queryErrorOrderByVariableAr;
-  public static final String[] queryErrorUnknownVariableAr;
-  public static final String[] queryErrorGrid1AxisAr;
-  public static final String[] queryErrorGridAmpAr;
-  public static final String[] queryErrorGridDiagnosticAr;
-  public static final String[] queryErrorGridBetweenAr;
-  public static final String[] queryErrorGridLessMinAr;
-  public static final String[] queryErrorGridGreaterMaxAr;
-  public static final String[] queryErrorGridMissingAr;
-  public static final String[] queryErrorGridNoAxisVarAr;
-  public static final String[] queryErrorGridNoDataVarAr;
-  public static final String[] queryErrorGridNotIdenticalAr;
-  public static final String[] queryErrorGridSLessSAr;
-  public static final String[] queryErrorLastEndPAr;
-  public static final String[] queryErrorLastExpectedAr;
-  public static final String[] queryErrorLastUnexpectedAr;
-  public static final String[] queryErrorLastPMInvalidAr;
-  public static final String[] queryErrorLastPMIntegerAr;
-  public static final String[] rangesFromToAr;
-  public static final String[] requiredAr;
-  public static final String[] resetTheFormAr;
-  public static final String[] resetTheFormWasAr;
-  public static final String[] resourceNotFoundAr;
-  public static final String[] restfulWebServicesAr;
-  public static final String[] restfulHTMLAr;
-  public static final String[] restfulHTMLContinuedAr;
-  public static final String[] restfulGetAllDatasetAr;
-  public static final String[] restfulProtocolsAr;
-  public static final String[] SOSDocumentationAr;
-  public static final String[] WCSDocumentationAr;
-  public static final String[] WMSDocumentationAr;
-  public static final String[] requestFormatExamplesHtmlAr;
-  public static final String[] resultsFormatExamplesHtmlAr;
-  public static final String[] resultsOfSearchForAr;
-  public static final String[] restfulInformationFormatsAr;
-  public static final String[] restfulViaServiceAr;
-  public static final String[] rowsAr;
-  public static final String[] rssNoAr;
-  public static final String[] searchTitleAr;
-  public static final String[] searchDoFullTextHtmlAr;
-  public static final String[] searchFullTextHtmlAr;
-  public static final String[] searchHintsLuceneTooltipAr;
-  public static final String[] searchHintsOriginalTooltipAr;
-  public static final String[] searchHintsTooltipAr;
-  public static final String[] searchButtonAr;
-  public static final String[] searchClickTipAr;
-  public static final String[] searchMultipleERDDAPsAr;
-  public static final String[] searchMultipleERDDAPsDescriptionAr;
-  public static final String[] searchNotAvailableAr;
-  public static final String[] searchTipAr;
-  public static final String[] searchSpellingAr;
-  public static final String[] searchFewerWordsAr;
-  public static final String[] searchWithQueryAr;
-  public static final String[] seeProtocolDocumentationAr;
-  public static final String[] selectNextAr;
-  public static final String[] selectPreviousAr;
-  public static final String[] shiftXAllTheWayLeftAr;
-  public static final String[] shiftXLeftAr;
-  public static final String[] shiftXRightAr;
-  public static final String[] shiftXAllTheWayRightAr;
-  public static final String[] slideSorterAr;
-  public static final String[] SOSAr;
-  public static final String[] sosDescriptionHtmlAr;
-  public static final String[] sosLongDescriptionHtmlAr;
-  public static final String[] sosOverview1Ar;
-  public static final String[] sosOverview2Ar;
-  public static final String[] ssUseAr;
-  public static final String[] ssUsePlainAr;
-  public static final String[] ssBePatientAr;
-  public static final String[] ssInstructionsHtmlAr;
-  public static final String[] standardShortDescriptionHtmlAr;
-  public static final String[] statusAr;
-  public static final String[] statusHtmlAr;
-  public static final String[] submitAr;
-  public static final String[] submitTooltipAr;
-  public static final String[] subscriptionOfferRssAr;
-  public static final String[] subscriptionOfferUrlAr;
-  public static final String[] subscriptionsTitleAr;
-  public static final String[] subscriptionEmailListAr;
-  public static final String[] subscriptionAddAr;
-  public static final String[] subscriptionAddHtmlAr;
-  public static final String[] subscriptionValidateAr;
-  public static final String[] subscriptionValidateHtmlAr;
-  public static final String[] subscriptionListAr;
-  public static final String[] subscriptionListHtmlAr;
-  public static final String[] subscriptionRemoveAr;
-  public static final String[] subscriptionRemoveHtmlAr;
-  public static final String[] subscriptionAbuseAr;
-  public static final String[] subscriptionAddErrorAr;
-  public static final String[] subscriptionAdd2Ar;
-  public static final String[] subscriptionAddSuccessAr;
-  public static final String[] subscriptionEmailAr;
-  public static final String[] subscriptionEmailOnBlacklistAr;
-  public static final String[] subscriptionEmailInvalidAr;
-  public static final String[] subscriptionEmailTooLongAr;
-  public static final String[] subscriptionEmailUnspecifiedAr;
-  public static final String[] subscription0HtmlAr;
-  public static final String[] subscription1HtmlAr;
-  public static final String[] subscription2HtmlAr;
-  public static final String[] subscriptionIDInvalidAr;
-  public static final String[] subscriptionIDTooLongAr;
-  public static final String[] subscriptionIDUnspecifiedAr;
-  public static final String[] subscriptionKeyInvalidAr;
-  public static final String[] subscriptionKeyUnspecifiedAr;
-  public static final String[] subscriptionListErrorAr;
-  public static final String[] subscriptionListSuccessAr;
-  public static final String[] subscriptionRemoveErrorAr;
-  public static final String[] subscriptionRemove2Ar;
-  public static final String[] subscriptionRemoveSuccessAr;
-  public static final String[] subscriptionRSSAr;
-  public static final String[] subscriptionsNotAvailableAr;
-  public static final String[] subscriptionUrlHtmlAr;
-  public static final String[] subscriptionUrlInvalidAr;
-  public static final String[] subscriptionUrlTooLongAr;
-  public static final String[] subscriptionValidateErrorAr;
-  public static final String[] subscriptionValidateSuccessAr;
-  public static final String[] subsetAr;
-  public static final String[] subsetSelectAr;
-  public static final String[] subsetNMatchingAr;
-  public static final String[] subsetInstructionsAr;
-  public static final String[] subsetOptionAr;
-  public static final String[] subsetOptionsAr;
-  public static final String[] subsetRefineMapDownloadAr;
-  public static final String[] subsetRefineSubsetDownloadAr;
-  public static final String[] subsetClickResetClosestAr;
-  public static final String[] subsetClickResetLLAr;
-  public static final String[] subsetMetadataAr;
-  public static final String[] subsetCountAr;
-  public static final String[] subsetPercentAr;
-  public static final String[] subsetViewSelectAr;
-  public static final String[] subsetViewSelectDistinctCombosAr;
-  public static final String[] subsetViewSelectRelatedCountsAr;
-  public static final String[] subsetWhenAr;
-  public static final String[] subsetWhenNoConstraintsAr;
-  public static final String[] subsetWhenCountsAr;
-  public static final String[] subsetComboClickSelectAr;
-  public static final String[] subsetNVariableCombosAr;
-  public static final String[] subsetShowingAllRowsAr;
-  public static final String[] subsetShowingNRowsAr;
-  public static final String[] subsetChangeShowingAr;
-  public static final String[] subsetNRowsRelatedDataAr;
-  public static final String[] subsetViewRelatedChangeAr;
-  public static final String[] subsetTotalCountAr;
-  public static final String[] subsetViewAr;
-  public static final String[] subsetViewCheckAr;
-  public static final String[] subsetViewCheck1Ar;
-  public static final String[] subsetViewDistinctMapAr;
-  public static final String[] subsetViewRelatedMapAr;
-  public static final String[] subsetViewDistinctDataCountsAr;
-  public static final String[] subsetViewDistinctDataAr;
-  public static final String[] subsetViewRelatedDataCountsAr;
-  public static final String[] subsetViewRelatedDataAr;
-  public static final String[] subsetViewDistinctMapTooltipAr;
-  public static final String[] subsetViewRelatedMapTooltipAr;
-  public static final String[] subsetViewDistinctDataCountsTooltipAr;
-  public static final String[] subsetViewDistinctDataTooltipAr;
-  public static final String[] subsetViewRelatedDataCountsTooltipAr;
-  public static final String[] subsetViewRelatedDataTooltipAr;
-  public static final String[] subsetWarnAr;
-  public static final String[] subsetWarn10000Ar;
-  public static final String[] subsetTooltipAr;
-  public static final String[] subsetNotSetUpAr;
-  public static final String[] subsetLongNotShownAr;
-  public static final String[] tabledapVideoIntroAr;
-  public static final String[] theDatasetIDAr;
-  public static final String[] theKeyAr;
-  public static final String[] theSubscriptionIDAr;
-  public static final String[] theUrlActionAr;
-  public static final String[] ThenAr;
-  public static final String[] thisParticularErddapAr;
-  public static final String[] timeAr;
-  public static final String[] timeoutOtherRequestsAr;
-  public static final String[] unitsAr;
-  public static final String[] unknownDatasetIDAr;
-  public static final String[] unknownProtocolAr;
-  public static final String[] unsupportedFileTypeAr;
-  public static final String[] updateUrlsFrom; // not Ar. They were arrays before and now
-  public static final String[] updateUrlsTo; // not Ar
-  public static final String[] updateUrlsSkipAttributes; // not Ar
-  public static final String[] usingGriddapAr;
-  public static final String[] usingTabledapAr;
-  public static final String[] variableNamesAr;
-  public static final String[] viewAllDatasetsHtmlAr;
-  public static final String[] waitThenTryAgainAr;
-  public static final String[] warningAr;
-  public static final String[] WCSAr;
-  public static final String[] wcsDescriptionHtmlAr;
-  public static final String[] wcsLongDescriptionHtmlAr;
-  public static final String[] wcsOverview1Ar;
-  public static final String[] wcsOverview2Ar;
-  public static final String[] wmsDescriptionHtmlAr;
-  public static final String[] WMSDocumentation1Ar;
-  public static final String[] WMSGetCapabilitiesAr;
-  public static final String[] WMSGetMapAr;
-  public static final String[] WMSNotesAr;
-  public static final String[] wmsInstructionsAr;
-  public static final String[] wmsLongDescriptionHtmlAr;
-  public static final String[] wmsManyDatasetsAr;
-  public static final String[] yourEmailAddressAr;
-  public static final String[] zoomInAr;
-  public static final String[] zoomOutAr;
-  public static final int[] imageWidths;
-  public static final int[] imageHeights;
-  public static final int[] pdfWidths;
-  public static final int[] pdfHeights;
-  private static final String[] theLongDescriptionHtmlAr; // see the xxx() methods
-  public static final String errorFromDataSource = String2.ERROR + " from data source: ";
-  public static final int nLanguages = TranslateMessages.languageList.size();
 
   /**
    * These are only created/used by GenerateDatasetsXml threads. See the related methods below that
@@ -1856,10 +801,7 @@ public class EDStatic {
 
       fullPaletteDirectory = webInfParentDirectory + "WEB-INF/cptfiles/";
       fullPublicDirectory = webInfParentDirectory + PUBLIC_DIR;
-      downloadDir = webInfParentDirectory + DOWNLOAD_DIR; // local directory on this computer
       imageDir = webInfParentDirectory + IMAGES_DIR; // local directory on this computer
-
-      skipEmailThread = Boolean.parseBoolean(System.getProperty("skipEmailThread"));
 
       // route calls to a logger to com.cohort.util.String2Log
       String2.setupCommonsLogging(-1);
@@ -1879,6 +821,7 @@ public class EDStatic {
               + eol
               + String2.standardHelpAboutMessage());
 
+      skipEmailThread = Boolean.parseBoolean(System.getProperty("skipEmailThread"));
       // **** find contentDirectory
       String ecd = "erddapContentDirectory"; // the name of the environment variable
       errorInMethod =
@@ -2442,1798 +1385,7 @@ public class EDStatic {
         File2.copy(contentDirectory + "cptfiles/" + tFile, fullPaletteDirectory + tFile);
       }
 
-      // **** messages.xml *************************************************************
-      // This is read AFTER setup.xml. If that is a problem for something, defer reading it in setup
-      // and add it below.
-      // Read static messages from messages(2).xml in contentDirectory.
-      errorInMethod = "ERROR while reading messages.xml: ";
-      ResourceBundle2[] messagesAr = new ResourceBundle2[nLanguages];
-      String messagesFileName = contentDirectory + "messages.xml";
-      if (File2.isFile(messagesFileName)) {
-        String2.log("Using custom messages.xml from " + messagesFileName);
-        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
-        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false));
-      } else {
-        // use default messages.xml
-        String2.log("Custom messages.xml not found at " + messagesFileName);
-        // use String2.getClass(), not ClassLoader.getSystemResource (which fails in Tomcat)
-        URL messagesResourceFile = Resources.getResource("gov/noaa/pfel/erddap/util/messages.xml");
-        // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
-        messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesResourceFile, false));
-        String2.log("Using default messages.xml from  " + messagesFileName);
-      }
-
-      for (int tl = 1; tl < nLanguages; tl++) {
-        String tName = "messages-" + TranslateMessages.languageCodeList.get(tl) + ".xml";
-        errorInMethod = "ERROR while reading " + tName + ": ";
-        URL messageFile = new URL(TranslateMessages.translatedMessagesDir + tName);
-        messagesAr[tl] = ResourceBundle2.fromXml(XML.parseXml(messageFile, false));
-      }
-
-      // read all the static Strings from messages.xml
-      errorInMethod = "ERROR while reading from all the messages.xml files: ";
-      acceptEncodingHtmlAr = getNotNothingString(messagesAr, "acceptEncodingHtml", errorInMethod);
-      accessRESTFULAr = getNotNothingString(messagesAr, "accessRestful", errorInMethod);
-      acronymsAr = getNotNothingString(messagesAr, "acronyms", errorInMethod);
-      addConstraintsAr = getNotNothingString(messagesAr, "addConstraints", errorInMethod);
-      addVarWhereAttNameAr = getNotNothingString(messagesAr, "addVarWhereAttName", errorInMethod);
-      addVarWhereAttValueAr = getNotNothingString(messagesAr, "addVarWhereAttValue", errorInMethod);
-      addVarWhereAr = getNotNothingString(messagesAr, "addVarWhere", errorInMethod);
-      additionalLinksAr = getNotNothingString(messagesAr, "additionalLinks", errorInMethod);
-      admKeywords = messagesAr[0].getNotNothingString("admKeywords", errorInMethod);
-      admSubsetVariables = messagesAr[0].getNotNothingString("admSubsetVariables", errorInMethod);
-      admSummaryAr = getNotNothingString(messagesAr, "admSummary", errorInMethod);
-      admTitleAr = getNotNothingString(messagesAr, "admTitle", errorInMethod);
-      advl_datasetID = messagesAr[0].getNotNothingString("advl_datasetID", errorInMethod);
-      advc_accessibleAr = getNotNothingString(messagesAr, "advc_accessible", errorInMethod);
-      advl_accessibleAr = getNotNothingString(messagesAr, "advl_accessible", errorInMethod);
-      advl_institutionAr = getNotNothingString(messagesAr, "advl_institution", errorInMethod);
-      advc_dataStructureAr = getNotNothingString(messagesAr, "advc_dataStructure", errorInMethod);
-      advl_dataStructureAr = getNotNothingString(messagesAr, "advl_dataStructure", errorInMethod);
-      advr_dataStructure = messagesAr[0].getNotNothingString("advr_dataStructure", errorInMethod);
-      advl_cdm_data_typeAr = getNotNothingString(messagesAr, "advl_cdm_data_type", errorInMethod);
-      advr_cdm_data_type = messagesAr[0].getNotNothingString("advr_cdm_data_type", errorInMethod);
-      advl_classAr = getNotNothingString(messagesAr, "advl_class", errorInMethod);
-      advr_class = messagesAr[0].getNotNothingString("advr_class", errorInMethod);
-      advl_titleAr = getNotNothingString(messagesAr, "advl_title", errorInMethod);
-      advl_minLongitudeAr = getNotNothingString(messagesAr, "advl_minLongitude", errorInMethod);
-      advl_maxLongitudeAr = getNotNothingString(messagesAr, "advl_maxLongitude", errorInMethod);
-      advl_longitudeSpacingAr =
-          getNotNothingString(messagesAr, "advl_longitudeSpacing", errorInMethod);
-      advl_minLatitudeAr = getNotNothingString(messagesAr, "advl_minLatitude", errorInMethod);
-      advl_maxLatitudeAr = getNotNothingString(messagesAr, "advl_maxLatitude", errorInMethod);
-      advl_latitudeSpacingAr =
-          getNotNothingString(messagesAr, "advl_latitudeSpacing", errorInMethod);
-      advl_minAltitudeAr = getNotNothingString(messagesAr, "advl_minAltitude", errorInMethod);
-      advl_maxAltitudeAr = getNotNothingString(messagesAr, "advl_maxAltitude", errorInMethod);
-      advl_minTimeAr = getNotNothingString(messagesAr, "advl_minTime", errorInMethod);
-      advc_maxTimeAr = getNotNothingString(messagesAr, "advc_maxTime", errorInMethod);
-      advl_maxTimeAr = getNotNothingString(messagesAr, "advl_maxTime", errorInMethod);
-      advl_timeSpacingAr = getNotNothingString(messagesAr, "advl_timeSpacing", errorInMethod);
-      advc_griddapAr = getNotNothingString(messagesAr, "advc_griddap", errorInMethod);
-      advl_griddapAr = getNotNothingString(messagesAr, "advl_griddap", errorInMethod);
-      advl_subsetAr = getNotNothingString(messagesAr, "advl_subset", errorInMethod);
-      advc_tabledapAr = getNotNothingString(messagesAr, "advc_tabledap", errorInMethod);
-      advl_tabledapAr = getNotNothingString(messagesAr, "advl_tabledap", errorInMethod);
-      advl_MakeAGraphAr = getNotNothingString(messagesAr, "advl_MakeAGraph", errorInMethod);
-      advc_sosAr = getNotNothingString(messagesAr, "advc_sos", errorInMethod);
-      advl_sosAr = getNotNothingString(messagesAr, "advl_sos", errorInMethod);
-      advl_wcsAr = getNotNothingString(messagesAr, "advl_wcs", errorInMethod);
-      advl_wmsAr = getNotNothingString(messagesAr, "advl_wms", errorInMethod);
-      advc_filesAr = getNotNothingString(messagesAr, "advc_files", errorInMethod);
-      advl_filesAr = getNotNothingString(messagesAr, "advl_files", errorInMethod);
-      advc_fgdcAr = getNotNothingString(messagesAr, "advc_fgdc", errorInMethod);
-      advl_fgdcAr = getNotNothingString(messagesAr, "advl_fgdc", errorInMethod);
-      advc_iso19115Ar = getNotNothingString(messagesAr, "advc_iso19115", errorInMethod);
-      advl_iso19115Ar = getNotNothingString(messagesAr, "advl_iso19115", errorInMethod);
-      advc_metadataAr = getNotNothingString(messagesAr, "advc_metadata", errorInMethod);
-      advl_metadataAr = getNotNothingString(messagesAr, "advl_metadata", errorInMethod);
-      advl_sourceUrlAr = getNotNothingString(messagesAr, "advl_sourceUrl", errorInMethod);
-      advl_infoUrlAr = getNotNothingString(messagesAr, "advl_infoUrl", errorInMethod);
-      advl_rssAr = getNotNothingString(messagesAr, "advl_rss", errorInMethod);
-      advc_emailAr = getNotNothingString(messagesAr, "advc_email", errorInMethod);
-      advl_emailAr = getNotNothingString(messagesAr, "advl_email", errorInMethod);
-      advl_summaryAr = getNotNothingString(messagesAr, "advl_summary", errorInMethod);
-      advc_testOutOfDateAr = getNotNothingString(messagesAr, "advc_testOutOfDate", errorInMethod);
-      advl_testOutOfDateAr = getNotNothingString(messagesAr, "advl_testOutOfDate", errorInMethod);
-      advc_outOfDateAr = getNotNothingString(messagesAr, "advc_outOfDate", errorInMethod);
-      advl_outOfDateAr = getNotNothingString(messagesAr, "advl_outOfDate", errorInMethod);
-      advn_outOfDateAr = getNotNothingString(messagesAr, "advn_outOfDate", errorInMethod);
-      advancedSearchAr = getNotNothingString(messagesAr, "advancedSearch", errorInMethod);
-      advancedSearchResultsAr =
-          getNotNothingString(messagesAr, "advancedSearchResults", errorInMethod);
-      advancedSearchDirectionsAr =
-          getNotNothingString(messagesAr, "advancedSearchDirections", errorInMethod);
-      advancedSearchTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchTooltip", errorInMethod);
-      advancedSearchBoundsAr =
-          getNotNothingString(messagesAr, "advancedSearchBounds", errorInMethod);
-      advancedSearchMinLatAr =
-          getNotNothingString(messagesAr, "advancedSearchMinLat", errorInMethod);
-      advancedSearchMaxLatAr =
-          getNotNothingString(messagesAr, "advancedSearchMaxLat", errorInMethod);
-      advancedSearchMinLonAr =
-          getNotNothingString(messagesAr, "advancedSearchMinLon", errorInMethod);
-      advancedSearchMaxLonAr =
-          getNotNothingString(messagesAr, "advancedSearchMaxLon", errorInMethod);
-      advancedSearchMinMaxLonAr =
-          getNotNothingString(messagesAr, "advancedSearchMinMaxLon", errorInMethod);
-      advancedSearchMinTimeAr =
-          getNotNothingString(messagesAr, "advancedSearchMinTime", errorInMethod);
-      advancedSearchMaxTimeAr =
-          getNotNothingString(messagesAr, "advancedSearchMaxTime", errorInMethod);
-      advancedSearchClearAr = getNotNothingString(messagesAr, "advancedSearchClear", errorInMethod);
-      advancedSearchClearHelpAr =
-          getNotNothingString(messagesAr, "advancedSearchClearHelp", errorInMethod);
-      advancedSearchCategoryTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchCategoryTooltip", errorInMethod);
-      advancedSearchRangeTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchRangeTooltip", errorInMethod);
-      advancedSearchMapTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchMapTooltip", errorInMethod);
-      advancedSearchLonTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchLonTooltip", errorInMethod);
-      advancedSearchTimeTooltipAr =
-          getNotNothingString(messagesAr, "advancedSearchTimeTooltip", errorInMethod);
-      advancedSearchWithCriteriaAr =
-          getNotNothingString(messagesAr, "advancedSearchWithCriteria", errorInMethod);
-      advancedSearchFewerCriteriaAr =
-          getNotNothingString(messagesAr, "advancedSearchFewerCriteria", errorInMethod);
-      advancedSearchNoCriteriaAr =
-          getNotNothingString(messagesAr, "advancedSearchNoCriteria", errorInMethod);
-      advancedSearchErrorHandlingAr =
-          getNotNothingString(messagesAr, "advancedSearchErrorHandling", errorInMethod);
-      PrimitiveArray.ArrayAddN = messagesAr[0].getNotNothingString("ArrayAddN", errorInMethod);
-      PrimitiveArray.ArrayAppendTables =
-          messagesAr[0].getNotNothingString("ArrayAppendTables", errorInMethod);
-      PrimitiveArray.ArrayAtInsert =
-          messagesAr[0].getNotNothingString("ArrayAtInsert", errorInMethod);
-      PrimitiveArray.ArrayDiff = messagesAr[0].getNotNothingString("ArrayDiff", errorInMethod);
-      PrimitiveArray.ArrayDifferentSize =
-          messagesAr[0].getNotNothingString("ArrayDifferentSize", errorInMethod);
-      PrimitiveArray.ArrayDifferentValue =
-          messagesAr[0].getNotNothingString("ArrayDifferentValue", errorInMethod);
-      PrimitiveArray.ArrayDiffString =
-          messagesAr[0].getNotNothingString("ArrayDiffString", errorInMethod);
-      PrimitiveArray.ArrayMissingValue =
-          messagesAr[0].getNotNothingString("ArrayMissingValue", errorInMethod);
-      PrimitiveArray.ArrayNotAscending =
-          messagesAr[0].getNotNothingString("ArrayNotAscending", errorInMethod);
-      PrimitiveArray.ArrayNotDescending =
-          messagesAr[0].getNotNothingString("ArrayNotDescending", errorInMethod);
-      PrimitiveArray.ArrayNotEvenlySpaced =
-          messagesAr[0].getNotNothingString("ArrayNotEvenlySpaced", errorInMethod);
-      PrimitiveArray.ArrayRemove = messagesAr[0].getNotNothingString("ArrayRemove", errorInMethod);
-      PrimitiveArray.ArraySubsetStart =
-          messagesAr[0].getNotNothingString("ArraySubsetStart", errorInMethod);
-      PrimitiveArray.ArraySubsetStride =
-          messagesAr[0].getNotNothingString("ArraySubsetStride", errorInMethod);
-      autoRefreshAr = getNotNothingString(messagesAr, "autoRefresh", errorInMethod);
-      blacklistMsgAr = getNotNothingString(messagesAr, "blacklistMsg", errorInMethod);
-      BroughtToYouByAr = getNotNothingString(messagesAr, "BroughtToYouBy", errorInMethod);
-
-      categoryTitleHtmlAr = getNotNothingString(messagesAr, "categoryTitleHtml", errorInMethod);
-      categoryHtmlAr = getNotNothingString(messagesAr, "categoryHtml", errorInMethod);
-      category3HtmlAr = getNotNothingString(messagesAr, "category3Html", errorInMethod);
-      categoryPickAttributeAr =
-          getNotNothingString(messagesAr, "categoryPickAttribute", errorInMethod);
-      categorySearchHtmlAr = getNotNothingString(messagesAr, "categorySearchHtml", errorInMethod);
-      categorySearchDifferentHtmlAr =
-          getNotNothingString(messagesAr, "categorySearchDifferentHtml", errorInMethod);
-      categoryClickHtmlAr = getNotNothingString(messagesAr, "categoryClickHtml", errorInMethod);
-      categoryNotAnOptionAr = getNotNothingString(messagesAr, "categoryNotAnOption", errorInMethod);
-      caughtInterruptedAr = getNotNothingString(messagesAr, "caughtInterrupted", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        caughtInterruptedAr[tl] = " " + caughtInterruptedAr[tl];
-
-      cdmDataTypeHelpAr = getNotNothingString(messagesAr, "cdmDataTypeHelp", errorInMethod);
-
-      clickAccessAr = getNotNothingString(messagesAr, "clickAccess", errorInMethod);
-      clickBackgroundInfoAr = getNotNothingString(messagesAr, "clickBackgroundInfo", errorInMethod);
-      clickERDDAPAr = getNotNothingString(messagesAr, "clickERDDAP", errorInMethod);
-      clickInfoAr = getNotNothingString(messagesAr, "clickInfo", errorInMethod);
-      clickToSubmitAr = getNotNothingString(messagesAr, "clickToSubmit", errorInMethod);
-      HtmlWidgets.comboBoxAltAr = getNotNothingString(messagesAr, "comboBoxAlt", errorInMethod);
-      convertAr = getNotNothingString(messagesAr, "convert", errorInMethod);
-      convertBypassAr = getNotNothingString(messagesAr, "convertBypass", errorInMethod);
-
-      convertToAFullNameAr = getNotNothingString(messagesAr, "convertToAFullName", errorInMethod);
-      convertToAnAcronymAr = getNotNothingString(messagesAr, "convertToAnAcronym", errorInMethod);
-      convertToACountyNameAr =
-          getNotNothingString(messagesAr, "convertToACountyName", errorInMethod);
-      convertToAFIPSCodeAr = getNotNothingString(messagesAr, "convertToAFIPSCode", errorInMethod);
-      convertToGCMDAr = getNotNothingString(messagesAr, "convertToGCMD", errorInMethod);
-      convertToCFStandardNamesAr =
-          getNotNothingString(messagesAr, "convertToCFStandardNames", errorInMethod);
-      convertToNumericTimeAr =
-          getNotNothingString(messagesAr, "convertToNumericTime", errorInMethod);
-      convertToStringTimeAr = getNotNothingString(messagesAr, "convertToStringTime", errorInMethod);
-      convertAnyStringTimeAr =
-          getNotNothingString(messagesAr, "convertAnyStringTime", errorInMethod);
-      convertToProperTimeUnitsAr =
-          getNotNothingString(messagesAr, "convertToProperTimeUnits", errorInMethod);
-      convertFromUDUNITSToUCUMAr =
-          getNotNothingString(messagesAr, "convertFromUDUNITSToUCUM", errorInMethod);
-      convertFromUCUMToUDUNITSAr =
-          getNotNothingString(messagesAr, "convertFromUCUMToUDUNITS", errorInMethod);
-      convertToUCUMAr = getNotNothingString(messagesAr, "convertToUCUM", errorInMethod);
-      convertToUDUNITSAr = getNotNothingString(messagesAr, "convertToUDUNITS", errorInMethod);
-      convertStandardizeUDUNITSAr =
-          getNotNothingString(messagesAr, "convertStandardizeUDUNITS", errorInMethod);
-      convertToFullNameAr = getNotNothingString(messagesAr, "convertToFullName", errorInMethod);
-      convertToVariableNameAr =
-          getNotNothingString(messagesAr, "convertToVariableName", errorInMethod);
-
-      converterWebServiceAr = getNotNothingString(messagesAr, "converterWebService", errorInMethod);
-      convertOAAcronymsAr = getNotNothingString(messagesAr, "convertOAAcronyms", errorInMethod);
-      convertOAAcronymsToFromAr =
-          getNotNothingString(messagesAr, "convertOAAcronymsToFrom", errorInMethod);
-      convertOAAcronymsIntroAr =
-          getNotNothingString(messagesAr, "convertOAAcronymsIntro", errorInMethod);
-      convertOAAcronymsNotesAr =
-          getNotNothingString(messagesAr, "convertOAAcronymsNotes", errorInMethod);
-      convertOAAcronymsServiceAr =
-          getNotNothingString(messagesAr, "convertOAAcronymsService", errorInMethod);
-      convertOAVariableNamesAr =
-          getNotNothingString(messagesAr, "convertOAVariableNames", errorInMethod);
-      convertOAVariableNamesToFromAr =
-          getNotNothingString(messagesAr, "convertOAVariableNamesToFrom", errorInMethod);
-      convertOAVariableNamesIntroAr =
-          getNotNothingString(messagesAr, "convertOAVariableNamesIntro", errorInMethod);
-      convertOAVariableNamesNotesAr =
-          getNotNothingString(messagesAr, "convertOAVariableNamesNotes", errorInMethod);
-      convertOAVariableNamesServiceAr =
-          getNotNothingString(messagesAr, "convertOAVariableNamesService", errorInMethod);
-      convertFipsCountyAr = getNotNothingString(messagesAr, "convertFipsCounty", errorInMethod);
-      convertFipsCountyIntroAr =
-          getNotNothingString(messagesAr, "convertFipsCountyIntro", errorInMethod);
-      convertFipsCountyNotesAr =
-          getNotNothingString(messagesAr, "convertFipsCountyNotes", errorInMethod);
-      convertFipsCountyServiceAr =
-          getNotNothingString(messagesAr, "convertFipsCountyService", errorInMethod);
-      convertHtmlAr = getNotNothingString(messagesAr, "convertHtml", errorInMethod);
-      convertInterpolateAr = getNotNothingString(messagesAr, "convertInterpolate", errorInMethod);
-      convertInterpolateIntroAr =
-          getNotNothingString(messagesAr, "convertInterpolateIntro", errorInMethod);
-      convertInterpolateTLLTableAr =
-          getNotNothingString(messagesAr, "convertInterpolateTLLTable", errorInMethod);
-      convertInterpolateTLLTableHelpAr =
-          getNotNothingString(messagesAr, "convertInterpolateTLLTableHelp", errorInMethod);
-      convertInterpolateDatasetIDVariableAr =
-          getNotNothingString(messagesAr, "convertInterpolateDatasetIDVariable", errorInMethod);
-      convertInterpolateDatasetIDVariableHelpAr =
-          getNotNothingString(messagesAr, "convertInterpolateDatasetIDVariableHelp", errorInMethod);
-      convertInterpolateNotesAr =
-          getNotNothingString(messagesAr, "convertInterpolateNotes", errorInMethod);
-      convertInterpolateServiceAr =
-          getNotNothingString(messagesAr, "convertInterpolateService", errorInMethod);
-      convertKeywordsAr = getNotNothingString(messagesAr, "convertKeywords", errorInMethod);
-      convertKeywordsCfTooltipAr =
-          getNotNothingString(messagesAr, "convertKeywordsCfTooltip", errorInMethod);
-      convertKeywordsGcmdTooltipAr =
-          getNotNothingString(messagesAr, "convertKeywordsGcmdTooltip", errorInMethod);
-      convertKeywordsIntroAr =
-          getNotNothingString(messagesAr, "convertKeywordsIntro", errorInMethod);
-      convertKeywordsNotesAr =
-          getNotNothingString(messagesAr, "convertKeywordsNotes", errorInMethod);
-      convertKeywordsServiceAr =
-          getNotNothingString(messagesAr, "convertKeywordsService", errorInMethod);
-
-      convertTimeAr = getNotNothingString(messagesAr, "convertTime", errorInMethod);
-      convertTimeReferenceAr =
-          getNotNothingString(messagesAr, "convertTimeReference", errorInMethod);
-      convertTimeIntroAr = getNotNothingString(messagesAr, "convertTimeIntro", errorInMethod);
-      convertTimeNotesAr = getNotNothingString(messagesAr, "convertTimeNotes", errorInMethod);
-      convertTimeServiceAr = getNotNothingString(messagesAr, "convertTimeService", errorInMethod);
-      convertTimeNumberTooltipAr =
-          getNotNothingString(messagesAr, "convertTimeNumberTooltip", errorInMethod);
-      convertTimeStringTimeTooltipAr =
-          getNotNothingString(messagesAr, "convertTimeStringTimeTooltip", errorInMethod);
-      convertTimeUnitsTooltipAr =
-          getNotNothingString(messagesAr, "convertTimeUnitsTooltip", errorInMethod);
-      convertTimeUnitsHelpAr =
-          getNotNothingString(messagesAr, "convertTimeUnitsHelp", errorInMethod);
-      convertTimeIsoFormatErrorAr =
-          getNotNothingString(messagesAr, "convertTimeIsoFormatError", errorInMethod);
-      convertTimeNoSinceErrorAr =
-          getNotNothingString(messagesAr, "convertTimeNoSinceError", errorInMethod);
-      convertTimeNumberErrorAr =
-          getNotNothingString(messagesAr, "convertTimeNumberError", errorInMethod);
-      convertTimeNumericTimeErrorAr =
-          getNotNothingString(messagesAr, "convertTimeNumericTimeError", errorInMethod);
-      convertTimeParametersErrorAr =
-          getNotNothingString(messagesAr, "convertTimeParametersError", errorInMethod);
-      convertTimeStringFormatErrorAr =
-          getNotNothingString(messagesAr, "convertTimeStringFormatError", errorInMethod);
-      convertTimeTwoTimeErrorAr =
-          getNotNothingString(messagesAr, "convertTimeTwoTimeError", errorInMethod);
-      convertTimeUnitsErrorAr =
-          getNotNothingString(messagesAr, "convertTimeUnitsError", errorInMethod);
-      convertUnitsAr = getNotNothingString(messagesAr, "convertUnits", errorInMethod);
-      convertUnitsComparisonAr =
-          getNotNothingString(messagesAr, "convertUnitsComparison", errorInMethod);
-      convertUnitsFilterAr = getNotNothingString(messagesAr, "convertUnitsFilter", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) {
-        convertUnitsComparisonAr[tl] =
-            convertUnitsComparisonAr[tl]
-                .replaceAll(
-                    "&C;",
-                    "C") // these handled this way be cause you can't just avoid translating all
-                // words with 'C'
-                .replaceAll("&g;", "g") // "
-                .replaceAll("&F;", "F") // "
-                .replaceAll("&NTU;", "NTU")
-                .replaceAll("&ntu;", "ntu")
-                .replaceAll("&PSU;", "PSU")
-                .replaceAll("&psu;", "psu");
-      }
-
-      convertUnitsIntroAr = getNotNothingString(messagesAr, "convertUnitsIntro", errorInMethod);
-      convertUnitsNotesAr = getNotNothingString(messagesAr, "convertUnitsNotes", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        convertUnitsNotesAr[tl] =
-            convertUnitsNotesAr[tl].replace("&unitsStandard;", units_standard);
-      convertUnitsServiceAr = getNotNothingString(messagesAr, "convertUnitsService", errorInMethod);
-      convertURLsAr = getNotNothingString(messagesAr, "convertURLs", errorInMethod);
-      convertURLsIntroAr = getNotNothingString(messagesAr, "convertURLsIntro", errorInMethod);
-      convertURLsNotesAr = getNotNothingString(messagesAr, "convertURLsNotes", errorInMethod);
-      convertURLsServiceAr = getNotNothingString(messagesAr, "convertURLsService", errorInMethod);
-      cookiesHelpAr = getNotNothingString(messagesAr, "cookiesHelp", errorInMethod);
-      copyImageToClipboardAr =
-          getNotNothingString(messagesAr, "copyImageToClipboard", errorInMethod);
-      copyTextToClipboardAr = getNotNothingString(messagesAr, "copyTextToClipboard", errorInMethod);
-      copyToClipboardNotAvailableAr =
-          getNotNothingString(messagesAr, "copyToClipboardNotAvailable", errorInMethod);
-
-      dafAr = getNotNothingString(messagesAr, "daf", errorInMethod);
-      dafGridBypassTooltipAr =
-          getNotNothingString(messagesAr, "dafGridBypassTooltip", errorInMethod);
-      dafGridTooltipAr = getNotNothingString(messagesAr, "dafGridTooltip", errorInMethod);
-      dafTableBypassTooltipAr =
-          getNotNothingString(messagesAr, "dafTableBypassTooltip", errorInMethod);
-      dafTableTooltipAr = getNotNothingString(messagesAr, "dafTableTooltip", errorInMethod);
-      dasTitleAr = getNotNothingString(messagesAr, "dasTitle", errorInMethod);
-      dataAccessNotAllowedAr =
-          getNotNothingString(messagesAr, "dataAccessNotAllowed", errorInMethod);
-      databaseUnableToConnectAr =
-          getNotNothingString(messagesAr, "databaseUnableToConnect", errorInMethod);
-      dataProviderFormAr = getNotNothingString(messagesAr, "dataProviderForm", errorInMethod);
-      dataProviderFormP1Ar = getNotNothingString(messagesAr, "dataProviderFormP1", errorInMethod);
-      dataProviderFormP2Ar = getNotNothingString(messagesAr, "dataProviderFormP2", errorInMethod);
-      dataProviderFormP3Ar = getNotNothingString(messagesAr, "dataProviderFormP3", errorInMethod);
-      dataProviderFormP4Ar = getNotNothingString(messagesAr, "dataProviderFormP4", errorInMethod);
-      dataProviderFormDoneAr =
-          getNotNothingString(messagesAr, "dataProviderFormDone", errorInMethod);
-      dataProviderFormSuccessAr =
-          getNotNothingString(messagesAr, "dataProviderFormSuccess", errorInMethod);
-      dataProviderFormShortDescriptionAr =
-          getNotNothingString(messagesAr, "dataProviderFormShortDescription", errorInMethod);
-      dataProviderFormLongDescriptionHTMLAr =
-          getNotNothingString(messagesAr, "dataProviderFormLongDescriptionHTML", errorInMethod);
-      disabledAr = getNotNothingString(messagesAr, "disabled", errorInMethod);
-      dataProviderFormPart1Ar =
-          getNotNothingString(messagesAr, "dataProviderFormPart1", errorInMethod);
-      dataProviderFormPart2HeaderAr =
-          getNotNothingString(messagesAr, "dataProviderFormPart2Header", errorInMethod);
-      dataProviderFormPart2GlobalMetadataAr =
-          getNotNothingString(messagesAr, "dataProviderFormPart2GlobalMetadata", errorInMethod);
-      dataProviderContactInfoAr =
-          getNotNothingString(messagesAr, "dataProviderContactInfo", errorInMethod);
-      dataProviderDataAr = getNotNothingString(messagesAr, "dataProviderData", errorInMethod);
-      documentationAr = getNotNothingString(messagesAr, "documentation", errorInMethod);
-
-      dpf_submitAr = getNotNothingString(messagesAr, "dpf_submit", errorInMethod);
-      dpf_fixProblemAr = getNotNothingString(messagesAr, "dpf_fixProblem", errorInMethod);
-      dpf_yourNameAr = getNotNothingString(messagesAr, "dpf_yourName", errorInMethod);
-      dpf_emailAddressAr = getNotNothingString(messagesAr, "dpf_emailAddress", errorInMethod);
-      dpf_TimestampAr = getNotNothingString(messagesAr, "dpf_Timestamp", errorInMethod);
-      dpf_frequencyAr = getNotNothingString(messagesAr, "dpf_frequency", errorInMethod);
-      dpf_titleAr = getNotNothingString(messagesAr, "dpf_title", errorInMethod);
-      dpf_titleTooltipAr = getNotNothingString(messagesAr, "dpf_titleTooltip", errorInMethod);
-      dpf_summaryAr = getNotNothingString(messagesAr, "dpf_summary", errorInMethod);
-      dpf_summaryTooltipAr = getNotNothingString(messagesAr, "dpf_summaryTooltip", errorInMethod);
-      dpf_creatorNameAr = getNotNothingString(messagesAr, "dpf_creatorName", errorInMethod);
-      dpf_creatorNameTooltipAr =
-          getNotNothingString(messagesAr, "dpf_creatorNameTooltip", errorInMethod);
-      dpf_creatorTypeAr = getNotNothingString(messagesAr, "dpf_creatorType", errorInMethod);
-      dpf_creatorTypeTooltipAr =
-          getNotNothingString(messagesAr, "dpf_creatorTypeTooltip", errorInMethod);
-      dpf_creatorEmailAr = getNotNothingString(messagesAr, "dpf_creatorEmail", errorInMethod);
-      dpf_creatorEmailTooltipAr =
-          getNotNothingString(messagesAr, "dpf_creatorEmailTooltip", errorInMethod);
-      dpf_institutionAr = getNotNothingString(messagesAr, "dpf_institution", errorInMethod);
-      dpf_institutionTooltipAr =
-          getNotNothingString(messagesAr, "dpf_institutionTooltip", errorInMethod);
-      dpf_infoUrlAr = getNotNothingString(messagesAr, "dpf_infoUrl", errorInMethod);
-      dpf_infoUrlTooltipAr = getNotNothingString(messagesAr, "dpf_infoUrlTooltip", errorInMethod);
-      dpf_licenseAr = getNotNothingString(messagesAr, "dpf_license", errorInMethod);
-      dpf_licenseTooltipAr = getNotNothingString(messagesAr, "dpf_licenseTooltip", errorInMethod);
-      dpf_howYouStoreDataAr = getNotNothingString(messagesAr, "dpf_howYouStoreData", errorInMethod);
-      dpf_provideIfAvailableAr =
-          getNotNothingString(messagesAr, "dpf_provideIfAvailable", errorInMethod);
-      dpf_acknowledgementAr = getNotNothingString(messagesAr, "dpf_acknowledgement", errorInMethod);
-      dpf_acknowledgementTooltipAr =
-          getNotNothingString(messagesAr, "dpf_acknowledgementTooltip", errorInMethod);
-      dpf_historyAr = getNotNothingString(messagesAr, "dpf_history", errorInMethod);
-      dpf_historyTooltipAr = getNotNothingString(messagesAr, "dpf_historyTooltip", errorInMethod);
-      dpf_idTooltipAr = getNotNothingString(messagesAr, "dpf_idTooltip", errorInMethod);
-      dpf_namingAuthorityAr = getNotNothingString(messagesAr, "dpf_namingAuthority", errorInMethod);
-      dpf_namingAuthorityTooltipAr =
-          getNotNothingString(messagesAr, "dpf_namingAuthorityTooltip", errorInMethod);
-      dpf_productVersionAr = getNotNothingString(messagesAr, "dpf_productVersion", errorInMethod);
-      dpf_productVersionTooltipAr =
-          getNotNothingString(messagesAr, "dpf_productVersionTooltip", errorInMethod);
-      dpf_referencesAr = getNotNothingString(messagesAr, "dpf_references", errorInMethod);
-      dpf_referencesTooltipAr =
-          getNotNothingString(messagesAr, "dpf_referencesTooltip", errorInMethod);
-      dpf_commentAr = getNotNothingString(messagesAr, "dpf_comment", errorInMethod);
-      dpf_commentTooltipAr = getNotNothingString(messagesAr, "dpf_commentTooltip", errorInMethod);
-      dpf_dataTypeHelpAr = getNotNothingString(messagesAr, "dpf_dataTypeHelp", errorInMethod);
-      dpf_ioosCategoryAr = getNotNothingString(messagesAr, "dpf_ioosCategory", errorInMethod);
-      dpf_ioosCategoryHelpAr =
-          getNotNothingString(messagesAr, "dpf_ioosCategoryHelp", errorInMethod);
-      dpf_part3HeaderAr = getNotNothingString(messagesAr, "dpf_part3Header", errorInMethod);
-      dpf_variableMetadataAr =
-          getNotNothingString(messagesAr, "dpf_variableMetadata", errorInMethod);
-      dpf_sourceNameAr = getNotNothingString(messagesAr, "dpf_sourceName", errorInMethod);
-      dpf_sourceNameTooltipAr =
-          getNotNothingString(messagesAr, "dpf_sourceNameTooltip", errorInMethod);
-      dpf_destinationNameAr = getNotNothingString(messagesAr, "dpf_destinationName", errorInMethod);
-      dpf_destinationNameTooltipAr =
-          getNotNothingString(messagesAr, "dpf_destinationNameTooltip", errorInMethod);
-
-      dpf_longNameAr = getNotNothingString(messagesAr, "dpf_longName", errorInMethod);
-      dpf_longNameTooltipAr = getNotNothingString(messagesAr, "dpf_longNameTooltip", errorInMethod);
-      dpf_standardNameAr = getNotNothingString(messagesAr, "dpf_standardName", errorInMethod);
-      dpf_standardNameTooltipAr =
-          getNotNothingString(messagesAr, "dpf_standardNameTooltip", errorInMethod);
-      dpf_dataTypeAr = getNotNothingString(messagesAr, "dpf_dataType", errorInMethod);
-      dpf_fillValueAr = getNotNothingString(messagesAr, "dpf_fillValue", errorInMethod);
-      dpf_fillValueTooltipAr =
-          getNotNothingString(messagesAr, "dpf_fillValueTooltip", errorInMethod);
-      dpf_unitsAr = getNotNothingString(messagesAr, "dpf_units", errorInMethod);
-      dpf_unitsTooltipAr = getNotNothingString(messagesAr, "dpf_unitsTooltip", errorInMethod);
-      dpf_rangeAr = getNotNothingString(messagesAr, "dpf_range", errorInMethod);
-      dpf_rangeTooltipAr = getNotNothingString(messagesAr, "dpf_rangeTooltip", errorInMethod);
-      dpf_part4HeaderAr = getNotNothingString(messagesAr, "dpf_part4Header", errorInMethod);
-      dpf_otherCommentAr = getNotNothingString(messagesAr, "dpf_otherComment", errorInMethod);
-      dpf_finishPart4Ar = getNotNothingString(messagesAr, "dpf_finishPart4", errorInMethod);
-      dpf_congratulationAr = getNotNothingString(messagesAr, "dpf_congratulation", errorInMethod);
-
-      distinctValuesTooltipAr =
-          getNotNothingString(messagesAr, "distinctValuesTooltip", errorInMethod);
-      doWithGraphsAr = getNotNothingString(messagesAr, "doWithGraphs", errorInMethod);
-
-      dtAccessibleAr = getNotNothingString(messagesAr, "dtAccessible", errorInMethod);
-      dtAccessiblePublicAr = getNotNothingString(messagesAr, "dtAccessiblePublic", errorInMethod);
-      dtAccessibleYesAr = getNotNothingString(messagesAr, "dtAccessibleYes", errorInMethod);
-      dtAccessibleGraphsAr = getNotNothingString(messagesAr, "dtAccessibleGraphs", errorInMethod);
-      dtAccessibleNoAr = getNotNothingString(messagesAr, "dtAccessibleNo", errorInMethod);
-      dtAccessibleLogInAr = getNotNothingString(messagesAr, "dtAccessibleLogIn", errorInMethod);
-      dtLogInAr = getNotNothingString(messagesAr, "dtLogIn", errorInMethod);
-      dtDAFAr = getNotNothingString(messagesAr, "dtDAF", errorInMethod);
-      dtFilesAr = getNotNothingString(messagesAr, "dtFiles", errorInMethod);
-      dtMAGAr = getNotNothingString(messagesAr, "dtMAG", errorInMethod);
-      dtSOSAr = getNotNothingString(messagesAr, "dtSOS", errorInMethod);
-      dtSubsetAr = getNotNothingString(messagesAr, "dtSubset", errorInMethod);
-      dtWCSAr = getNotNothingString(messagesAr, "dtWCS", errorInMethod);
-      dtWMSAr = getNotNothingString(messagesAr, "dtWMS", errorInMethod);
-
-      EasierAccessToScientificDataAr =
-          getNotNothingString(messagesAr, "EasierAccessToScientificData", errorInMethod);
-      EDDDatasetIDAr = getNotNothingString(messagesAr, "EDDDatasetID", errorInMethod);
-      EDDFgdc = messagesAr[0].getNotNothingString("EDDFgdc", errorInMethod);
-      EDDFgdcMetadataAr = getNotNothingString(messagesAr, "EDDFgdcMetadata", errorInMethod);
-      EDDFilesAr = getNotNothingString(messagesAr, "EDDFiles", errorInMethod);
-      EDDIso19115 = messagesAr[0].getNotNothingString("EDDIso19115", errorInMethod);
-      EDDIso19115MetadataAr = getNotNothingString(messagesAr, "EDDIso19115Metadata", errorInMethod);
-      EDDMetadataAr = getNotNothingString(messagesAr, "EDDMetadata", errorInMethod);
-      EDDBackgroundAr = getNotNothingString(messagesAr, "EDDBackground", errorInMethod);
-      EDDClickOnSubmitHtmlAr =
-          getNotNothingString(messagesAr, "EDDClickOnSubmitHtml", errorInMethod);
-      EDDInformationAr = getNotNothingString(messagesAr, "EDDInformation", errorInMethod);
-      EDDInstitutionAr = getNotNothingString(messagesAr, "EDDInstitution", errorInMethod);
-      EDDSummaryAr = getNotNothingString(messagesAr, "EDDSummary", errorInMethod);
-      EDDDatasetTitleAr = getNotNothingString(messagesAr, "EDDDatasetTitle", errorInMethod);
-      EDDDownloadDataAr = getNotNothingString(messagesAr, "EDDDownloadData", errorInMethod);
-      EDDMakeAGraphAr = getNotNothingString(messagesAr, "EDDMakeAGraph", errorInMethod);
-      EDDMakeAMapAr = getNotNothingString(messagesAr, "EDDMakeAMap", errorInMethod);
-      EDDFileTypeAr = getNotNothingString(messagesAr, "EDDFileType", errorInMethod);
-      EDDFileTypeInformationAr =
-          getNotNothingString(messagesAr, "EDDFileTypeInformation", errorInMethod);
-      EDDSelectFileTypeAr = getNotNothingString(messagesAr, "EDDSelectFileType", errorInMethod);
-      EDDMinimumAr = getNotNothingString(messagesAr, "EDDMinimum", errorInMethod);
-      EDDMaximumAr = getNotNothingString(messagesAr, "EDDMaximum", errorInMethod);
-      EDDConstraintAr = getNotNothingString(messagesAr, "EDDConstraint", errorInMethod);
-
-      EDDChangedWasnt = messagesAr[0].getNotNothingString("EDDChangedWasnt", errorInMethod);
-      EDDChangedDifferentNVar =
-          messagesAr[0].getNotNothingString("EDDChangedDifferentNVar", errorInMethod);
-      EDDChanged2Different =
-          messagesAr[0].getNotNothingString("EDDChanged2Different", errorInMethod);
-      EDDChanged1Different =
-          messagesAr[0].getNotNothingString("EDDChanged1Different", errorInMethod);
-      EDDChangedCGADifferent =
-          messagesAr[0].getNotNothingString("EDDChangedCGADifferent", errorInMethod);
-      EDDChangedAxesDifferentNVar =
-          messagesAr[0].getNotNothingString("EDDChangedAxesDifferentNVar", errorInMethod);
-      EDDChangedAxes2Different =
-          messagesAr[0].getNotNothingString("EDDChangedAxes2Different", errorInMethod);
-      EDDChangedAxes1Different =
-          messagesAr[0].getNotNothingString("EDDChangedAxes1Different", errorInMethod);
-      EDDChangedNoValue = messagesAr[0].getNotNothingString("EDDChangedNoValue", errorInMethod);
-      EDDChangedTableToGrid =
-          messagesAr[0].getNotNothingString("EDDChangedTableToGrid", errorInMethod);
-
-      EDDSimilarDifferentNVar =
-          messagesAr[0].getNotNothingString("EDDSimilarDifferentNVar", errorInMethod);
-      EDDSimilarDifferent = messagesAr[0].getNotNothingString("EDDSimilarDifferent", errorInMethod);
-
-      EDDGridDownloadTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridDownloadTooltip", errorInMethod);
-      EDDGridDapDescriptionAr =
-          getNotNothingString(messagesAr, "EDDGridDapDescription", errorInMethod);
-      EDDGridDapLongDescriptionAr =
-          getNotNothingString(messagesAr, "EDDGridDapLongDescription", errorInMethod);
-      EDDGridDownloadDataTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridDownloadDataTooltip", errorInMethod);
-      EDDGridDimensionAr = getNotNothingString(messagesAr, "EDDGridDimension", errorInMethod);
-      EDDGridDimensionRangesAr =
-          getNotNothingString(messagesAr, "EDDGridDimensionRanges", errorInMethod);
-      EDDGridFirstAr = getNotNothingString(messagesAr, "EDDGridFirst", errorInMethod);
-      EDDGridLastAr = getNotNothingString(messagesAr, "EDDGridLast", errorInMethod);
-      EDDGridStartAr = getNotNothingString(messagesAr, "EDDGridStart", errorInMethod);
-      EDDGridStopAr = getNotNothingString(messagesAr, "EDDGridStop", errorInMethod);
-      EDDGridStartStopTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridStartStopTooltip", errorInMethod);
-      EDDGridStrideAr = getNotNothingString(messagesAr, "EDDGridStride", errorInMethod);
-      EDDGridNValuesAr = getNotNothingString(messagesAr, "EDDGridNValues", errorInMethod);
-      EDDGridNValuesHtmlAr = getNotNothingString(messagesAr, "EDDGridNValuesHtml", errorInMethod);
-      EDDGridSpacingAr = getNotNothingString(messagesAr, "EDDGridSpacing", errorInMethod);
-      EDDGridJustOneValueAr = getNotNothingString(messagesAr, "EDDGridJustOneValue", errorInMethod);
-      EDDGridEvenAr = getNotNothingString(messagesAr, "EDDGridEven", errorInMethod);
-      EDDGridUnevenAr = getNotNothingString(messagesAr, "EDDGridUneven", errorInMethod);
-      EDDGridDimensionTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridDimensionTooltip", errorInMethod);
-      EDDGridDimensionFirstTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridDimensionFirstTooltip", errorInMethod);
-      EDDGridDimensionLastTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridDimensionLastTooltip", errorInMethod);
-      EDDGridVarHasDimTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridVarHasDimTooltip", errorInMethod);
-      EDDGridSSSTooltipAr = getNotNothingString(messagesAr, "EDDGridSSSTooltip", errorInMethod);
-      EDDGridStartTooltipAr = getNotNothingString(messagesAr, "EDDGridStartTooltip", errorInMethod);
-      EDDGridStopTooltipAr = getNotNothingString(messagesAr, "EDDGridStopTooltip", errorInMethod);
-      EDDGridStrideTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridStrideTooltip", errorInMethod);
-      EDDGridSpacingTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridSpacingTooltip", errorInMethod);
-      EDDGridGridVariableHtmlAr =
-          getNotNothingString(messagesAr, "EDDGridGridVariableHtml", errorInMethod);
-      EDDGridCheckAllAr = getNotNothingString(messagesAr, "EDDGridCheckAll", errorInMethod);
-      EDDGridCheckAllTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridCheckAllTooltip", errorInMethod);
-      EDDGridUncheckAllAr = getNotNothingString(messagesAr, "EDDGridUncheckAll", errorInMethod);
-      EDDGridUncheckAllTooltipAr =
-          getNotNothingString(messagesAr, "EDDGridUncheckAllTooltip", errorInMethod);
-
-      // default EDDGrid...Example
-      EDDGridErddapUrlExample =
-          messagesAr[0].getNotNothingString("EDDGridErddapUrlExample", errorInMethod);
-      EDDGridIdExample = messagesAr[0].getNotNothingString("EDDGridIdExample", errorInMethod);
-      EDDGridDimensionExample =
-          messagesAr[0].getNotNothingString("EDDGridDimensionExample", errorInMethod);
-      EDDGridNoHyperExample =
-          messagesAr[0].getNotNothingString("EDDGridNoHyperExample", errorInMethod);
-      EDDGridDimNamesExample =
-          messagesAr[0].getNotNothingString("EDDGridDimNamesExample", errorInMethod);
-      EDDGridDataTimeExample =
-          messagesAr[0].getNotNothingString("EDDGridDataTimeExample", errorInMethod);
-      EDDGridDataValueExample =
-          messagesAr[0].getNotNothingString("EDDGridDataValueExample", errorInMethod);
-      EDDGridDataIndexExample =
-          messagesAr[0].getNotNothingString("EDDGridDataIndexExample", errorInMethod);
-      EDDGridGraphExample = messagesAr[0].getNotNothingString("EDDGridGraphExample", errorInMethod);
-      EDDGridMapExample = messagesAr[0].getNotNothingString("EDDGridMapExample", errorInMethod);
-      EDDGridMatlabPlotExample =
-          messagesAr[0].getNotNothingString("EDDGridMatlabPlotExample", errorInMethod);
-
-      // admin provides EDDGrid...Example
-      EDDGridErddapUrlExample =
-          getSetupEVString(setup, ev, "EDDGridErddapUrlExample", EDDGridErddapUrlExample);
-      EDDGridIdExample = getSetupEVString(setup, ev, "EDDGridIdExample", EDDGridIdExample);
-      EDDGridDimensionExample =
-          getSetupEVString(setup, ev, "EDDGridDimensionExample", EDDGridDimensionExample);
-      EDDGridNoHyperExample =
-          getSetupEVString(setup, ev, "EDDGridNoHyperExample", EDDGridNoHyperExample);
-      EDDGridDimNamesExample =
-          getSetupEVString(setup, ev, "EDDGridDimNamesExample", EDDGridDimNamesExample);
-      EDDGridDataIndexExample =
-          getSetupEVString(setup, ev, "EDDGridDataIndexExample", EDDGridDataIndexExample);
-      EDDGridDataValueExample =
-          getSetupEVString(setup, ev, "EDDGridDataValueExample", EDDGridDataValueExample);
-      EDDGridDataTimeExample =
-          getSetupEVString(setup, ev, "EDDGridDataTimeExample", EDDGridDataTimeExample);
-      EDDGridGraphExample = getSetupEVString(setup, ev, "EDDGridGraphExample", EDDGridGraphExample);
-      EDDGridMapExample = getSetupEVString(setup, ev, "EDDGridMapExample", EDDGridMapExample);
-      EDDGridMatlabPlotExample =
-          getSetupEVString(setup, ev, "EDDGridMatlabPlotExample", EDDGridMatlabPlotExample);
-
-      // variants encoded to be Html Examples
-      EDDGridDimensionExampleHE = XML.encodeAsHTML(EDDGridDimensionExample);
-      EDDGridDataIndexExampleHE = XML.encodeAsHTML(EDDGridDataIndexExample);
-      EDDGridDataValueExampleHE = XML.encodeAsHTML(EDDGridDataValueExample);
-      EDDGridDataTimeExampleHE = XML.encodeAsHTML(EDDGridDataTimeExample);
-      EDDGridGraphExampleHE = XML.encodeAsHTML(EDDGridGraphExample);
-      EDDGridMapExampleHE = XML.encodeAsHTML(EDDGridMapExample);
-
-      // variants encoded to be Html Attributes
-      EDDGridDimensionExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDimensionExample));
-      EDDGridDataIndexExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataIndexExample));
-      EDDGridDataValueExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataValueExample));
-      EDDGridDataTimeExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridDataTimeExample));
-      EDDGridGraphExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridGraphExample));
-      EDDGridMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDGridMapExample));
-
-      EDDTableConstraintsAr = getNotNothingString(messagesAr, "EDDTableConstraints", errorInMethod);
-      EDDTableDapDescriptionAr =
-          getNotNothingString(messagesAr, "EDDTableDapDescription", errorInMethod);
-      EDDTableDapLongDescriptionAr =
-          getNotNothingString(messagesAr, "EDDTableDapLongDescription", errorInMethod);
-      EDDTableDownloadDataTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableDownloadDataTooltip", errorInMethod);
-      EDDTableTabularDatasetTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableTabularDatasetTooltip", errorInMethod);
-      EDDTableVariableAr = getNotNothingString(messagesAr, "EDDTableVariable", errorInMethod);
-      EDDTableCheckAllAr = getNotNothingString(messagesAr, "EDDTableCheckAll", errorInMethod);
-      EDDTableCheckAllTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableCheckAllTooltip", errorInMethod);
-      EDDTableUncheckAllAr = getNotNothingString(messagesAr, "EDDTableUncheckAll", errorInMethod);
-      EDDTableUncheckAllTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableUncheckAllTooltip", errorInMethod);
-      EDDTableMinimumTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableMinimumTooltip", errorInMethod);
-      EDDTableMaximumTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableMaximumTooltip", errorInMethod);
-      EDDTableCheckTheVariablesAr =
-          getNotNothingString(messagesAr, "EDDTableCheckTheVariables", errorInMethod);
-      EDDTableSelectAnOperatorAr =
-          getNotNothingString(messagesAr, "EDDTableSelectAnOperator", errorInMethod);
-      EDDTableFromEDDGridSummaryAr =
-          getNotNothingString(messagesAr, "EDDTableFromEDDGridSummary", errorInMethod);
-      EDDTableOptConstraint1HtmlAr =
-          getNotNothingString(messagesAr, "EDDTableOptConstraint1Html", errorInMethod);
-      EDDTableOptConstraint2HtmlAr =
-          getNotNothingString(messagesAr, "EDDTableOptConstraint2Html", errorInMethod);
-      EDDTableOptConstraintVarAr =
-          getNotNothingString(messagesAr, "EDDTableOptConstraintVar", errorInMethod);
-      EDDTableNumericConstraintTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableNumericConstraintTooltip", errorInMethod);
-      EDDTableStringConstraintTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableStringConstraintTooltip", errorInMethod);
-      EDDTableTimeConstraintTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableTimeConstraintTooltip", errorInMethod);
-      EDDTableConstraintTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableConstraintTooltip", errorInMethod);
-      EDDTableSelectConstraintTooltipAr =
-          getNotNothingString(messagesAr, "EDDTableSelectConstraintTooltip", errorInMethod);
-
-      // default EDDGrid...Example
-      EDDTableErddapUrlExample =
-          messagesAr[0].getNotNothingString("EDDTableErddapUrlExample", errorInMethod);
-      EDDTableIdExample = messagesAr[0].getNotNothingString("EDDTableIdExample", errorInMethod);
-      EDDTableVariablesExample =
-          messagesAr[0].getNotNothingString("EDDTableVariablesExample", errorInMethod);
-      EDDTableConstraintsExample =
-          messagesAr[0].getNotNothingString("EDDTableConstraintsExample", errorInMethod);
-      EDDTableDataValueExample =
-          messagesAr[0].getNotNothingString("EDDTableDataValueExample", errorInMethod);
-      EDDTableDataTimeExample =
-          messagesAr[0].getNotNothingString("EDDTableDataTimeExample", errorInMethod);
-      EDDTableGraphExample =
-          messagesAr[0].getNotNothingString("EDDTableGraphExample", errorInMethod);
-      EDDTableMapExample = messagesAr[0].getNotNothingString("EDDTableMapExample", errorInMethod);
-      EDDTableMatlabPlotExample =
-          messagesAr[0].getNotNothingString("EDDTableMatlabPlotExample", errorInMethod);
-
-      // admin provides EDDGrid...Example
-      EDDTableErddapUrlExample =
-          getSetupEVString(setup, ev, "EDDTableErddapUrlExample", EDDTableErddapUrlExample);
-      EDDTableIdExample = getSetupEVString(setup, ev, "EDDTableIdExample", EDDTableIdExample);
-      EDDTableVariablesExample =
-          getSetupEVString(setup, ev, "EDDTableVariablesExample", EDDTableVariablesExample);
-      EDDTableConstraintsExample =
-          getSetupEVString(setup, ev, "EDDTableConstraintsExample", EDDTableConstraintsExample);
-      EDDTableDataValueExample =
-          getSetupEVString(setup, ev, "EDDTableDataValueExample", EDDTableDataValueExample);
-      EDDTableDataTimeExample =
-          getSetupEVString(setup, ev, "EDDTableDataTimeExample", EDDTableDataTimeExample);
-      EDDTableGraphExample =
-          getSetupEVString(setup, ev, "EDDTableGraphExample", EDDTableGraphExample);
-      EDDTableMapExample = getSetupEVString(setup, ev, "EDDTableMapExample", EDDTableMapExample);
-      EDDTableMatlabPlotExample =
-          getSetupEVString(setup, ev, "EDDTableMatlabPlotExample", EDDTableMatlabPlotExample);
-
-      // variants encoded to be Html Examples
-      EDDTableConstraintsExampleHE = XML.encodeAsHTML(EDDTableConstraintsExample);
-      EDDTableDataTimeExampleHE = XML.encodeAsHTML(EDDTableDataTimeExample);
-      EDDTableDataValueExampleHE = XML.encodeAsHTML(EDDTableDataValueExample);
-      EDDTableGraphExampleHE = XML.encodeAsHTML(EDDTableGraphExample);
-      EDDTableMapExampleHE = XML.encodeAsHTML(EDDTableMapExample);
-
-      // variants encoded to be Html Attributes
-      EDDTableConstraintsExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableConstraintsExample));
-      EDDTableDataTimeExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataTimeExample));
-      EDDTableDataValueExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableDataValueExample));
-      EDDTableGraphExampleHA =
-          XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableGraphExample));
-      EDDTableMapExampleHA = XML.encodeAsHTMLAttribute(SSR.pseudoPercentEncode(EDDTableMapExample));
-
-      EDDTableFromHttpGetDatasetDescription =
-          XML.decodeEntities( // because this is used as plain text
-              messagesAr[0].getNotNothingString(
-                  "EDDTableFromHttpGetDatasetDescription", errorInMethod));
-      EDDTableFromHttpGetAuthorDescription =
-          messagesAr[0].getNotNothingString("EDDTableFromHttpGetAuthorDescription", errorInMethod);
-      EDDTableFromHttpGetTimestampDescription =
-          messagesAr[0].getNotNothingString(
-              "EDDTableFromHttpGetTimestampDescription", errorInMethod);
-
-      errorTitleAr = getNotNothingString(messagesAr, "errorTitle", errorInMethod);
-      erddapIsAr = getNotNothingString(messagesAr, "erddapIs", errorInMethod);
-      erddapVersionHTMLAr = getNotNothingString(messagesAr, "erddapVersionHTML", errorInMethod);
-      errorRequestUrlAr = getNotNothingString(messagesAr, "errorRequestUrl", errorInMethod);
-      errorRequestQueryAr = getNotNothingString(messagesAr, "errorRequestQuery", errorInMethod);
-      errorTheErrorAr = getNotNothingString(messagesAr, "errorTheError", errorInMethod);
-      errorCopyFromAr = getNotNothingString(messagesAr, "errorCopyFrom", errorInMethod);
-      errorFileNotFoundAr = getNotNothingString(messagesAr, "errorFileNotFound", errorInMethod);
-      errorFileNotFoundImageAr =
-          getNotNothingString(messagesAr, "errorFileNotFoundImage", errorInMethod);
-      errorInternalAr = getNotNothingString(messagesAr, "errorInternal", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) errorInternalAr[tl] += " ";
-
-      errorJsonpFunctionNameAr =
-          getNotNothingString(messagesAr, "errorJsonpFunctionName", errorInMethod);
-      errorJsonpNotAllowedAr =
-          getNotNothingString(messagesAr, "errorJsonpNotAllowed", errorInMethod);
-      errorMoreThan2GBAr = getNotNothingString(messagesAr, "errorMoreThan2GB", errorInMethod);
-      errorNotFoundAr = getNotNothingString(messagesAr, "errorNotFound", errorInMethod);
-      errorNotFoundInAr = getNotNothingString(messagesAr, "errorNotFoundIn", errorInMethod);
-      errorOdvLLTGridAr = getNotNothingString(messagesAr, "errorOdvLLTGrid", errorInMethod);
-      errorOdvLLTTableAr = getNotNothingString(messagesAr, "errorOdvLLTTable", errorInMethod);
-      errorOnWebPageAr = getNotNothingString(messagesAr, "errorOnWebPage", errorInMethod);
-      HtmlWidgets.errorXWasntSpecifiedAr =
-          getNotNothingString(messagesAr, "errorXWasntSpecified", errorInMethod);
-      HtmlWidgets.errorXWasTooLongAr =
-          getNotNothingString(messagesAr, "errorXWasTooLong", errorInMethod);
-      extensionsNoRangeRequests =
-          StringArray.arrayFromCSV(
-              messagesAr[0].getNotNothingString("extensionsNoRangeRequests", errorInMethod),
-              ",",
-              true,
-              false); // trim, keepNothing
-
-      externalLinkAr = getNotNothingString(messagesAr, "externalLink", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) externalLinkAr[tl] = " " + externalLinkAr[tl];
-
-      externalWebSiteAr = getNotNothingString(messagesAr, "externalWebSite", errorInMethod);
-      fileHelp_ascAr = getNotNothingString(messagesAr, "fileHelp_asc", errorInMethod);
-      fileHelp_csvAr = getNotNothingString(messagesAr, "fileHelp_csv", errorInMethod);
-      fileHelp_csvpAr = getNotNothingString(messagesAr, "fileHelp_csvp", errorInMethod);
-      fileHelp_csv0Ar = getNotNothingString(messagesAr, "fileHelp_csv0", errorInMethod);
-      fileHelp_dataTableAr = getNotNothingString(messagesAr, "fileHelp_dataTable", errorInMethod);
-      fileHelp_dasAr = getNotNothingString(messagesAr, "fileHelp_das", errorInMethod);
-      fileHelp_ddsAr = getNotNothingString(messagesAr, "fileHelp_dds", errorInMethod);
-      fileHelp_dodsAr = getNotNothingString(messagesAr, "fileHelp_dods", errorInMethod);
-      fileHelpGrid_esriAsciiAr =
-          getNotNothingString(messagesAr, "fileHelpGrid_esriAscii", errorInMethod);
-      fileHelpTable_esriCsvAr =
-          getNotNothingString(messagesAr, "fileHelpTable_esriCsv", errorInMethod);
-      fileHelp_fgdcAr = getNotNothingString(messagesAr, "fileHelp_fgdc", errorInMethod);
-      fileHelp_geoJsonAr = getNotNothingString(messagesAr, "fileHelp_geoJson", errorInMethod);
-      fileHelp_graphAr = getNotNothingString(messagesAr, "fileHelp_graph", errorInMethod);
-      fileHelpGrid_helpAr = getNotNothingString(messagesAr, "fileHelpGrid_help", errorInMethod);
-      fileHelpTable_helpAr = getNotNothingString(messagesAr, "fileHelpTable_help", errorInMethod);
-      fileHelp_htmlAr = getNotNothingString(messagesAr, "fileHelp_html", errorInMethod);
-      fileHelp_htmlTableAr = getNotNothingString(messagesAr, "fileHelp_htmlTable", errorInMethod);
-      fileHelp_iso19115Ar = getNotNothingString(messagesAr, "fileHelp_iso19115", errorInMethod);
-      fileHelp_itxGridAr = getNotNothingString(messagesAr, "fileHelp_itxGrid", errorInMethod);
-      fileHelp_itxTableAr = getNotNothingString(messagesAr, "fileHelp_itxTable", errorInMethod);
-      fileHelp_jsonAr = getNotNothingString(messagesAr, "fileHelp_json", errorInMethod);
-      fileHelp_jsonlCSV1Ar = getNotNothingString(messagesAr, "fileHelp_jsonlCSV1", errorInMethod);
-      fileHelp_jsonlCSVAr = getNotNothingString(messagesAr, "fileHelp_jsonlCSV", errorInMethod);
-      fileHelp_jsonlKVPAr = getNotNothingString(messagesAr, "fileHelp_jsonlKVP", errorInMethod);
-      fileHelp_matAr = getNotNothingString(messagesAr, "fileHelp_mat", errorInMethod);
-      fileHelpGrid_nc3Ar = getNotNothingString(messagesAr, "fileHelpGrid_nc3", errorInMethod);
-      fileHelpGrid_nc4Ar = getNotNothingString(messagesAr, "fileHelpGrid_nc4", errorInMethod);
-      fileHelpTable_nc3Ar = getNotNothingString(messagesAr, "fileHelpTable_nc3", errorInMethod);
-      fileHelpTable_nc4Ar = getNotNothingString(messagesAr, "fileHelpTable_nc4", errorInMethod);
-      fileHelp_nc3HeaderAr = getNotNothingString(messagesAr, "fileHelp_nc3Header", errorInMethod);
-      fileHelp_nc4HeaderAr = getNotNothingString(messagesAr, "fileHelp_nc4Header", errorInMethod);
-      fileHelp_nccsvAr = getNotNothingString(messagesAr, "fileHelp_nccsv", errorInMethod);
-      fileHelp_nccsvMetadataAr =
-          getNotNothingString(messagesAr, "fileHelp_nccsvMetadata", errorInMethod);
-      fileHelp_ncCFAr = getNotNothingString(messagesAr, "fileHelp_ncCF", errorInMethod);
-      fileHelp_ncCFHeaderAr = getNotNothingString(messagesAr, "fileHelp_ncCFHeader", errorInMethod);
-      fileHelp_ncCFMAAr = getNotNothingString(messagesAr, "fileHelp_ncCFMA", errorInMethod);
-      fileHelp_ncCFMAHeaderAr =
-          getNotNothingString(messagesAr, "fileHelp_ncCFMAHeader", errorInMethod);
-      fileHelp_ncmlAr = getNotNothingString(messagesAr, "fileHelp_ncml", errorInMethod);
-      fileHelp_ncoJsonAr = getNotNothingString(messagesAr, "fileHelp_ncoJson", errorInMethod);
-      fileHelpGrid_odvTxtAr = getNotNothingString(messagesAr, "fileHelpGrid_odvTxt", errorInMethod);
-      fileHelpTable_odvTxtAr =
-          getNotNothingString(messagesAr, "fileHelpTable_odvTxt", errorInMethod);
-      fileHelp_parquetAr = getNotNothingString(messagesAr, "fileHelp_parquet", errorInMethod);
-      fileHelp_parquet_with_metaAr =
-          getNotNothingString(messagesAr, "fileHelp_parquet_with_meta", errorInMethod);
-      fileHelp_subsetAr = getNotNothingString(messagesAr, "fileHelp_subset", errorInMethod);
-      fileHelp_timeGapsAr = getNotNothingString(messagesAr, "fileHelp_timeGaps", errorInMethod);
-      fileHelp_tsvAr = getNotNothingString(messagesAr, "fileHelp_tsv", errorInMethod);
-      fileHelp_tsvpAr = getNotNothingString(messagesAr, "fileHelp_tsvp", errorInMethod);
-      fileHelp_tsv0Ar = getNotNothingString(messagesAr, "fileHelp_tsv0", errorInMethod);
-      fileHelp_wavAr = getNotNothingString(messagesAr, "fileHelp_wav", errorInMethod);
-      fileHelp_xhtmlAr = getNotNothingString(messagesAr, "fileHelp_xhtml", errorInMethod);
-      fileHelp_geotifAr = getNotNothingString(messagesAr, "fileHelp_geotif", errorInMethod);
-      fileHelpGrid_kmlAr = getNotNothingString(messagesAr, "fileHelpGrid_kml", errorInMethod);
-      fileHelpTable_kmlAr = getNotNothingString(messagesAr, "fileHelpTable_kml", errorInMethod);
-      fileHelp_smallPdfAr = getNotNothingString(messagesAr, "fileHelp_smallPdf", errorInMethod);
-      fileHelp_pdfAr = getNotNothingString(messagesAr, "fileHelp_pdf", errorInMethod);
-      fileHelp_largePdfAr = getNotNothingString(messagesAr, "fileHelp_largePdf", errorInMethod);
-      fileHelp_smallPngAr = getNotNothingString(messagesAr, "fileHelp_smallPng", errorInMethod);
-      fileHelp_pngAr = getNotNothingString(messagesAr, "fileHelp_png", errorInMethod);
-      fileHelp_largePngAr = getNotNothingString(messagesAr, "fileHelp_largePng", errorInMethod);
-      fileHelp_transparentPngAr =
-          getNotNothingString(messagesAr, "fileHelp_transparentPng", errorInMethod);
-      filesDescriptionAr = getNotNothingString(messagesAr, "filesDescription", errorInMethod);
-      filesDocumentationAr = getNotNothingString(messagesAr, "filesDocumentation", errorInMethod);
-      filesSortAr = getNotNothingString(messagesAr, "filesSort", errorInMethod);
-      filesWarningAr = getNotNothingString(messagesAr, "filesWarning", errorInMethod);
-      findOutChangeAr = getNotNothingString(messagesAr, "findOutChange", errorInMethod);
-      FIPSCountyCodesAr = getNotNothingString(messagesAr, "FIPSCountyCodes", errorInMethod);
-      forSOSUseAr = getNotNothingString(messagesAr, "forSOSUse", errorInMethod);
-      forWCSUseAr = getNotNothingString(messagesAr, "forWCSUse", errorInMethod);
-      forWMSUseAr = getNotNothingString(messagesAr, "forWMSUse", errorInMethod);
-      functionsAr = getNotNothingString(messagesAr, "functions", errorInMethod);
-      functionTooltipAr = getNotNothingString(messagesAr, "functionTooltip", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        functionTooltipAr[tl] = MessageFormat.format(functionTooltipAr[tl], "distinct()");
-
-      functionDistinctCheckAr =
-          getNotNothingString(messagesAr, "functionDistinctCheck", errorInMethod);
-      functionDistinctTooltipAr =
-          getNotNothingString(messagesAr, "functionDistinctTooltip", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        functionDistinctTooltipAr[tl] =
-            MessageFormat.format(functionDistinctTooltipAr[tl], "distinct()");
-
-      functionOrderByExtraAr =
-          getNotNothingString(messagesAr, "functionOrderByExtra", errorInMethod);
-      functionOrderByTooltipAr =
-          getNotNothingString(messagesAr, "functionOrderByTooltip", errorInMethod);
-      functionOrderBySortAr = getNotNothingString(messagesAr, "functionOrderBySort", errorInMethod);
-      functionOrderBySort1Ar =
-          getNotNothingString(messagesAr, "functionOrderBySort1", errorInMethod);
-      functionOrderBySort2Ar =
-          getNotNothingString(messagesAr, "functionOrderBySort2", errorInMethod);
-      functionOrderBySort3Ar =
-          getNotNothingString(messagesAr, "functionOrderBySort3", errorInMethod);
-      functionOrderBySort4Ar =
-          getNotNothingString(messagesAr, "functionOrderBySort4", errorInMethod);
-      functionOrderBySortLeastAr =
-          getNotNothingString(messagesAr, "functionOrderBySortLeast", errorInMethod);
-      functionOrderBySortRowMaxAr =
-          getNotNothingString(messagesAr, "functionOrderBySortRowMax", errorInMethod);
-      generatedAtAr = getNotNothingString(messagesAr, "generatedAt", errorInMethod);
-      geoServicesDescriptionAr =
-          getNotNothingString(messagesAr, "geoServicesDescription", errorInMethod);
-      getStartedHtmlAr = getNotNothingString(messagesAr, "getStartedHtml", errorInMethod);
-      helpAr = getNotNothingString(messagesAr, "help", errorInMethod);
-      TableWriterHtmlTable.htmlTableMaxMB =
-          messagesAr[0].getInt("htmlTableMaxMB", TableWriterHtmlTable.htmlTableMaxMB);
-      htmlTableMaxMessageAr = getNotNothingString(messagesAr, "htmlTableMaxMessage", errorInMethod);
-
-      imageDataCourtesyOfAr = getNotNothingString(messagesAr, "imageDataCourtesyOf", errorInMethod);
-      imageWidths =
-          String2.toIntArray(
-              String2.split(messagesAr[0].getNotNothingString("imageWidths", errorInMethod), ','));
-      imageHeights =
-          String2.toIntArray(
-              String2.split(messagesAr[0].getNotNothingString("imageHeights", errorInMethod), ','));
-      imagesEmbedAr = getNotNothingString(messagesAr, "imagesEmbed", errorInMethod);
-      indexViewAllAr = getNotNothingString(messagesAr, "indexViewAll", errorInMethod);
-      indexSearchWithAr = getNotNothingString(messagesAr, "indexSearchWith", errorInMethod);
-      indexDevelopersSearchAr =
-          getNotNothingString(messagesAr, "indexDevelopersSearch", errorInMethod);
-      indexProtocolAr = getNotNothingString(messagesAr, "indexProtocol", errorInMethod);
-      indexDescriptionAr = getNotNothingString(messagesAr, "indexDescription", errorInMethod);
-      indexDatasetsAr = getNotNothingString(messagesAr, "indexDatasets", errorInMethod);
-      indexDocumentationAr = getNotNothingString(messagesAr, "indexDocumentation", errorInMethod);
-      indexRESTfulSearchAr = getNotNothingString(messagesAr, "indexRESTfulSearch", errorInMethod);
-      indexAllDatasetsSearchAr =
-          getNotNothingString(messagesAr, "indexAllDatasetsSearch", errorInMethod);
-      indexOpenSearchAr = getNotNothingString(messagesAr, "indexOpenSearch", errorInMethod);
-      indexServicesAr = getNotNothingString(messagesAr, "indexServices", errorInMethod);
-      indexDescribeServicesAr =
-          getNotNothingString(messagesAr, "indexDescribeServices", errorInMethod);
-      indexMetadataAr = getNotNothingString(messagesAr, "indexMetadata", errorInMethod);
-      indexWAF1Ar = getNotNothingString(messagesAr, "indexWAF1", errorInMethod);
-      indexWAF2Ar = getNotNothingString(messagesAr, "indexWAF2", errorInMethod);
-      indexConvertersAr = getNotNothingString(messagesAr, "indexConverters", errorInMethod);
-      indexDescribeConvertersAr =
-          getNotNothingString(messagesAr, "indexDescribeConverters", errorInMethod);
-      infoAboutFromAr = getNotNothingString(messagesAr, "infoAboutFrom", errorInMethod);
-      infoTableTitleHtmlAr = getNotNothingString(messagesAr, "infoTableTitleHtml", errorInMethod);
-      infoRequestFormAr = getNotNothingString(messagesAr, "infoRequestForm", errorInMethod);
-      informationAr = getNotNothingString(messagesAr, "information", errorInMethod);
-      inotifyFixAr = getNotNothingString(messagesAr, "inotifyFix", errorInMethod);
-      inotifyFixCommands = messagesAr[0].getNotNothingString("inotifyFixCommands", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        inotifyFixAr[tl] = MessageFormat.format(inotifyFixAr[tl], inotifyFixCommands);
-      interpolateAr = getNotNothingString(messagesAr, "interpolate", errorInMethod);
-      javaProgramsHTMLAr = getNotNothingString(messagesAr, "javaProgramsHTML", errorInMethod);
-      justGenerateAndViewAr = getNotNothingString(messagesAr, "justGenerateAndView", errorInMethod);
-      justGenerateAndViewTooltipAr =
-          getNotNothingString(messagesAr, "justGenerateAndViewTooltip", errorInMethod);
-      justGenerateAndViewUrlAr =
-          getNotNothingString(messagesAr, "justGenerateAndViewUrl", errorInMethod);
-      justGenerateAndViewGraphUrlTooltipAr =
-          getNotNothingString(messagesAr, "justGenerateAndViewGraphUrlTooltip", errorInMethod);
-      keywordsAr = getNotNothingString(messagesAr, "keywords", errorInMethod);
-      langCodeAr = getNotNothingString(messagesAr, "langCode", errorInMethod);
-
-      legal = messagesAr[0].getNotNothingString("legal", errorInMethod);
-      legal = getSetupEVString(setup, ev, "legal", legal); // optionally in setup.xml
-      legalNoticesAr = getNotNothingString(messagesAr, "legalNotices", errorInMethod);
-      legalNoticesTitleAr = getNotNothingString(messagesAr, "legalNoticesTitle", errorInMethod);
-
-      legendTitle1 = messagesAr[0].getString("legendTitle1", "");
-      legendTitle2 = messagesAr[0].getString("legendTitle2", "");
-      legendTitle1 =
-          getSetupEVString(setup, ev, "legendTitle1", legendTitle1); // optionally in setup.xml
-      legendTitle2 =
-          getSetupEVString(setup, ev, "legendTitle2", legendTitle2); // optionally in setup.xml
-
-      licenseAr = getNotNothingString(messagesAr, "license", errorInMethod);
-      likeThisAr = getNotNothingString(messagesAr, "likeThis", errorInMethod);
-      listAllAr = getNotNothingString(messagesAr, "listAll", errorInMethod);
-      listOfDatasetsAr = getNotNothingString(messagesAr, "listOfDatasets", errorInMethod);
-      LogInAr = getNotNothingString(messagesAr, "LogIn", errorInMethod);
-      loginAr = getNotNothingString(messagesAr, "login", errorInMethod);
-      loginHTMLAr = getNotNothingString(messagesAr, "loginHTML", errorInMethod);
-      loginAttemptBlockedAr = getNotNothingString(messagesAr, "loginAttemptBlocked", errorInMethod);
-      loginDescribeCustomAr = getNotNothingString(messagesAr, "loginDescribeCustom", errorInMethod);
-      loginDescribeEmailAr = getNotNothingString(messagesAr, "loginDescribeEmail", errorInMethod);
-      loginDescribeGoogleAr = getNotNothingString(messagesAr, "loginDescribeGoogle", errorInMethod);
-      loginDescribeOrcidAr = getNotNothingString(messagesAr, "loginDescribeOrcid", errorInMethod);
-      loginDescribeOauth2Ar = getNotNothingString(messagesAr, "loginDescribeOauth2", errorInMethod);
-      loginCanNotAr = getNotNothingString(messagesAr, "loginCanNot", errorInMethod);
-      loginAreNotAr = getNotNothingString(messagesAr, "loginAreNot", errorInMethod);
-      loginToLogInAr = getNotNothingString(messagesAr, "loginToLogIn", errorInMethod);
-      loginEmailAddressAr = getNotNothingString(messagesAr, "loginEmailAddress", errorInMethod);
-      loginYourEmailAddressAr =
-          getNotNothingString(messagesAr, "loginYourEmailAddress", errorInMethod);
-      loginUserNameAr = getNotNothingString(messagesAr, "loginUserName", errorInMethod);
-      loginPasswordAr = getNotNothingString(messagesAr, "loginPassword", errorInMethod);
-      loginUserNameAndPasswordAr =
-          getNotNothingString(messagesAr, "loginUserNameAndPassword", errorInMethod);
-      loginGoogleSignInAr = getNotNothingString(messagesAr, "loginGoogleSignIn", errorInMethod);
-      loginOrcidSignInAr = getNotNothingString(messagesAr, "loginOrcidSignIn", errorInMethod);
-      loginErddapAr = getNotNothingString(messagesAr, "loginErddap", errorInMethod);
-      loginOpenIDAr = getNotNothingString(messagesAr, "loginOpenID", errorInMethod);
-      loginOpenIDOrAr = getNotNothingString(messagesAr, "loginOpenIDOr", errorInMethod);
-      loginOpenIDCreateAr = getNotNothingString(messagesAr, "loginOpenIDCreate", errorInMethod);
-      loginOpenIDFreeAr = getNotNothingString(messagesAr, "loginOpenIDFree", errorInMethod);
-      loginOpenIDSameAr = getNotNothingString(messagesAr, "loginOpenIDSame", errorInMethod);
-      loginAsAr = getNotNothingString(messagesAr, "loginAs", errorInMethod);
-      loginPartwayAsAr = getNotNothingString(messagesAr, "loginPartwayAs", errorInMethod);
-      loginFailedAr = getNotNothingString(messagesAr, "loginFailed", errorInMethod);
-      loginSucceededAr = getNotNothingString(messagesAr, "loginSucceeded", errorInMethod);
-      loginInvalidAr = getNotNothingString(messagesAr, "loginInvalid", errorInMethod);
-      loginNotAr = getNotNothingString(messagesAr, "loginNot", errorInMethod);
-      loginBackAr = getNotNothingString(messagesAr, "loginBack", errorInMethod);
-      loginProblemExactAr = getNotNothingString(messagesAr, "loginProblemExact", errorInMethod);
-      loginProblemExpireAr = getNotNothingString(messagesAr, "loginProblemExpire", errorInMethod);
-      loginProblemGoogleAgainAr =
-          getNotNothingString(messagesAr, "loginProblemGoogleAgain", errorInMethod);
-      loginProblemOrcidAgainAr =
-          getNotNothingString(messagesAr, "loginProblemOrcidAgain", errorInMethod);
-      loginProblemOauth2AgainAr =
-          getNotNothingString(messagesAr, "loginProblemOauth2Again", errorInMethod);
-      loginProblemSameBrowserAr =
-          getNotNothingString(messagesAr, "loginProblemSameBrowser", errorInMethod);
-      loginProblem3TimesAr = getNotNothingString(messagesAr, "loginProblem3Times", errorInMethod);
-      loginProblemsAr = getNotNothingString(messagesAr, "loginProblems", errorInMethod);
-      loginProblemsAfterAr = getNotNothingString(messagesAr, "loginProblemsAfter", errorInMethod);
-      loginPublicAccessAr = getNotNothingString(messagesAr, "loginPublicAccess", errorInMethod);
-      LogOutAr = getNotNothingString(messagesAr, "LogOut", errorInMethod);
-      logoutAr = getNotNothingString(messagesAr, "logout", errorInMethod);
-      logoutOpenIDAr = getNotNothingString(messagesAr, "logoutOpenID", errorInMethod);
-      logoutSuccessAr = getNotNothingString(messagesAr, "logoutSuccess", errorInMethod);
-      magAr = getNotNothingString(messagesAr, "mag", errorInMethod);
-      magAxisXAr = getNotNothingString(messagesAr, "magAxisX", errorInMethod);
-      magAxisYAr = getNotNothingString(messagesAr, "magAxisY", errorInMethod);
-      magAxisColorAr = getNotNothingString(messagesAr, "magAxisColor", errorInMethod);
-      magAxisStickXAr = getNotNothingString(messagesAr, "magAxisStickX", errorInMethod);
-      magAxisStickYAr = getNotNothingString(messagesAr, "magAxisStickY", errorInMethod);
-      magAxisVectorXAr = getNotNothingString(messagesAr, "magAxisVectorX", errorInMethod);
-      magAxisVectorYAr = getNotNothingString(messagesAr, "magAxisVectorY", errorInMethod);
-      magAxisHelpGraphXAr = getNotNothingString(messagesAr, "magAxisHelpGraphX", errorInMethod);
-      magAxisHelpGraphYAr = getNotNothingString(messagesAr, "magAxisHelpGraphY", errorInMethod);
-      magAxisHelpMarkerColorAr =
-          getNotNothingString(messagesAr, "magAxisHelpMarkerColor", errorInMethod);
-      magAxisHelpSurfaceColorAr =
-          getNotNothingString(messagesAr, "magAxisHelpSurfaceColor", errorInMethod);
-      magAxisHelpStickXAr = getNotNothingString(messagesAr, "magAxisHelpStickX", errorInMethod);
-      magAxisHelpStickYAr = getNotNothingString(messagesAr, "magAxisHelpStickY", errorInMethod);
-      magAxisHelpMapXAr = getNotNothingString(messagesAr, "magAxisHelpMapX", errorInMethod);
-      magAxisHelpMapYAr = getNotNothingString(messagesAr, "magAxisHelpMapY", errorInMethod);
-      magAxisHelpVectorXAr = getNotNothingString(messagesAr, "magAxisHelpVectorX", errorInMethod);
-      magAxisHelpVectorYAr = getNotNothingString(messagesAr, "magAxisHelpVectorY", errorInMethod);
-      magAxisVarHelpAr = getNotNothingString(messagesAr, "magAxisVarHelp", errorInMethod);
-      magAxisVarHelpGridAr = getNotNothingString(messagesAr, "magAxisVarHelpGrid", errorInMethod);
-      magConstraintHelpAr = getNotNothingString(messagesAr, "magConstraintHelp", errorInMethod);
-      magDocumentationAr = getNotNothingString(messagesAr, "magDocumentation", errorInMethod);
-      magDownloadAr = getNotNothingString(messagesAr, "magDownload", errorInMethod);
-      magDownloadTooltipAr = getNotNothingString(messagesAr, "magDownloadTooltip", errorInMethod);
-      magFileTypeAr = getNotNothingString(messagesAr, "magFileType", errorInMethod);
-      magGraphTypeAr = getNotNothingString(messagesAr, "magGraphType", errorInMethod);
-      magGraphTypeTooltipGridAr =
-          getNotNothingString(messagesAr, "magGraphTypeTooltipGrid", errorInMethod);
-      magGraphTypeTooltipTableAr =
-          getNotNothingString(messagesAr, "magGraphTypeTooltipTable", errorInMethod);
-      magGSAr = getNotNothingString(messagesAr, "magGS", errorInMethod);
-      magGSMarkerTypeAr = getNotNothingString(messagesAr, "magGSMarkerType", errorInMethod);
-      magGSSizeAr = getNotNothingString(messagesAr, "magGSSize", errorInMethod);
-      magGSColorAr = getNotNothingString(messagesAr, "magGSColor", errorInMethod);
-      magGSColorBarAr = getNotNothingString(messagesAr, "magGSColorBar", errorInMethod);
-      magGSColorBarTooltipAr =
-          getNotNothingString(messagesAr, "magGSColorBarTooltip", errorInMethod);
-      magGSContinuityAr = getNotNothingString(messagesAr, "magGSContinuity", errorInMethod);
-      magGSContinuityTooltipAr =
-          getNotNothingString(messagesAr, "magGSContinuityTooltip", errorInMethod);
-      magGSScaleAr = getNotNothingString(messagesAr, "magGSScale", errorInMethod);
-      magGSScaleTooltipAr = getNotNothingString(messagesAr, "magGSScaleTooltip", errorInMethod);
-      magGSMinAr = getNotNothingString(messagesAr, "magGSMin", errorInMethod);
-      magGSMinTooltipAr = getNotNothingString(messagesAr, "magGSMinTooltip", errorInMethod);
-      magGSMaxAr = getNotNothingString(messagesAr, "magGSMax", errorInMethod);
-      magGSMaxTooltipAr = getNotNothingString(messagesAr, "magGSMaxTooltip", errorInMethod);
-      magGSNSectionsAr = getNotNothingString(messagesAr, "magGSNSections", errorInMethod);
-      magGSNSectionsTooltipAr =
-          getNotNothingString(messagesAr, "magGSNSectionsTooltip", errorInMethod);
-      magGSLandMaskAr = getNotNothingString(messagesAr, "magGSLandMask", errorInMethod);
-      magGSLandMaskTooltipGridAr =
-          getNotNothingString(messagesAr, "magGSLandMaskTooltipGrid", errorInMethod);
-      magGSLandMaskTooltipTableAr =
-          getNotNothingString(messagesAr, "magGSLandMaskTooltipTable", errorInMethod);
-      magGSVectorStandardAr = getNotNothingString(messagesAr, "magGSVectorStandard", errorInMethod);
-      magGSVectorStandardTooltipAr =
-          getNotNothingString(messagesAr, "magGSVectorStandardTooltip", errorInMethod);
-      magGSYAscendingTooltipAr =
-          getNotNothingString(messagesAr, "magGSYAscendingTooltip", errorInMethod);
-      magGSYAxisMinAr = getNotNothingString(messagesAr, "magGSYAxisMin", errorInMethod);
-      magGSYAxisMaxAr = getNotNothingString(messagesAr, "magGSYAxisMax", errorInMethod);
-      magGSYRangeMinTooltipAr =
-          getNotNothingString(messagesAr, "magGSYRangeMinTooltip", errorInMethod);
-      magGSYRangeMaxTooltipAr =
-          getNotNothingString(messagesAr, "magGSYRangeMaxTooltip", errorInMethod);
-      magGSYRangeTooltipAr = getNotNothingString(messagesAr, "magGSYRangeTooltip", errorInMethod);
-      magGSYScaleTooltipAr = getNotNothingString(messagesAr, "magGSYScaleTooltip", errorInMethod);
-      magItemFirstAr = getNotNothingString(messagesAr, "magItemFirst", errorInMethod);
-      magItemPreviousAr = getNotNothingString(messagesAr, "magItemPrevious", errorInMethod);
-      magItemNextAr = getNotNothingString(messagesAr, "magItemNext", errorInMethod);
-      magItemLastAr = getNotNothingString(messagesAr, "magItemLast", errorInMethod);
-      magJust1ValueAr = getNotNothingString(messagesAr, "magJust1Value", errorInMethod);
-      magRangeAr = getNotNothingString(messagesAr, "magRange", errorInMethod);
-      magRangeToAr = getNotNothingString(messagesAr, "magRangeTo", errorInMethod);
-      magRedrawAr = getNotNothingString(messagesAr, "magRedraw", errorInMethod);
-      magRedrawTooltipAr = getNotNothingString(messagesAr, "magRedrawTooltip", errorInMethod);
-      magTimeRangeAr = getNotNothingString(messagesAr, "magTimeRange", errorInMethod);
-      magTimeRangeFirstAr = getNotNothingString(messagesAr, "magTimeRangeFirst", errorInMethod);
-      magTimeRangeBackAr = getNotNothingString(messagesAr, "magTimeRangeBack", errorInMethod);
-      magTimeRangeForwardAr = getNotNothingString(messagesAr, "magTimeRangeForward", errorInMethod);
-      magTimeRangeLastAr = getNotNothingString(messagesAr, "magTimeRangeLast", errorInMethod);
-      magTimeRangeTooltipAr = getNotNothingString(messagesAr, "magTimeRangeTooltip", errorInMethod);
-      magTimeRangeTooltip2Ar =
-          getNotNothingString(messagesAr, "magTimeRangeTooltip2", errorInMethod);
-      magTimesVaryAr = getNotNothingString(messagesAr, "magTimesVary", errorInMethod);
-      magViewUrlAr = getNotNothingString(messagesAr, "magViewUrl", errorInMethod);
-      magZoomAr = getNotNothingString(messagesAr, "magZoom", errorInMethod);
-      magZoomCenterAr = getNotNothingString(messagesAr, "magZoomCenter", errorInMethod);
-      magZoomCenterTooltipAr =
-          getNotNothingString(messagesAr, "magZoomCenterTooltip", errorInMethod);
-      magZoomInAr = getNotNothingString(messagesAr, "magZoomIn", errorInMethod);
-      magZoomInTooltipAr = getNotNothingString(messagesAr, "magZoomInTooltip", errorInMethod);
-      magZoomOutAr = getNotNothingString(messagesAr, "magZoomOut", errorInMethod);
-      magZoomOutTooltipAr = getNotNothingString(messagesAr, "magZoomOutTooltip", errorInMethod);
-      magZoomALittleAr = getNotNothingString(messagesAr, "magZoomALittle", errorInMethod);
-      magZoomDataAr = getNotNothingString(messagesAr, "magZoomData", errorInMethod);
-      magZoomOutDataAr = getNotNothingString(messagesAr, "magZoomOutData", errorInMethod);
-      magGridTooltipAr = getNotNothingString(messagesAr, "magGridTooltip", errorInMethod);
-      magTableTooltipAr = getNotNothingString(messagesAr, "magTableTooltip", errorInMethod);
-
-      Math2.memory = messagesAr[0].getNotNothingString("memory", errorInMethod);
-      Math2.memoryTooMuchData =
-          messagesAr[0].getNotNothingString("memoryTooMuchData", errorInMethod);
-      Math2.memoryArraySize = messagesAr[0].getNotNothingString("memoryArraySize", errorInMethod);
-      Math2.memoryThanCurrentlySafe =
-          messagesAr[0].getNotNothingString("memoryThanCurrentlySafe", errorInMethod);
-      Math2.memoryThanSafe = messagesAr[0].getNotNothingString("memoryThanSafe", errorInMethod);
-
-      metadataDownloadAr = getNotNothingString(messagesAr, "metadataDownload", errorInMethod);
-      moreInformationAr = getNotNothingString(messagesAr, "moreInformation", errorInMethod);
-
-      MustBe.THERE_IS_NO_DATA =
-          messagesAr[0].getNotNothingString("MustBeThereIsNoData", errorInMethod);
-      MustBe.NotNull = messagesAr[0].getNotNothingString("MustBeNotNull", errorInMethod);
-      MustBe.NotEmpty = messagesAr[0].getNotNothingString("MustBeNotEmpty", errorInMethod);
-      MustBe.InternalError =
-          messagesAr[0].getNotNothingString("MustBeInternalError", errorInMethod);
-      MustBe.OutOfMemoryError =
-          messagesAr[0].getNotNothingString("MustBeOutOfMemoryError", errorInMethod);
-
-      nMatching1Ar = getNotNothingString(messagesAr, "nMatching1", errorInMethod);
-      nMatchingAr = getNotNothingString(messagesAr, "nMatching", errorInMethod);
-      nMatchingAlphabeticalAr =
-          getNotNothingString(messagesAr, "nMatchingAlphabetical", errorInMethod);
-      nMatchingMostRelevantAr =
-          getNotNothingString(messagesAr, "nMatchingMostRelevant", errorInMethod);
-      nMatchingPageAr = getNotNothingString(messagesAr, "nMatchingPage", errorInMethod);
-      nMatchingCurrentAr = getNotNothingString(messagesAr, "nMatchingCurrent", errorInMethod);
-      noDataFixedValueAr = getNotNothingString(messagesAr, "noDataFixedValue", errorInMethod);
-      noDataNoLLAr = getNotNothingString(messagesAr, "noDataNoLL", errorInMethod);
-      noDatasetWithAr = getNotNothingString(messagesAr, "noDatasetWith", errorInMethod);
-      noPage1Ar = getNotNothingString(messagesAr, "noPage1", errorInMethod);
-      noPage2Ar = getNotNothingString(messagesAr, "noPage2", errorInMethod);
-      notAllowedAr = getNotNothingString(messagesAr, "notAllowed", errorInMethod);
-      notAuthorizedAr = getNotNothingString(messagesAr, "notAuthorized", errorInMethod);
-      notAuthorizedForDataAr =
-          getNotNothingString(messagesAr, "notAuthorizedForData", errorInMethod);
-      notAvailableAr = getNotNothingString(messagesAr, "notAvailable", errorInMethod);
-      noteAr = getNotNothingString(messagesAr, "note", errorInMethod);
-      noXxxAr = getNotNothingString(messagesAr, "noXxx", errorInMethod);
-      noXxxBecauseAr = getNotNothingString(messagesAr, "noXxxBecause", errorInMethod);
-      noXxxBecause2Ar = getNotNothingString(messagesAr, "noXxxBecause2", errorInMethod);
-      noXxxNotActiveAr = getNotNothingString(messagesAr, "noXxxNotActive", errorInMethod);
-      noXxxNoAxis1Ar = getNotNothingString(messagesAr, "noXxxNoAxis1", errorInMethod);
-      noXxxNoCdmDataTypeAr = getNotNothingString(messagesAr, "noXxxNoCdmDataType", errorInMethod);
-      noXxxNoColorBarAr = getNotNothingString(messagesAr, "noXxxNoColorBar", errorInMethod);
-      noXxxNoLLAr = getNotNothingString(messagesAr, "noXxxNoLL", errorInMethod);
-      noXxxNoLLEvenlySpacedAr =
-          getNotNothingString(messagesAr, "noXxxNoLLEvenlySpaced", errorInMethod);
-      noXxxNoLLGt1Ar = getNotNothingString(messagesAr, "noXxxNoLLGt1", errorInMethod);
-      noXxxNoLLTAr = getNotNothingString(messagesAr, "noXxxNoLLT", errorInMethod);
-      noXxxNoLonIn180Ar = getNotNothingString(messagesAr, "noXxxNoLonIn180", errorInMethod);
-      noXxxNoNonStringAr = getNotNothingString(messagesAr, "noXxxNoNonString", errorInMethod);
-      noXxxNo2NonStringAr = getNotNothingString(messagesAr, "noXxxNo2NonString", errorInMethod);
-      noXxxNoStationAr = getNotNothingString(messagesAr, "noXxxNoStation", errorInMethod);
-      noXxxNoStationIDAr = getNotNothingString(messagesAr, "noXxxNoStationID", errorInMethod);
-      noXxxNoSubsetVariablesAr =
-          getNotNothingString(messagesAr, "noXxxNoSubsetVariables", errorInMethod);
-      noXxxNoOLLSubsetVariablesAr =
-          getNotNothingString(messagesAr, "noXxxNoOLLSubsetVariables", errorInMethod);
-      noXxxNoMinMaxAr = getNotNothingString(messagesAr, "noXxxNoMinMax", errorInMethod);
-      noXxxItsGriddedAr = getNotNothingString(messagesAr, "noXxxItsGridded", errorInMethod);
-      noXxxItsTabularAr = getNotNothingString(messagesAr, "noXxxItsTabular", errorInMethod);
-      oneRequestAtATimeAr = getNotNothingString(messagesAr, "oneRequestAtATime", errorInMethod);
-      openSearchDescriptionAr =
-          getNotNothingString(messagesAr, "openSearchDescription", errorInMethod);
-      optionalAr = getNotNothingString(messagesAr, "optional", errorInMethod);
-      optionsAr = getNotNothingString(messagesAr, "options", errorInMethod);
-      orAListOfValuesAr = getNotNothingString(messagesAr, "orAListOfValues", errorInMethod);
-      orRefineSearchWithAr = getNotNothingString(messagesAr, "orRefineSearchWith", errorInMethod);
-      orSearchWithAr = getNotNothingString(messagesAr, "orSearchWith", errorInMethod);
-      orCommaAr = getNotNothingString(messagesAr, "orComma", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) {
-        orRefineSearchWithAr[tl] += " ";
-        orSearchWithAr[tl] += " ";
-        orCommaAr[tl] += " ";
-      }
-      otherFeaturesAr = getNotNothingString(messagesAr, "otherFeatures", errorInMethod);
-      outOfDateDatasetsAr = getNotNothingString(messagesAr, "outOfDateDatasets", errorInMethod);
-      outOfDateHtmlAr = getNotNothingString(messagesAr, "outOfDateHtml", errorInMethod);
-      outOfDateKeepTrackAr = getNotNothingString(messagesAr, "outOfDateKeepTrack", errorInMethod);
-
-      // just one set of palettes info (from messagesAr[0])
-      palettes = String2.split(messagesAr[0].getNotNothingString("palettes", errorInMethod), ',');
-      DEFAULT_palettes = palettes; // used by LoadDatasets if palettes tag is empty
-      DEFAULT_palettes_set = String2.stringArrayToSet(palettes);
-      palettes0 = new String[palettes.length + 1];
-      palettes0[0] = "";
-      System.arraycopy(palettes, 0, palettes0, 1, palettes.length);
-
-      patientDataAr = getNotNothingString(messagesAr, "patientData", errorInMethod);
-      patientYourGraphAr = getNotNothingString(messagesAr, "patientYourGraph", errorInMethod);
-
-      pdfWidths =
-          String2.toIntArray(
-              String2.split(messagesAr[0].getNotNothingString("pdfWidths", errorInMethod), ','));
-      pdfHeights =
-          String2.toIntArray(
-              String2.split(messagesAr[0].getNotNothingString("pdfHeights", errorInMethod), ','));
-
-      percentEncodeAr = getNotNothingString(messagesAr, "percentEncode", errorInMethod);
-      pickADatasetAr = getNotNothingString(messagesAr, "pickADataset", errorInMethod);
-      protocolSearchHtmlAr = getNotNothingString(messagesAr, "protocolSearchHtml", errorInMethod);
-      protocolSearch2HtmlAr = getNotNothingString(messagesAr, "protocolSearch2Html", errorInMethod);
-      protocolClickAr = getNotNothingString(messagesAr, "protocolClick", errorInMethod);
-      queryErrorAr = getNotNothingString(messagesAr, "queryError", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) queryErrorAr[tl] += " ";
-      queryError180Ar = getNotNothingString(messagesAr, "queryError180", errorInMethod);
-      queryError1ValueAr = getNotNothingString(messagesAr, "queryError1Value", errorInMethod);
-      queryError1VarAr = getNotNothingString(messagesAr, "queryError1Var", errorInMethod);
-      queryError2VarAr = getNotNothingString(messagesAr, "queryError2Var", errorInMethod);
-      queryErrorActualRangeAr =
-          getNotNothingString(messagesAr, "queryErrorActualRange", errorInMethod);
-      queryErrorAdjustedAr = getNotNothingString(messagesAr, "queryErrorAdjusted", errorInMethod);
-      queryErrorAscendingAr = getNotNothingString(messagesAr, "queryErrorAscending", errorInMethod);
-      queryErrorConstraintNaNAr =
-          getNotNothingString(messagesAr, "queryErrorConstraintNaN", errorInMethod);
-      queryErrorEqualSpacingAr =
-          getNotNothingString(messagesAr, "queryErrorEqualSpacing", errorInMethod);
-      queryErrorExpectedAtAr =
-          getNotNothingString(messagesAr, "queryErrorExpectedAt", errorInMethod);
-      queryErrorFileTypeAr = getNotNothingString(messagesAr, "queryErrorFileType", errorInMethod);
-      queryErrorInvalidAr = getNotNothingString(messagesAr, "queryErrorInvalid", errorInMethod);
-      queryErrorLLAr = getNotNothingString(messagesAr, "queryErrorLL", errorInMethod);
-      queryErrorLLGt1Ar = getNotNothingString(messagesAr, "queryErrorLLGt1", errorInMethod);
-      queryErrorLLTAr = getNotNothingString(messagesAr, "queryErrorLLT", errorInMethod);
-      queryErrorNeverTrueAr = getNotNothingString(messagesAr, "queryErrorNeverTrue", errorInMethod);
-      queryErrorNeverBothTrueAr =
-          getNotNothingString(messagesAr, "queryErrorNeverBothTrue", errorInMethod);
-      queryErrorNotAxisAr = getNotNothingString(messagesAr, "queryErrorNotAxis", errorInMethod);
-      queryErrorNotExpectedAtAr =
-          getNotNothingString(messagesAr, "queryErrorNotExpectedAt", errorInMethod);
-      queryErrorNotFoundAfterAr =
-          getNotNothingString(messagesAr, "queryErrorNotFoundAfter", errorInMethod);
-      queryErrorOccursTwiceAr =
-          getNotNothingString(messagesAr, "queryErrorOccursTwice", errorInMethod);
-
-      queryErrorOrderByClosestAr =
-          getNotNothingString(messagesAr, "queryErrorOrderByClosest", errorInMethod);
-      queryErrorOrderByLimitAr =
-          getNotNothingString(messagesAr, "queryErrorOrderByLimit", errorInMethod);
-      queryErrorOrderByMeanAr =
-          getNotNothingString(messagesAr, "queryErrorOrderByMean", errorInMethod);
-      queryErrorOrderBySumAr =
-          getNotNothingString(messagesAr, "queryErrorOrderBySum", errorInMethod);
-
-      queryErrorOrderByVariableAr =
-          getNotNothingString(messagesAr, "queryErrorOrderByVariable", errorInMethod);
-      queryErrorUnknownVariableAr =
-          getNotNothingString(messagesAr, "queryErrorUnknownVariable", errorInMethod);
-
-      queryErrorGrid1AxisAr = getNotNothingString(messagesAr, "queryErrorGrid1Axis", errorInMethod);
-      queryErrorGridAmpAr = getNotNothingString(messagesAr, "queryErrorGridAmp", errorInMethod);
-      queryErrorGridDiagnosticAr =
-          getNotNothingString(messagesAr, "queryErrorGridDiagnostic", errorInMethod);
-      queryErrorGridBetweenAr =
-          getNotNothingString(messagesAr, "queryErrorGridBetween", errorInMethod);
-      queryErrorGridLessMinAr =
-          getNotNothingString(messagesAr, "queryErrorGridLessMin", errorInMethod);
-      queryErrorGridGreaterMaxAr =
-          getNotNothingString(messagesAr, "queryErrorGridGreaterMax", errorInMethod);
-      queryErrorGridMissingAr =
-          getNotNothingString(messagesAr, "queryErrorGridMissing", errorInMethod);
-      queryErrorGridNoAxisVarAr =
-          getNotNothingString(messagesAr, "queryErrorGridNoAxisVar", errorInMethod);
-      queryErrorGridNoDataVarAr =
-          getNotNothingString(messagesAr, "queryErrorGridNoDataVar", errorInMethod);
-      queryErrorGridNotIdenticalAr =
-          getNotNothingString(messagesAr, "queryErrorGridNotIdentical", errorInMethod);
-      queryErrorGridSLessSAr =
-          getNotNothingString(messagesAr, "queryErrorGridSLessS", errorInMethod);
-      queryErrorLastEndPAr = getNotNothingString(messagesAr, "queryErrorLastEndP", errorInMethod);
-      queryErrorLastExpectedAr =
-          getNotNothingString(messagesAr, "queryErrorLastExpected", errorInMethod);
-      queryErrorLastUnexpectedAr =
-          getNotNothingString(messagesAr, "queryErrorLastUnexpected", errorInMethod);
-      queryErrorLastPMInvalidAr =
-          getNotNothingString(messagesAr, "queryErrorLastPMInvalid", errorInMethod);
-      queryErrorLastPMIntegerAr =
-          getNotNothingString(messagesAr, "queryErrorLastPMInteger", errorInMethod);
-
-      questionMarkImageFile =
-          messagesAr[0].getNotNothingString("questionMarkImageFile", errorInMethod);
-      questionMarkImageFile =
-          getSetupEVString(setup, ev, "questionMarkImageFile", questionMarkImageFile); // optional
-
-      rangesFromToAr = getNotNothingString(messagesAr, "rangesFromTo", errorInMethod);
-      requiredAr = getNotNothingString(messagesAr, "required", errorInMethod);
-      requestFormatExamplesHtmlAr =
-          getNotNothingString(messagesAr, "requestFormatExamplesHtml", errorInMethod);
-      resetTheFormAr = getNotNothingString(messagesAr, "resetTheForm", errorInMethod);
-      resetTheFormWasAr = getNotNothingString(messagesAr, "resetTheFormWas", errorInMethod);
-      resourceNotFoundAr = getNotNothingString(messagesAr, "resourceNotFound", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) resourceNotFoundAr[tl] += " ";
-      restfulWebServicesAr = getNotNothingString(messagesAr, "restfulWebServices", errorInMethod);
-      restfulHTMLAr = getNotNothingString(messagesAr, "restfulHTML", errorInMethod);
-      restfulHTMLContinuedAr =
-          getNotNothingString(messagesAr, "restfulHTMLContinued", errorInMethod);
-      restfulGetAllDatasetAr =
-          getNotNothingString(messagesAr, "restfulGetAllDataset", errorInMethod);
-      restfulProtocolsAr = getNotNothingString(messagesAr, "restfulProtocols", errorInMethod);
-      SOSDocumentationAr = getNotNothingString(messagesAr, "SOSDocumentation", errorInMethod);
-      WCSDocumentationAr = getNotNothingString(messagesAr, "WCSDocumentation", errorInMethod);
-      WMSDocumentationAr = getNotNothingString(messagesAr, "WMSDocumentation", errorInMethod);
-      resultsFormatExamplesHtmlAr =
-          getNotNothingString(messagesAr, "resultsFormatExamplesHtml", errorInMethod);
-      resultsOfSearchForAr = getNotNothingString(messagesAr, "resultsOfSearchFor", errorInMethod);
-      restfulInformationFormatsAr =
-          getNotNothingString(messagesAr, "restfulInformationFormats", errorInMethod);
-      restfulViaServiceAr = getNotNothingString(messagesAr, "restfulViaService", errorInMethod);
-      rowsAr = getNotNothingString(messagesAr, "rows", errorInMethod);
-      rssNoAr = getNotNothingString(messagesAr, "rssNo", errorInMethod);
-      searchTitleAr = getNotNothingString(messagesAr, "searchTitle", errorInMethod);
-      searchDoFullTextHtmlAr =
-          getNotNothingString(messagesAr, "searchDoFullTextHtml", errorInMethod);
-      searchFullTextHtmlAr = getNotNothingString(messagesAr, "searchFullTextHtml", errorInMethod);
-      searchButtonAr = getNotNothingString(messagesAr, "searchButton", errorInMethod);
-      searchClickTipAr = getNotNothingString(messagesAr, "searchClickTip", errorInMethod);
-      searchHintsLuceneTooltipAr =
-          getNotNothingString(messagesAr, "searchHintsLuceneTooltip", errorInMethod);
-      searchHintsOriginalTooltipAr =
-          getNotNothingString(messagesAr, "searchHintsOriginalTooltip", errorInMethod);
-      searchHintsTooltipAr = getNotNothingString(messagesAr, "searchHintsTooltip", errorInMethod);
-      searchMultipleERDDAPsAr =
-          getNotNothingString(messagesAr, "searchMultipleERDDAPs", errorInMethod);
-      searchMultipleERDDAPsDescriptionAr =
-          getNotNothingString(messagesAr, "searchMultipleERDDAPsDescription", errorInMethod);
-      searchNotAvailableAr = getNotNothingString(messagesAr, "searchNotAvailable", errorInMethod);
-      searchTipAr = getNotNothingString(messagesAr, "searchTip", errorInMethod);
-      searchSpellingAr = getNotNothingString(messagesAr, "searchSpelling", errorInMethod);
-      searchFewerWordsAr = getNotNothingString(messagesAr, "searchFewerWords", errorInMethod);
-      searchWithQueryAr = getNotNothingString(messagesAr, "searchWithQuery", errorInMethod);
-      selectNextAr = getNotNothingString(messagesAr, "selectNext", errorInMethod);
-      selectPreviousAr = getNotNothingString(messagesAr, "selectPrevious", errorInMethod);
-      shiftXAllTheWayLeftAr = getNotNothingString(messagesAr, "shiftXAllTheWayLeft", errorInMethod);
-      shiftXLeftAr = getNotNothingString(messagesAr, "shiftXLeft", errorInMethod);
-      shiftXRightAr = getNotNothingString(messagesAr, "shiftXRight", errorInMethod);
-      shiftXAllTheWayRightAr =
-          getNotNothingString(messagesAr, "shiftXAllTheWayRight", errorInMethod);
-
-      Attributes.signedToUnsignedAttNames =
-          StringArray.arrayFromCSV(
-              messagesAr[0].getNotNothingString("signedToUnsignedAttNames", errorInMethod));
-
-      seeProtocolDocumentationAr =
-          getNotNothingString(messagesAr, "seeProtocolDocumentation", errorInMethod);
-
-      slideSorterAr = getNotNothingString(messagesAr, "slideSorter", errorInMethod);
-      SOSAr = getNotNothingString(messagesAr, "SOS", errorInMethod);
-      sosDescriptionHtmlAr = getNotNothingString(messagesAr, "sosDescriptionHtml", errorInMethod);
-      sosLongDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "sosLongDescriptionHtml", errorInMethod);
-      sosOverview1Ar = getNotNothingString(messagesAr, "sosOverview1", errorInMethod);
-      sosOverview2Ar = getNotNothingString(messagesAr, "sosOverview2", errorInMethod);
-      sparqlP01toP02pre = messagesAr[0].getNotNothingString("sparqlP01toP02pre", errorInMethod);
-      sparqlP01toP02post = messagesAr[0].getNotNothingString("sparqlP01toP02post", errorInMethod);
-      ssUseAr = getNotNothingString(messagesAr, "ssUse", errorInMethod);
-      ssUsePlainAr = getNotNothingString(messagesAr, "ssUse", errorInMethod); // start with this
-      for (int tl = 0; tl < nLanguages; tl++)
-        ssUsePlainAr[tl] = XML.removeHTMLTags(ssUsePlainAr[tl]);
-
-      ssBePatientAr = getNotNothingString(messagesAr, "ssBePatient", errorInMethod);
-      ssInstructionsHtmlAr = getNotNothingString(messagesAr, "ssInstructionsHtml", errorInMethod);
-
-      statusAr = getNotNothingString(messagesAr, "status", errorInMethod);
-      statusHtmlAr = getNotNothingString(messagesAr, "statusHtml", errorInMethod);
-      submitAr = getNotNothingString(messagesAr, "submit", errorInMethod);
-      submitTooltipAr = getNotNothingString(messagesAr, "submitTooltip", errorInMethod);
-      subscriptionOfferRssAr =
-          getNotNothingString(messagesAr, "subscriptionOfferRss", errorInMethod);
-      subscriptionOfferUrlAr =
-          getNotNothingString(messagesAr, "subscriptionOfferUrl", errorInMethod);
-      subscriptionsTitleAr = getNotNothingString(messagesAr, "subscriptionsTitle", errorInMethod);
-      subscriptionEmailListAr =
-          getNotNothingString(messagesAr, "subscriptionEmailList", errorInMethod);
-      subscriptionAddAr = getNotNothingString(messagesAr, "subscriptionAdd", errorInMethod);
-      subscriptionValidateAr =
-          getNotNothingString(messagesAr, "subscriptionValidate", errorInMethod);
-      subscriptionListAr = getNotNothingString(messagesAr, "subscriptionList", errorInMethod);
-      subscriptionRemoveAr = getNotNothingString(messagesAr, "subscriptionRemove", errorInMethod);
-      subscription0HtmlAr = getNotNothingString(messagesAr, "subscription0Html", errorInMethod);
-      subscription1HtmlAr = getNotNothingString(messagesAr, "subscription1Html", errorInMethod);
-      subscription2HtmlAr = getNotNothingString(messagesAr, "subscription2Html", errorInMethod);
-      subscriptionAbuseAr = getNotNothingString(messagesAr, "subscriptionAbuse", errorInMethod);
-      subscriptionAddErrorAr =
-          getNotNothingString(messagesAr, "subscriptionAddError", errorInMethod);
-      subscriptionAddHtmlAr = getNotNothingString(messagesAr, "subscriptionAddHtml", errorInMethod);
-      subscriptionAdd2Ar = getNotNothingString(messagesAr, "subscriptionAdd2", errorInMethod);
-      subscriptionAddSuccessAr =
-          getNotNothingString(messagesAr, "subscriptionAddSuccess", errorInMethod);
-      subscriptionEmailAr = getNotNothingString(messagesAr, "subscriptionEmail", errorInMethod);
-      subscriptionEmailOnBlacklistAr =
-          getNotNothingString(messagesAr, "subscriptionEmailOnBlacklist", errorInMethod);
-      subscriptionEmailInvalidAr =
-          getNotNothingString(messagesAr, "subscriptionEmailInvalid", errorInMethod);
-      subscriptionEmailTooLongAr =
-          getNotNothingString(messagesAr, "subscriptionEmailTooLong", errorInMethod);
-      subscriptionEmailUnspecifiedAr =
-          getNotNothingString(messagesAr, "subscriptionEmailUnspecified", errorInMethod);
-      subscriptionIDInvalidAr =
-          getNotNothingString(messagesAr, "subscriptionIDInvalid", errorInMethod);
-      subscriptionIDTooLongAr =
-          getNotNothingString(messagesAr, "subscriptionIDTooLong", errorInMethod);
-      subscriptionIDUnspecifiedAr =
-          getNotNothingString(messagesAr, "subscriptionIDUnspecified", errorInMethod);
-      subscriptionKeyInvalidAr =
-          getNotNothingString(messagesAr, "subscriptionKeyInvalid", errorInMethod);
-      subscriptionKeyUnspecifiedAr =
-          getNotNothingString(messagesAr, "subscriptionKeyUnspecified", errorInMethod);
-      subscriptionListErrorAr =
-          getNotNothingString(messagesAr, "subscriptionListError", errorInMethod);
-      subscriptionListHtmlAr =
-          getNotNothingString(messagesAr, "subscriptionListHtml", errorInMethod);
-      subscriptionListSuccessAr =
-          getNotNothingString(messagesAr, "subscriptionListSuccess", errorInMethod);
-      subscriptionRemoveErrorAr =
-          getNotNothingString(messagesAr, "subscriptionRemoveError", errorInMethod);
-      subscriptionRemoveHtmlAr =
-          getNotNothingString(messagesAr, "subscriptionRemoveHtml", errorInMethod);
-      subscriptionRemove2Ar = getNotNothingString(messagesAr, "subscriptionRemove2", errorInMethod);
-      subscriptionRemoveSuccessAr =
-          getNotNothingString(messagesAr, "subscriptionRemoveSuccess", errorInMethod);
-      subscriptionRSSAr = getNotNothingString(messagesAr, "subscriptionRSS", errorInMethod);
-      subscriptionsNotAvailableAr =
-          getNotNothingString(messagesAr, "subscriptionsNotAvailable", errorInMethod);
-      subscriptionUrlHtmlAr = getNotNothingString(messagesAr, "subscriptionUrlHtml", errorInMethod);
-      subscriptionUrlInvalidAr =
-          getNotNothingString(messagesAr, "subscriptionUrlInvalid", errorInMethod);
-      subscriptionUrlTooLongAr =
-          getNotNothingString(messagesAr, "subscriptionUrlTooLong", errorInMethod);
-      subscriptionValidateErrorAr =
-          getNotNothingString(messagesAr, "subscriptionValidateError", errorInMethod);
-      subscriptionValidateHtmlAr =
-          getNotNothingString(messagesAr, "subscriptionValidateHtml", errorInMethod);
-      subscriptionValidateSuccessAr =
-          getNotNothingString(messagesAr, "subscriptionValidateSuccess", errorInMethod);
-      subsetAr = getNotNothingString(messagesAr, "subset", errorInMethod);
-      subsetSelectAr = getNotNothingString(messagesAr, "subsetSelect", errorInMethod);
-      subsetNMatchingAr = getNotNothingString(messagesAr, "subsetNMatching", errorInMethod);
-      subsetInstructionsAr = getNotNothingString(messagesAr, "subsetInstructions", errorInMethod);
-      subsetOptionAr = getNotNothingString(messagesAr, "subsetOption", errorInMethod);
-      subsetOptionsAr = getNotNothingString(messagesAr, "subsetOptions", errorInMethod);
-      subsetRefineMapDownloadAr =
-          getNotNothingString(messagesAr, "subsetRefineMapDownload", errorInMethod);
-      subsetRefineSubsetDownloadAr =
-          getNotNothingString(messagesAr, "subsetRefineSubsetDownload", errorInMethod);
-      subsetClickResetClosestAr =
-          getNotNothingString(messagesAr, "subsetClickResetClosest", errorInMethod);
-      subsetClickResetLLAr = getNotNothingString(messagesAr, "subsetClickResetLL", errorInMethod);
-      subsetMetadataAr = getNotNothingString(messagesAr, "subsetMetadata", errorInMethod);
-      subsetCountAr = getNotNothingString(messagesAr, "subsetCount", errorInMethod);
-      subsetPercentAr = getNotNothingString(messagesAr, "subsetPercent", errorInMethod);
-      subsetViewSelectAr = getNotNothingString(messagesAr, "subsetViewSelect", errorInMethod);
-      subsetViewSelectDistinctCombosAr =
-          getNotNothingString(messagesAr, "subsetViewSelectDistinctCombos", errorInMethod);
-      subsetViewSelectRelatedCountsAr =
-          getNotNothingString(messagesAr, "subsetViewSelectRelatedCounts", errorInMethod);
-      subsetWhenAr = getNotNothingString(messagesAr, "subsetWhen", errorInMethod);
-      subsetWhenNoConstraintsAr =
-          getNotNothingString(messagesAr, "subsetWhenNoConstraints", errorInMethod);
-      subsetWhenCountsAr = getNotNothingString(messagesAr, "subsetWhenCounts", errorInMethod);
-      subsetComboClickSelectAr =
-          getNotNothingString(messagesAr, "subsetComboClickSelect", errorInMethod);
-      subsetNVariableCombosAr =
-          getNotNothingString(messagesAr, "subsetNVariableCombos", errorInMethod);
-      subsetShowingAllRowsAr =
-          getNotNothingString(messagesAr, "subsetShowingAllRows", errorInMethod);
-      subsetShowingNRowsAr = getNotNothingString(messagesAr, "subsetShowingNRows", errorInMethod);
-      subsetChangeShowingAr = getNotNothingString(messagesAr, "subsetChangeShowing", errorInMethod);
-      subsetNRowsRelatedDataAr =
-          getNotNothingString(messagesAr, "subsetNRowsRelatedData", errorInMethod);
-      subsetViewRelatedChangeAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedChange", errorInMethod);
-      subsetTotalCountAr = getNotNothingString(messagesAr, "subsetTotalCount", errorInMethod);
-      subsetViewAr = getNotNothingString(messagesAr, "subsetView", errorInMethod);
-      subsetViewCheckAr = getNotNothingString(messagesAr, "subsetViewCheck", errorInMethod);
-      subsetViewCheck1Ar = getNotNothingString(messagesAr, "subsetViewCheck1", errorInMethod);
-      subsetViewDistinctMapAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctMap", errorInMethod);
-      subsetViewRelatedMapAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedMap", errorInMethod);
-      subsetViewDistinctDataCountsAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctDataCounts", errorInMethod);
-      subsetViewDistinctDataAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctData", errorInMethod);
-      subsetViewRelatedDataCountsAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedDataCounts", errorInMethod);
-      subsetViewRelatedDataAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedData", errorInMethod);
-      subsetViewDistinctMapTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctMapTooltip", errorInMethod);
-      subsetViewRelatedMapTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedMapTooltip", errorInMethod);
-      subsetViewDistinctDataCountsTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctDataCountsTooltip", errorInMethod);
-      subsetViewDistinctDataTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewDistinctDataTooltip", errorInMethod);
-      subsetViewRelatedDataCountsTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedDataCountsTooltip", errorInMethod);
-      subsetViewRelatedDataTooltipAr =
-          getNotNothingString(messagesAr, "subsetViewRelatedDataTooltip", errorInMethod);
-      subsetWarnAr = getNotNothingString(messagesAr, "subsetWarn", errorInMethod);
-      subsetWarn10000Ar = getNotNothingString(messagesAr, "subsetWarn10000", errorInMethod);
-      subsetTooltipAr = getNotNothingString(messagesAr, "subsetTooltip", errorInMethod);
-      subsetNotSetUpAr = getNotNothingString(messagesAr, "subsetNotSetUp", errorInMethod);
-      subsetLongNotShownAr = getNotNothingString(messagesAr, "subsetLongNotShown", errorInMethod);
-
-      tabledapVideoIntroAr = getNotNothingString(messagesAr, "tabledapVideoIntro", errorInMethod);
-      theDatasetIDAr = getNotNothingString(messagesAr, "theDatasetID", errorInMethod);
-      theKeyAr = getNotNothingString(messagesAr, "theKey", errorInMethod);
-      theSubscriptionIDAr = getNotNothingString(messagesAr, "theSubscriptionID", errorInMethod);
-      theUrlActionAr = getNotNothingString(messagesAr, "theUrlAction", errorInMethod);
-      theLongDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "theLongDescriptionHtml", errorInMethod);
-      timeAr = getNotNothingString(messagesAr, "time", errorInMethod);
-      ThenAr = getNotNothingString(messagesAr, "Then", errorInMethod);
-      thisParticularErddapAr =
-          getNotNothingString(messagesAr, "thisParticularErddap", errorInMethod);
-      timeoutOtherRequestsAr =
-          getNotNothingString(messagesAr, "timeoutOtherRequests", errorInMethod);
-      HtmlWidgets.twoClickMapDefaultTooltipAr =
-          getNotNothingString(messagesAr, "twoClickMapDefaultTooltip", errorInMethod);
-
-      unitsAr = getNotNothingString(messagesAr, "units", errorInMethod);
-      unknownDatasetIDAr = getNotNothingString(messagesAr, "unknownDatasetID", errorInMethod);
-      unknownProtocolAr = getNotNothingString(messagesAr, "unknownProtocol", errorInMethod);
-      unsupportedFileTypeAr = getNotNothingString(messagesAr, "unsupportedFileType", errorInMethod);
-      String tStandardizeUdunits[] =
-          String2.split(
-              messagesAr[0].getNotNothingString("standardizeUdunits", errorInMethod) + "\n",
-              '\n'); // +\n\n since xml content is trimmed.
-      String tUcumToUdunits[] =
-          String2.split(
-              messagesAr[0].getNotNothingString("ucumToUdunits", errorInMethod) + "\n",
-              '\n'); // +\n\n since xml content is trimmed.
-      String tUdunitsToUcum[] =
-          String2.split(
-              messagesAr[0].getNotNothingString("udunitsToUcum", errorInMethod) + "\n",
-              '\n'); // +\n\n since xml content is trimmed.
-      String tUpdateUrls[] =
-          String2.split(
-              messagesAr[0].getNotNothingString("updateUrls", errorInMethod) + "\n",
-              '\n'); // +\n\n since xml content is trimmed.
-
-      updateUrlsSkipAttributes =
-          StringArray.arrayFromCSV(
-              messagesAr[0].getNotNothingString("updateUrlsSkipAttributes", errorInMethod));
-
-      usingGriddapAr = getNotNothingString(messagesAr, "usingGriddap", errorInMethod);
-      usingTabledapAr = getNotNothingString(messagesAr, "usingTabledap", errorInMethod);
-      variableNamesAr = getNotNothingString(messagesAr, "variableNames", errorInMethod);
-      viewAllDatasetsHtmlAr = getNotNothingString(messagesAr, "viewAllDatasetsHtml", errorInMethod);
-      waitThenTryAgainAr = getNotNothingString(messagesAr, "waitThenTryAgain", errorInMethod);
-      gov.noaa.pfel.erddap.dataset.WaitThenTryAgainException.waitThenTryAgain =
-          waitThenTryAgainAr[0];
-      warningAr = getNotNothingString(messagesAr, "warning", errorInMethod);
-      WCSAr = getNotNothingString(messagesAr, "WCS", errorInMethod);
-      wcsDescriptionHtmlAr = getNotNothingString(messagesAr, "wcsDescriptionHtml", errorInMethod);
-      wcsLongDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "wcsLongDescriptionHtml", errorInMethod);
-      wcsOverview1Ar = getNotNothingString(messagesAr, "wcsOverview1", errorInMethod);
-      wcsOverview2Ar = getNotNothingString(messagesAr, "wcsOverview2", errorInMethod);
-      wmsDescriptionHtmlAr = getNotNothingString(messagesAr, "wmsDescriptionHtml", errorInMethod);
-      wmsInstructionsAr = getNotNothingString(messagesAr, "wmsInstructions", errorInMethod);
-      wmsLongDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "wmsLongDescriptionHtml", errorInMethod);
-      wmsManyDatasetsAr = getNotNothingString(messagesAr, "wmsManyDatasets", errorInMethod);
-      WMSDocumentation1Ar = getNotNothingString(messagesAr, "WMSDocumentation1", errorInMethod);
-      WMSGetCapabilitiesAr = getNotNothingString(messagesAr, "WMSGetCapabilities", errorInMethod);
-      WMSGetMapAr = getNotNothingString(messagesAr, "WMSGetMap", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) {
-        WMSGetCapabilitiesAr[tl] =
-            WMSGetCapabilitiesAr[tl] // some things should stay in English
-                .replaceAll("&serviceWMS;", "service=WMS")
-                .replaceAll("&version;", "version")
-                .replaceAll("&requestGetCapabilities;", "request=GetCapabilities");
-        WMSGetMapAr[tl] =
-            WMSGetMapAr[tl] // lots of things should stay in English
-                .replaceAll("&WMSSERVER;", EDD.WMS_SERVER)
-                .replaceAll("&WMSSEPARATOR;", Character.toString(EDD.WMS_SEPARATOR))
-                .replaceAll("&serviceWMS;", "service=WMS")
-                .replaceAll("&version;", "version")
-                .replaceAll("&requestGetMap;", "request=GetMap")
-                .replaceAll("&TRUE;", "TRUE")
-                .replaceAll("&FALSE;", "FALSE")
-                .replaceAll("&layers;", "layers")
-                .replaceAll("&styles;", "styles")
-                .replaceAll("&width;", "width")
-                .replaceAll("&height;", "height")
-                .replaceAll("&format;", "format")
-                .replaceAll("&transparentTRUEFALSE;", "transparent=<i>TRUE|FALSE</i>")
-                .replaceAll("&bgcolor;", "bgcolor")
-                .replaceAll("&exceptions;", "exceptions")
-                .replaceAll("&time;", "time")
-                .replaceAll("&elevation;", "elevation");
-      }
-
-      WMSNotesAr = getNotNothingString(messagesAr, "WMSNotes", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++)
-        WMSNotesAr[tl] =
-            WMSNotesAr[tl].replace("&WMSSEPARATOR;", Character.toString(EDD.WMS_SEPARATOR));
-
-      yourEmailAddressAr = getNotNothingString(messagesAr, "yourEmailAddress", errorInMethod);
-      zoomInAr = getNotNothingString(messagesAr, "zoomIn", errorInMethod);
-      zoomOutAr = getNotNothingString(messagesAr, "zoomOut", errorInMethod);
-
-      for (int tl = 0; tl < nLanguages; tl++) {
-        blacklistMsgAr[tl] = MessageFormat.format(blacklistMsgAr[tl], adminEmail);
-      }
-
-      standardShortDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "standardShortDescriptionHtml", errorInMethod);
-      for (int tl = 0; tl < nLanguages; tl++) {
-        standardShortDescriptionHtmlAr[tl] =
-            String2.replaceAll(
-                standardShortDescriptionHtmlAr[tl],
-                "&convertTimeReference;",
-                convertersActive ? convertTimeReferenceAr[tl] : "");
-        standardShortDescriptionHtmlAr[tl] =
-            String2.replaceAll(
-                standardShortDescriptionHtmlAr[tl],
-                "&wmsManyDatasets;",
-                wmsActive ? wmsManyDatasetsAr[tl] : "");
-      }
-
-      // just one
-      DEFAULT_commonStandardNames =
-          String2.canonical(
-              StringArray.arrayFromCSV(
-                  messagesAr[0].getNotNothingString("DEFAULT_commonStandardNames", errorInMethod)));
-      commonStandardNames = DEFAULT_commonStandardNames;
-      DEFAULT_standardLicense = messagesAr[0].getNotNothingString("standardLicense", errorInMethod);
-      standardLicense = getSetupEVString(setup, ev, "standardLicense", DEFAULT_standardLicense);
-
-      // [language]
-      DEFAULT_standardContactAr = getNotNothingString(messagesAr, "standardContact", errorInMethod);
-      standardContactAr = getSetupEVString(setup, ev, "standardContact", DEFAULT_standardContactAr);
-      DEFAULT_standardDataLicensesAr =
-          getNotNothingString(messagesAr, "standardDataLicenses", errorInMethod);
-      standardDataLicensesAr =
-          getSetupEVString(setup, ev, "standardDataLicenses", DEFAULT_standardDataLicensesAr);
-      DEFAULT_standardDisclaimerOfExternalLinksAr =
-          getNotNothingString(messagesAr, "standardDisclaimerOfExternalLinks", errorInMethod);
-      standardDisclaimerOfExternalLinksAr =
-          getSetupEVString(
-              setup,
-              ev,
-              "standardDisclaimerOfExternalLinks",
-              DEFAULT_standardDisclaimerOfExternalLinksAr);
-      DEFAULT_standardDisclaimerOfEndorsementAr =
-          getNotNothingString(messagesAr, "standardDisclaimerOfEndorsement", errorInMethod);
-      standardDisclaimerOfEndorsementAr =
-          getSetupEVString(
-              setup,
-              ev,
-              "standardDisclaimerOfEndorsement",
-              DEFAULT_standardDisclaimerOfEndorsementAr);
-      DEFAULT_standardGeneralDisclaimerAr =
-          getNotNothingString(messagesAr, "standardGeneralDisclaimer", errorInMethod);
-      standardGeneralDisclaimerAr =
-          getSetupEVString(
-              setup, ev, "standardGeneralDisclaimer", DEFAULT_standardGeneralDisclaimerAr);
-      DEFAULT_standardPrivacyPolicyAr =
-          getNotNothingString(messagesAr, "standardPrivacyPolicy", errorInMethod);
-      standardPrivacyPolicyAr =
-          getSetupEVString(setup, ev, "standardPrivacyPolicy", DEFAULT_standardPrivacyPolicyAr);
-
-      DEFAULT_startHeadHtml = messagesAr[0].getNotNothingString("startHeadHtml5", errorInMethod);
-      startHeadHtml = getSetupEVString(setup, ev, "startHeadHtml5", DEFAULT_startHeadHtml);
-      DEFAULT_startBodyHtmlAr = getNotNothingString(messagesAr, "startBodyHtml5", errorInMethod);
-      startBodyHtmlAr = getSetupEVString(setup, ev, "startBodyHtml5", DEFAULT_startBodyHtmlAr);
-      DEFAULT_theShortDescriptionHtmlAr =
-          getNotNothingString(messagesAr, "theShortDescriptionHtml", errorInMethod);
-      theShortDescriptionHtmlAr =
-          getSetupEVString(setup, ev, "theShortDescriptionHtml", DEFAULT_theShortDescriptionHtmlAr);
-      DEFAULT_endBodyHtmlAr = getNotNothingString(messagesAr, "endBodyHtml5", errorInMethod);
-      endBodyHtmlAr = getSetupEVString(setup, ev, "endBodyHtml5", DEFAULT_endBodyHtmlAr);
-
-      // ensure HTML5
-      Test.ensureTrue(
-          startHeadHtml.startsWith("<!DOCTYPE html>"),
-          "<startHeadHtml5> must start with \"<!DOCTYPE html>\".");
-      for (int tl = 0; tl < nLanguages; tl++) {
-        DEFAULT_standardDataLicensesAr[tl] =
-            String2.replaceAll(
-                DEFAULT_standardDataLicensesAr[tl],
-                "&license;",
-                "<kbd>license</kbd>"); // so not translated
-        standardDataLicensesAr[tl] =
-            String2.replaceAll(standardDataLicensesAr[tl], "&license;", "<kbd>license</kbd>");
-        standardContactAr[tl] =
-            String2.replaceAll(
-                standardContactAr[tl], "&adminEmail;", SSR.getSafeEmailAddress(adminEmail));
-        startBodyHtmlAr[tl] =
-            String2.replaceAll(startBodyHtmlAr[tl], "&erddapVersion;", erddapVersion);
-        endBodyHtmlAr[tl] = String2.replaceAll(endBodyHtmlAr[tl], "&erddapVersion;", erddapVersion);
-      }
-
-      Test.ensureEqual(imageWidths.length, 3, "imageWidths.length must be 3.");
-      Test.ensureEqual(imageHeights.length, 3, "imageHeights.length must be 3.");
-      Test.ensureEqual(pdfWidths.length, 3, "pdfWidths.length must be 3.");
-      Test.ensureEqual(pdfHeights.length, 3, "pdfHeights.length must be 3.");
-
-      int nStandardizeUdunits = tStandardizeUdunits.length / 3;
-      for (int i = 0; i < nStandardizeUdunits; i++) {
-        int i3 = i * 3;
-        Test.ensureTrue(
-            String2.isSomething(tStandardizeUdunits[i3]),
-            "standardizeUdunits line #" + (i3 + 0) + " is empty.");
-        Test.ensureTrue(
-            String2.isSomething(tStandardizeUdunits[i3 + 1]),
-            "standardizeUdunits line #" + (i3 + 1) + " is empty.");
-        Test.ensureEqual(
-            tStandardizeUdunits[i3 + 2].trim(),
-            "",
-            "standardizeUdunits line #" + (i3 + 2) + " isn't empty.");
-        Units2.standardizeUdunitsHM.put(
-            String2.canonical(tStandardizeUdunits[i3].trim()),
-            String2.canonical(tStandardizeUdunits[i3 + 1].trim()));
-      }
-
-      int nUcumToUdunits = tUcumToUdunits.length / 3;
-      for (int i = 0; i < nUcumToUdunits; i++) {
-        int i3 = i * 3;
-        Test.ensureTrue(
-            String2.isSomething(tUcumToUdunits[i3]),
-            "ucumToUdunits line #" + (i3 + 0) + " is empty.");
-        Test.ensureTrue(
-            String2.isSomething(tUcumToUdunits[i3 + 1]),
-            "ucumToUdunits line #" + (i3 + 1) + " is empty.");
-        Test.ensureEqual(
-            tUcumToUdunits[i3 + 2].trim(), "", "ucumToUdunits line #" + (i3 + 2) + " isn't empty.");
-        Units2.ucumToUdunitsHM.put(
-            String2.canonical(tUcumToUdunits[i3].trim()),
-            String2.canonical(tUcumToUdunits[i3 + 1].trim()));
-      }
-
-      int nUdunitsToUcum = tUdunitsToUcum.length / 3;
-      for (int i = 0; i < nUdunitsToUcum; i++) {
-        int i3 = i * 3;
-        Test.ensureTrue(
-            String2.isSomething(tUdunitsToUcum[i3]),
-            "udunitsToUcum line #" + (i3 + 0) + " is empty.");
-        Test.ensureTrue(
-            String2.isSomething(tUdunitsToUcum[i3 + 1]),
-            "udunitsToUcum line #" + (i3 + 1) + " is empty.");
-        Test.ensureEqual(
-            tUdunitsToUcum[i3 + 2].trim(), "", "udunitsToUcum line #" + (i3 + 2) + " isn't empty.");
-        Units2.udunitsToUcumHM.put(
-            String2.canonical(tUdunitsToUcum[i3].trim()),
-            String2.canonical(tUdunitsToUcum[i3 + 1].trim()));
-      }
-
-      int nUpdateUrls = tUpdateUrls.length / 3;
-      updateUrlsFrom = new String[nUpdateUrls];
-      updateUrlsTo = new String[nUpdateUrls];
-      for (int i = 0; i < nUpdateUrls; i++) {
-        int i3 = i * 3;
-        updateUrlsFrom[i] = String2.canonical(tUpdateUrls[i3].trim());
-        updateUrlsTo[i] = String2.canonical(tUpdateUrls[i3 + 1].trim());
-        Test.ensureTrue(
-            String2.isSomething(tUpdateUrls[i3]), "updateUrls line #" + (i3 + 0) + " is empty.");
-        Test.ensureTrue(
-            String2.isSomething(tUpdateUrls[i3 + 1]),
-            "updateUrls line #" + (i3 + 1) + " is empty.");
-        Test.ensureEqual(
-            tUpdateUrls[i3 + 2].trim(), "", "updateUrls line #" + (i3 + 0) + " isn't empty.");
-      }
-
-      for (String palette : palettes) {
-        String tName = fullPaletteDirectory + palette + ".cpt";
-        Test.ensureTrue(
-            File2.isFile(tName),
-            "\"" + palette + "\" is listed in <palettes>, but there is no file " + tName);
-      }
+      messages = new EDMessages(contentDirectory, setup, ev);
 
       // try to create an nc4 file
       accessibleViaNC4 = ".nc4 is not yet supported.";
@@ -4285,50 +1437,6 @@ public class EDStatic {
       //        File2.delete(testNc4Name);
       */
 
-      String tEmail = SSR.getSafeEmailAddress(adminEmail);
-      for (int tl = 0; tl < nLanguages; tl++) {
-        searchHintsTooltipAr[tl] =
-            "<div class=\"standard_max_width\">"
-                + searchHintsTooltipAr[tl]
-                + "\n"
-                + (useLuceneSearchEngine
-                    ? searchHintsLuceneTooltipAr[tl]
-                    : searchHintsOriginalTooltipAr[tl])
-                + "</div>";
-        advancedSearchDirectionsAr[tl] =
-            String2.replaceAll(
-                advancedSearchDirectionsAr[tl], "&searchButton;", searchButtonAr[tl]);
-
-        loginProblemsAr[tl] =
-            String2.replaceAll(loginProblemsAr[tl], "&cookiesHelp;", cookiesHelpAr[tl]);
-        loginProblemsAr[tl] =
-            String2.replaceAll(loginProblemsAr[tl], "&adminContact;", adminContact()) + "\n\n";
-        loginProblemsAfterAr[tl] =
-            String2.replaceAll(loginProblemsAfterAr[tl], "&adminContact;", adminContact()) + "\n\n";
-        loginPublicAccessAr[tl] += "\n";
-        logoutSuccessAr[tl] += "\n";
-
-        filesDocumentationAr[tl] =
-            String2.replaceAll(filesDocumentationAr[tl], "&adminEmail;", tEmail);
-
-        doWithGraphsAr[tl] =
-            String2.replaceAll(doWithGraphsAr[tl], "&ssUse;", slideSorterActive ? ssUseAr[tl] : "");
-
-        theLongDescriptionHtmlAr[tl] =
-            String2.replaceAll(
-                theLongDescriptionHtmlAr[tl], "&ssUse;", slideSorterActive ? ssUseAr[tl] : "");
-        theLongDescriptionHtmlAr[tl] =
-            String2.replaceAll(
-                theLongDescriptionHtmlAr[tl],
-                "&requestFormatExamplesHtml;",
-                requestFormatExamplesHtmlAr[tl]);
-        theLongDescriptionHtmlAr[tl] =
-            String2.replaceAll(
-                theLongDescriptionHtmlAr[tl],
-                "&resultsFormatExamplesHtml;",
-                resultsFormatExamplesHtmlAr[tl]);
-      }
-
       try {
         computerName = System.getenv("COMPUTERNAME"); // windows
         if (computerName == null) computerName = System.getenv("HOSTNAME"); // linux
@@ -4364,17 +1472,6 @@ public class EDStatic {
     }
   }
 
-  /** This does getNotNothingString for each messages[]. */
-  private static String[] getNotNothingString(
-      ResourceBundle2 messages[], String name, String errorInMethod) {
-
-    int nMessages = messages.length;
-    String ar[] = new String[nMessages];
-    for (int i = 0; i < nMessages; i++)
-      ar[i] = messages[i].getNotNothingString(name, errorInMethod + "When language=" + i + ", ");
-    return ar;
-  }
-
   /**
    * This gets a string from setup.xml or environmentalVariables (preferred).
    *
@@ -4392,28 +1489,6 @@ public class EDStatic {
       return value;
     }
     return setup.getString(paramName, tDefault);
-  }
-
-  /**
-   * A variant of getSetupEVString that works with an array of tDefault.
-   *
-   * @param setup from setup.xml
-   * @param ev from System.getenv()
-   * @param paramName If present in ev, it will be ERDDAP_paramName.
-   * @param tDefault the default value
-   * @return the desired value (or the default if it isn't defined anywhere)
-   */
-  private static String[] getSetupEVString(
-      ResourceBundle2 setup, Map<String, String> ev, String paramName, String tDefault[]) {
-    String value = ev.get("ERDDAP_" + paramName);
-    int n = tDefault.length;
-    if (String2.isSomething(value)) {
-      String2.log("got " + paramName + " from ERDDAP_" + paramName);
-      for (int i = 0; i < n; i++) tDefault[i] = value;
-      return tDefault;
-    }
-    for (int i = 0; i < n; i++) tDefault[i] = setup.getString(paramName, tDefault[i]);
-    return tDefault;
   }
 
   /**
@@ -4628,57 +1703,6 @@ public class EDStatic {
   }
 
   /**
-   * This returns the html needed to display the external.png image with the warning that the link
-   * is to an external website.
-   *
-   * @param language the index of the selected language
-   * @param tErddapUrl
-   * @return the html needed to display the external.png image and messages.
-   */
-  public static String externalLinkHtml(int language, String tErddapUrl) {
-    return "<img\n"
-        + "    src=\""
-        + tErddapUrl
-        + "/images/external.png\" "
-        + "alt=\""
-        + externalLinkAr[language]
-        + "\"\n"
-        + "    title=\""
-        + externalWebSiteAr[language]
-        + "\">";
-  }
-
-  /**
-   * This returns the html documentation for acceptEncoding.
-   *
-   * @param language the index of the selected language
-   * @param headingType e.g., h2 or h3
-   * @param tErddapUrl
-   * @return the html needed to document acceptEncodig.
-   */
-  public static String acceptEncodingHtml(int language, String headingType, String tErddapUrl) {
-    String s =
-        String2.replaceAll(
-            acceptEncodingHtmlAr[language], "&headingType;", "<" + headingType + ">");
-    s = String2.replaceAll(s, "&sheadingType;", "</" + headingType + ">");
-    return String2.replaceAll(s, "&externalLinkHtml;", externalLinkHtml(language, tErddapUrl));
-  }
-
-  /**
-   * This returns the html documentation for the /files/ system.
-   *
-   * @param language the index of the selected language
-   * @param tErddapUrl
-   * @return the html needed to document acceptEncodig.
-   */
-  public static String filesDocumentation(int language, String tErddapUrl) {
-    return String2.replaceAll(
-        filesDocumentationAr[language],
-        "&acceptEncodingHtml;",
-        acceptEncodingHtml(language, "h3", tErddapUrl));
-  }
-
-  /**
    * This is used by html web page generating methods to return the You Are Here html for ERDDAP.
    *
    * @return the You Are Here html for this EDD subclass.
@@ -4864,7 +1888,7 @@ public class EDStatic {
    */
   public static String htmlTooltipImage(int language, String loggedInAs, String html) {
     return HtmlWidgets.htmlTooltipImage(
-        imageDirUrl(loggedInAs, language) + questionMarkImageFile, "?", html, "");
+        imageDirUrl(loggedInAs, language) + messages.questionMarkImageFile, "?", html, "");
   }
 
   /**
@@ -5163,7 +2187,7 @@ public class EDStatic {
           requestNumber,
           response,
           HttpServletResponse.SC_FORBIDDEN, // a.k.a. Error 403
-          blacklistMsgAr[language]);
+          messages.blacklistMsgAr[language]);
       return true;
     }
     return false;
@@ -5714,8 +2738,8 @@ public class EDStatic {
         message =
             MessageFormat.format(
                 graphsAccessibleToPublic
-                    ? notAuthorizedForDataAr[language]
-                    : notAuthorizedAr[language],
+                    ? messages.notAuthorizedForDataAr[language]
+                    : messages.notAuthorizedAr[language],
                 loggedInAsHttps.equals(loggedInAs) ? "" : loggedInAs,
                 datasetID);
 
@@ -5755,7 +2779,7 @@ public class EDStatic {
       return loggedInAs == null || loggedInAsHttps.equals(loggedInAs)
           ? // ie not logged in
           // always use the erddapHttpsUrl for login/logout pages
-          "<a href=\"" + tUrl + "/login.html\">" + loginAr[language] + "</a>"
+          "<a href=\"" + tUrl + "/login.html\">" + messages.loginAr[language] + "</a>"
           : "<a href=\""
               + tUrl
               + "/login.html\"><strong>"
@@ -5764,7 +2788,7 @@ public class EDStatic {
               + "<a href=\""
               + tUrl
               + "/logout.html\">"
-              + logoutAr[language]
+              + messages.logoutAr[language]
               + "</a>";
     }
   }
@@ -5819,13 +2843,14 @@ public class EDStatic {
 
     String tErddapUrl = erddapUrl(loggedInAs, language);
     String s =
-        startBodyHtmlAr[
+        messages
+            .startBodyHtmlAr[
             0]; // It's hard for admins to customized this for all languages. So for now, just use
     // language=0.
     s =
         String2.replaceAll(
-            s, "&EasierAccessToScientificData;", EasierAccessToScientificDataAr[language]);
-    s = String2.replaceAll(s, "&BroughtToYouBy;", BroughtToYouByAr[language]);
+            s, "&EasierAccessToScientificData;", messages.EasierAccessToScientificDataAr[language]);
+    s = String2.replaceAll(s, "&BroughtToYouBy;", messages.BroughtToYouByAr[language]);
     if (String2.isSomething(otherBody))
       s = String2.replaceAll(s, "<body>", "<body " + otherBody + ">");
     s = String2.replaceAll(s, "&loginInfo;", getLoginHtml(language, loggedInAs));
@@ -5879,7 +2904,7 @@ public class EDStatic {
    * @param loggedInAs
    */
   public static String endBodyHtml(int language, String tErddapUrl, String loggedInAs) {
-    String s = String2.replaceAll(endBodyHtmlAr[language], "&erddapUrl;", tErddapUrl);
+    String s = String2.replaceAll(messages.endBodyHtmlAr[language], "&erddapUrl;", tErddapUrl);
     if (language > 0)
       s =
           s.replace(
@@ -5900,18 +2925,20 @@ public class EDStatic {
    *     if user is logged in)
    */
   public static String legal(int language, String tErddapUrl) {
-    StringBuilder tsb = new StringBuilder(legal);
-    String2.replaceAll(tsb, "[standardContact]", standardContactAr[language] + "\n\n");
-    String2.replaceAll(tsb, "[standardDataLicenses]", standardDataLicensesAr[language] + "\n\n");
+    StringBuilder tsb = new StringBuilder(messages.legal);
+    String2.replaceAll(tsb, "[standardContact]", messages.standardContactAr[language] + "\n\n");
+    String2.replaceAll(
+        tsb, "[standardDataLicenses]", messages.standardDataLicensesAr[language] + "\n\n");
     String2.replaceAll(
         tsb,
         "[standardDisclaimerOfExternalLinks]",
-        standardDisclaimerOfExternalLinksAr[language] + "\n\n");
+        messages.standardDisclaimerOfExternalLinksAr[language] + "\n\n");
     String2.replaceAll(
         tsb,
         "[standardDisclaimerOfEndorsement]",
-        standardDisclaimerOfEndorsementAr[language] + "\n\n");
-    String2.replaceAll(tsb, "[standardPrivacyPolicy]", standardPrivacyPolicyAr[language] + "\n\n");
+        messages.standardDisclaimerOfEndorsementAr[language] + "\n\n");
+    String2.replaceAll(
+        tsb, "[standardPrivacyPolicy]", messages.standardPrivacyPolicyAr[language] + "\n\n");
     String2.replaceAll(tsb, "&erddapUrl;", tErddapUrl);
     return tsb.toString();
   }
@@ -5923,7 +2950,7 @@ public class EDStatic {
    * @param addToTitle has not yet been encodeAsHTML(addToTitle).
    */
   public static String startHeadHtml(int language, String tErddapUrl, String addToTitle) {
-    String ts = startHeadHtml;
+    String ts = messages.startHeadHtml;
 
     if (addToTitle.length() > 0)
       ts = String2.replaceAll(ts, "</title>", " - " + XML.encodeAsHTML(addToTitle) + "</title>");
@@ -5931,7 +2958,7 @@ public class EDStatic {
         String2.replaceAll(
             ts,
             "&langCode;",
-            langCodeAr[language]
+            messages.langCodeAr[language]
                 + (language == 0
                     ? ""
                     : "-x-mtfrom-en")); // see https://cloud.google.com/translate/markup
@@ -5946,28 +2973,9 @@ public class EDStatic {
     return String2.replaceAll(ts, "&erddapUrl;", tErddapUrl);
   }
 
-  public static String theLongDescriptionHtml(int language, String tErddapUrl) {
-    return String2.replaceAll(theLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl);
-  }
-
-  public static String theShortDescriptionHtml(int language, String tErddapUrl) {
-    String s =
-        theShortDescriptionHtmlAr[
-            0]; // from datasets.xml or messages.xml.  Always use English, but parts (most) will be
-    // translated.
-    s = String2.replaceAll(s, "&erddapIs;", erddapIsAr[language]);
-    s = String2.replaceAll(s, "&thisParticularErddap;", thisParticularErddapAr[language]);
-    s =
-        String2.replaceAll(
-            s, "[standardShortDescriptionHtml]", standardShortDescriptionHtmlAr[language]);
-    s = String2.replaceAll(s, "&requestFormatExamplesHtml;", requestFormatExamplesHtmlAr[language]);
-    s = String2.replaceAll(s, "&erddapUrl;", tErddapUrl); // do last
-    return s;
-  }
-
   public static String erddapHref(int language, String tErddapUrl) {
     return "<a title=\""
-        + clickERDDAPAr[language]
+        + messages.clickERDDAPAr[language]
         + "\" \n"
         + "rel=\"start\" "
         + "href=\""
@@ -6013,7 +3021,7 @@ public class EDStatic {
     String message = MustBe.throwableToShortString(t);
     return "<p>&nbsp;<hr>\n"
         + "<p><span class=\"warningColor\"><strong>"
-        + errorOnWebPageAr[language]
+        + messages.errorOnWebPageAr[language]
         + "</strong></span>\n"
         + "<pre>"
         + XML.encodeAsPreHTML(message, 100)
@@ -6837,7 +3845,10 @@ public class EDStatic {
       String functionName = jsonp.substring(7); // it will be because it starts with .jsonp=
       if (!String2.isJsonpNameSafe(functionName))
         throw new SimpleException(
-            bilingual(language, errorJsonpFunctionNameAr[0], errorJsonpFunctionNameAr[language]));
+            bilingual(
+                language,
+                messages.errorJsonpFunctionNameAr[0],
+                messages.errorJsonpFunctionNameAr[language]));
       return ".jsonp=" + SSR.minimalPercentEncode(functionName) + "&";
     } catch (Throwable t) {
       String2.log(MustBe.throwableToString(t));
@@ -6921,8 +3932,8 @@ public class EDStatic {
     if (searchFor == null) searchFor = "";
     return new String[] {
       MustBe.THERE_IS_NO_DATA,
-      (searchFor.length() > 0 ? searchSpellingAr[language] + " " : "")
-          + (searchFor.indexOf(' ') >= 0 ? searchFewerWordsAr[language] : "")
+      (searchFor.length() > 0 ? messages.searchSpellingAr[language] + " " : "")
+          + (searchFor.indexOf(' ') >= 0 ? messages.searchFewerWordsAr[language] : "")
     };
   }
 
@@ -6936,8 +3947,8 @@ public class EDStatic {
    */
   public static String[] noPage(int language, int page, int lastPage) {
     return new String[] {
-      MessageFormat.format(noPage1Ar[language], "" + page, "" + lastPage),
-      MessageFormat.format(noPage2Ar[language], "" + page, "" + lastPage)
+      MessageFormat.format(messages.noPage1Ar[language], "" + page, "" + lastPage),
+      MessageFormat.format(messages.noPage2Ar[language], "" + page, "" + lastPage)
     };
   }
 
@@ -6956,14 +3967,14 @@ public class EDStatic {
   public static String nMatchingDatasetsHtml(
       int language, int nMatches, int page, int lastPage, boolean relevant, String urlWithQuery) {
 
-    if (nMatches == 1) return nMatching1Ar[language];
+    if (nMatches == 1) return messages.nMatching1Ar[language];
 
     StringBuilder results =
         new StringBuilder(
             MessageFormat.format(
                     relevant
-                        ? nMatchingMostRelevantAr[language]
-                        : nMatchingAlphabeticalAr[language],
+                        ? messages.nMatchingMostRelevantAr[language]
+                        : messages.nMatchingAlphabeticalAr[language],
                     "" + nMatches)
                 + "\n");
 
@@ -7000,7 +4011,7 @@ public class EDStatic {
           "&nbsp;"
               + page
               + "&nbsp;("
-              + nMatchingCurrentAr[language]
+              + messages.nMatchingCurrentAr[language]
               + ")&nbsp;\n"); // always show current page
       if (page <= lastPage - 2)
         sb.append(
@@ -7020,7 +4031,7 @@ public class EDStatic {
       results.append(
           "&nbsp;&nbsp;"
               + MessageFormat.format(
-                  nMatchingPageAr[language], "" + page, "" + lastPage, sb.toString())
+                  messages.nMatchingPageAr[language], "" + page, "" + lastPage, sb.toString())
               + "\n");
     }
 
@@ -7046,8 +4057,9 @@ public class EDStatic {
         "gov.noaa.pfel.",
         "gov.noaa.pfeg.");
 
-    int n = updateUrlsFrom.length;
-    for (int i = 0; i < n; i++) String2.replaceAll(sb, updateUrlsFrom[i], updateUrlsTo[i]);
+    int n = messages.updateUrlsFrom.length;
+    for (int i = 0; i < n; i++)
+      String2.replaceAll(sb, messages.updateUrlsFrom[i], messages.updateUrlsTo[i]);
     return sb.toString();
   }
 
@@ -7072,7 +4084,7 @@ public class EDStatic {
 
     // updateUrls in all attributes
     for (String name : names) {
-      if (String2.indexOf(updateUrlsSkipAttributes, name) >= 0) continue;
+      if (String2.indexOf(messages.updateUrlsSkipAttributes, name) >= 0) continue;
       PrimitiveArray pa = addAtts.get(name);
       if (pa == null && sourceAtts != null) pa = sourceAtts.get(name);
       if (pa != null && pa.size() > 0 && pa.elementType() == PAType.STRING) {
@@ -7390,7 +4402,7 @@ public class EDStatic {
         requestNumber,
         response,
         503, // Service Unavailable
-        waitThenTryAgainAr[language]);
+        messages.waitThenTryAgainAr[language]);
     metrics.shedRequests.inc();
     return true;
   }
@@ -7500,14 +4512,14 @@ public class EDStatic {
 
       // log the error
       String tErrorLC = tError.toLowerCase();
-      if (tError.indexOf(resourceNotFoundAr[0]) >= 0
+      if (tError.indexOf(messages.resourceNotFoundAr[0]) >= 0
           || tError.indexOf(MustBe.THERE_IS_NO_DATA)
               >= 0) { // check this first, since may also be Query error
         errorNo = HttpServletResponse.SC_NOT_FOUND; // http error 404  (might succeed later)
         // I wanted to use 204 No Content or 205 (similar) but browsers don't show any change for
         // these codes
 
-      } else if (tError.indexOf(queryErrorAr[0]) >= 0) {
+      } else if (tError.indexOf(messages.queryErrorAr[0]) >= 0) {
         errorNo = HttpServletResponse.SC_BAD_REQUEST; // http error 400 (won't succeed later)
 
       } else if (tError.indexOf(REQUESTED_RANGE_NOT_SATISFIABLE) >= 0) {
@@ -7664,7 +4676,7 @@ public class EDStatic {
               + String2.toJson(msg, 65536, false)
               + ";\n"
               + "}\n";
-      if (msg.indexOf(blacklistMsgAr[0]) < 0)
+      if (msg.indexOf(messages.blacklistMsgAr[0]) < 0)
         String2.log(
             "*** lowSendError for request #"
                 + requestNumber

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -54,7 +54,6 @@ import gov.noaa.pfel.erddap.dataset.TableWriterHtmlTable;
 import gov.noaa.pfel.erddap.http.CorsResponseFilter;
 import gov.noaa.pfel.erddap.variable.EDV;
 import gov.noaa.pfel.erddap.variable.EDVGridAxis;
-import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -251,33 +250,34 @@ public class EDStatic {
   public static final String fullPublicDirectory;
   public static final String downloadDir; // local directory on this computer
   public static final String imageDir; // local directory on this computer
+  public static final Metrics metrics;
   public static final Tally tally = new Tally();
-  public static int emailThreadFailedDistribution24[] = new int[String2.TimeDistributionSize];
+  public static int[] emailThreadFailedDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] emailThreadSucceededDistribution24 = new int[String2.TimeDistributionSize];
   public static int[] emailThreadFailedDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int emailThreadSucceededDistribution24[] = new int[String2.TimeDistributionSize];
   public static int[] emailThreadSucceededDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int emailThreadNEmailsDistribution24[] =
+  public static int[] emailThreadNEmailsDistribution24 =
       new int[String2.CountDistributionSize]; // count, not time
   public static int[] emailThreadNEmailsDistributionTotal =
       new int[String2.CountDistributionSize]; // count, not time
-  public static int failureTimesDistributionLoadDatasets[] = new int[String2.TimeDistributionSize];
-  public static int failureTimesDistribution24[] = new int[String2.TimeDistributionSize];
-  public static int[] failureTimesDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int majorLoadDatasetsDistribution24[] = new int[String2.TimeDistributionSize];
+  public static int[] majorLoadDatasetsDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] minorLoadDatasetsDistribution24 = new int[String2.TimeDistributionSize];
   public static int[] majorLoadDatasetsDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int minorLoadDatasetsDistribution24[] = new int[String2.TimeDistributionSize];
   public static int[] minorLoadDatasetsDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int responseTimesDistributionLoadDatasets[] = new int[String2.TimeDistributionSize];
-  public static int responseTimesDistribution24[] = new int[String2.TimeDistributionSize];
-  public static int[] responseTimesDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int taskThreadFailedDistribution24[] = new int[String2.TimeDistributionSize];
+  public static int[] taskThreadFailedDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] taskThreadSucceededDistribution24 = new int[String2.TimeDistributionSize];
   public static int[] taskThreadFailedDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int taskThreadSucceededDistribution24[] = new int[String2.TimeDistributionSize];
   public static int[] taskThreadSucceededDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int touchThreadFailedDistribution24[] = new int[String2.TimeDistributionSize];
+  public static int[] touchThreadFailedDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] touchThreadSucceededDistribution24 = new int[String2.TimeDistributionSize];
   public static int[] touchThreadFailedDistributionTotal = new int[String2.TimeDistributionSize];
-  public static int touchThreadSucceededDistribution24[] = new int[String2.TimeDistributionSize];
   public static int[] touchThreadSucceededDistributionTotal = new int[String2.TimeDistributionSize];
+  public static int[] responseTimesDistributionLoadDatasets = new int[String2.TimeDistributionSize];
+  public static int[] failureTimesDistributionLoadDatasets = new int[String2.TimeDistributionSize];
+  public static int[] responseTimesDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] failureTimesDistribution24 = new int[String2.TimeDistributionSize];
+  public static int[] responseTimesDistributionTotal = new int[String2.TimeDistributionSize];
+  public static int[] failureTimesDistributionTotal = new int[String2.TimeDistributionSize];
   public static final AtomicInteger requestsShed =
       new AtomicInteger(0); // since last Major LoadDatasets
   public static final AtomicInteger dangerousMemoryEmails =
@@ -297,8 +297,6 @@ public class EDStatic {
       null; // is read-only. Replacement is swapped into place.
   public static final long startupMillis = System.currentTimeMillis();
   public static final String startupLocalDateTime = Calendar2.getCurrentISODateTimeStringLocalTZ();
-  public static int nGridDatasets = 0; // as of end of last major loadDatasets
-  public static int nTableDatasets = 0; // as of end of last major loadDatasets
   public static long lastMajorLoadDatasetsStartTimeMillis = System.currentTimeMillis();
   public static long lastMajorLoadDatasetsStopTimeMillis = System.currentTimeMillis() - 1;
   // Currently Loading Dataset
@@ -1920,9 +1918,8 @@ public class EDStatic {
       setLogLevel(getSetupEVString(setup, ev, "logLevel", DEFAULT_logLevel));
 
       usePrometheusMetrics = getSetupEVBoolean(setup, ev, "usePrometheusMetrics", true);
-      if (usePrometheusMetrics) {
-        JvmMetrics.builder().register(); // initialize the out-of-the-box JVM metrics
-      }
+      metrics = new Metrics();
+      metrics.initialize(usePrometheusMetrics);
 
       bigParentDirectory = getSetupEVNotNothingString(setup, ev, "bigParentDirectory", "");
       bigParentDirectory = File2.addSlash(bigParentDirectory);
@@ -7351,6 +7348,7 @@ public class EDStatic {
       lastActiveRequestReportTime =
           System.currentTimeMillis(); // do first so other threads don't also report this
       dangerousMemoryEmails.incrementAndGet();
+      metrics.dangerousMemoryEmails.inc();
       activeRequests.remove(requestNumber + ""); // don't blame this request
       String activeRequestLines[] = activeRequests.values().toArray(new String[0]);
       Arrays.sort(activeRequestLines);
@@ -7393,6 +7391,7 @@ public class EDStatic {
         response,
         503, // Service Unavailable
         waitThenTryAgainAr[language]);
+    metrics.shedRequests.inc();
     return true;
   }
 
@@ -7520,6 +7519,7 @@ public class EDStatic {
                 .SC_REQUEST_ENTITY_TOO_LARGE; // http error 413 (the old name for Payload Too
         // Large), although it could be other user's requests
         // that are too large
+        metrics.dangerousMemoryFailures.inc();
         String ipAddress = getIPAddress(request);
         tally.add(
             "OutOfMemory (Array Size), IP Address (since last Major LoadDatasets)", ipAddress);
@@ -7536,6 +7536,7 @@ public class EDStatic {
         // Large), although it could be other user's requests
         // that are too large
         dangerousMemoryFailures.incrementAndGet();
+        metrics.dangerousMemoryFailures.inc();
         String ipAddress = getIPAddress(request);
         tally.add("OutOfMemory (Too Big), IP Address (since last Major LoadDatasets)", ipAddress);
         tally.add("OutOfMemory (Too Big), IP Address (since last daily report)", ipAddress);
@@ -7546,6 +7547,7 @@ public class EDStatic {
         errorNo =
             HttpServletResponse
                 .SC_REQUEST_ENTITY_TOO_LARGE; // http error 413 (the old name for Payload Too Large)
+        metrics.dangerousMemoryFailures.inc();
         String ipAddress = getIPAddress(request);
         tally.add(
             "OutOfMemory (Way Too Big), IP Address (since last Major LoadDatasets)", ipAddress);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EmailThread.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EmailThread.java
@@ -97,11 +97,11 @@ public class EmailThread extends Thread {
                 + Calendar2.getCurrentISODateTimeStringLocalTZ());
         Object oar[] =
             SSR.openEmailSession(
-                EDStatic.emailSmtpHost,
-                EDStatic.emailSmtpPort, // throws Exception
-                EDStatic.emailUserName,
-                EDStatic.emailPassword,
-                EDStatic.emailProperties);
+                EDStatic.config.emailSmtpHost,
+                EDStatic.config.emailSmtpPort, // throws Exception
+                EDStatic.config.emailUserName,
+                EDStatic.config.emailPassword,
+                EDStatic.config.emailProperties);
         session = (Session) oar[0];
         smtpTransport = (SMTPTransport) oar[1];
 
@@ -129,7 +129,7 @@ public class EmailThread extends Thread {
             SSR.lowSendEmail(
                 session,
                 smtpTransport,
-                EDStatic.emailFromAddress,
+                EDStatic.config.emailFromAddress,
                 emailOA[0],
                 emailOA[1],
                 emailOA[2]); // toAddresses, subject, content);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/Metrics.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/Metrics.java
@@ -1,0 +1,190 @@
+package gov.noaa.pfel.erddap.util;
+
+import gov.noaa.pfel.coastwatch.sgt.GSHHS;
+import gov.noaa.pfel.coastwatch.sgt.SgtMap;
+import gov.noaa.pfel.coastwatch.sgt.SgtUtil;
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.core.metrics.Gauge;
+import io.prometheus.metrics.core.metrics.Histogram;
+import io.prometheus.metrics.core.metrics.Info;
+import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.Unit;
+import java.awt.ImageCapabilities;
+import java.awt.image.BufferedImage;
+
+public class Metrics {
+
+  public enum ThreadStatus {
+    success,
+    fail,
+  }
+
+  public enum DatasetCategory {
+    grid,
+    table,
+  }
+
+  public enum LoadDatasetsType {
+    major,
+    minor,
+  }
+
+  public enum Cache {
+    cached,
+    not_cached,
+  }
+
+  public enum BoundaryRequest {
+    coarse,
+    success,
+    tossed,
+  }
+
+  public Histogram responseDuration =
+      Histogram.builder()
+          .name("http_request_duration_seconds")
+          .help("HTTP request service time in seconds")
+          .unit(Unit.SECONDS)
+          .labelNames(
+              "request_type", "dataset_id", "dataset_type", "file_type", "lang_code", "status_code")
+          .nativeOnly()
+          .build();
+
+  public Histogram touchThreadDuration =
+      Histogram.builder()
+          .name("touch_thread_duration_seconds")
+          .help("Touch thread service time in seconds")
+          .unit(Unit.SECONDS)
+          .labelNames("success")
+          .nativeOnly()
+          .build();
+
+  public Histogram taskThreadDuration =
+      Histogram.builder()
+          .name("task_thread_duration_seconds")
+          .help("Task thread service time in seconds")
+          .unit(Unit.SECONDS)
+          .labelNames("success", "task_type")
+          .nativeOnly()
+          .build();
+
+  public Histogram loadDatasetsDuration =
+      Histogram.builder()
+          .name("load_datasets_duration_seconds")
+          .help("Load datasets service time in seconds")
+          .unit(Unit.SECONDS)
+          .labelNames("major")
+          .nativeOnly()
+          .build();
+
+  public Histogram emailsCountDistribution =
+      Histogram.builder()
+          .name("email_count_distribution")
+          .help("Number of emails sent per session")
+          .nativeOnly()
+          .build();
+
+  public Histogram emailThreadDuration =
+      Histogram.builder()
+          .name("email_thread_duration_seconds")
+          .help("Email thread service time in seconds")
+          .unit(Unit.SECONDS)
+          .labelNames("success")
+          .nativeOnly()
+          .build();
+
+  public Gauge datasetsCount =
+      Gauge.builder()
+          .name("dataset_count")
+          .help("Count of datasets, set at the end of loadDatasets")
+          .labelNames("category")
+          .build();
+  public Gauge datasetsFailedCount =
+      Gauge.builder()
+          .name("dataset_failed_load_count")
+          .help("Count of datasets that failed to load, set at the end of loadDatasets")
+          .build();
+
+  public Counter shedRequests =
+      Counter.builder()
+          .name("shed_requests_total")
+          .help("Count of requests that have been shed")
+          .build();
+
+  public Counter dangerousMemoryEmails =
+      Counter.builder()
+          .name("dangerous_memory_emails_total")
+          .help("Count of dangerous memory emails")
+          .build();
+
+  public Counter dangerousMemoryFailures =
+      Counter.builder()
+          .name("dangerous_memory_failures_total")
+          .help("Count of failed requests due to memory")
+          .build();
+
+  public Counter sgtMapTopoRequest =
+      Counter.builder()
+          .name("topo_request_total")
+          .help("Count of topo requests")
+          .labelNames("cache")
+          .build();
+
+  public void initialize(boolean registerPrometheus) {
+    if (registerPrometheus) {
+      JvmMetrics.builder().register(); // initialize the out-of-the-box JVM metrics
+      addInfoMetrics();
+      PrometheusRegistry.defaultRegistry.register(loadDatasetsDuration);
+      PrometheusRegistry.defaultRegistry.register(emailThreadDuration);
+      PrometheusRegistry.defaultRegistry.register(taskThreadDuration);
+      PrometheusRegistry.defaultRegistry.register(touchThreadDuration);
+      PrometheusRegistry.defaultRegistry.register(responseDuration);
+      PrometheusRegistry.defaultRegistry.register(emailsCountDistribution);
+      PrometheusRegistry.defaultRegistry.register(datasetsCount);
+      PrometheusRegistry.defaultRegistry.register(datasetsFailedCount);
+      PrometheusRegistry.defaultRegistry.register(shedRequests);
+      PrometheusRegistry.defaultRegistry.register(dangerousMemoryEmails);
+      PrometheusRegistry.defaultRegistry.register(dangerousMemoryFailures);
+      PrometheusRegistry.defaultRegistry.register(sgtMapTopoRequest);
+      GSHHS.requestStatus.register(PrometheusRegistry.defaultRegistry);
+      SgtMap.nationalBoundaries.counter.register(PrometheusRegistry.defaultRegistry);
+      SgtMap.stateBoundaries.counter.register(PrometheusRegistry.defaultRegistry);
+      SgtMap.rivers.counter.register(PrometheusRegistry.defaultRegistry);
+    }
+    datasetsCount.initLabelValues(DatasetCategory.grid.name());
+    datasetsCount.initLabelValues(DatasetCategory.table.name());
+  }
+
+  private void addInfoMetrics() {
+    Info info =
+        Info.builder()
+            .name("ERDDAP_build_info")
+            .help("Information about the ERDDAP build")
+            .labelNames("version", "version_full", "deployment_info")
+            .register();
+    String doubleVersion = EDStatic.erddapVersion;
+    int po = doubleVersion.indexOf('_');
+    if (po >= 0) doubleVersion = doubleVersion.substring(0, po);
+    info.setLabelValues(
+        doubleVersion,
+        EDStatic.erddapVersion,
+        EDStatic.deploymentInfo != null ? EDStatic.deploymentInfo : "");
+
+    Info graphicsInfo =
+        Info.builder()
+            .name("bufferedImage")
+            .help("Information about the graphics state")
+            .labelNames("isAccelerated")
+            .register();
+    try {
+      BufferedImage bi = SgtUtil.getBufferedImage(10, 10);
+      ImageCapabilities imCap = bi.getCapabilities(null);
+      graphicsInfo.setLabelValues(
+          imCap == null ? "unknown" : imCap.isAccelerated() ? "true" : "false");
+
+    } catch (Throwable t) {
+      graphicsInfo.setLabelValues("unknown");
+    }
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/TaskThread.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/TaskThread.java
@@ -261,7 +261,7 @@ public class TaskThread extends Thread {
                 + Calendar2.elapsedTimeString(tElapsedTime);
         String content = taskSummary + "\n" + MustBe.throwableToString(t);
         String2.log("%%% " + subject + "\n" + content);
-        EDStatic.email(EDStatic.emailEverythingToCsv, subject, content);
+        EDStatic.email(EDStatic.config.emailEverythingToCsv, subject, content);
       }
 
       // whether succeeded or failed

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/TaskThread.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/TaskThread.java
@@ -12,6 +12,7 @@ import com.cohort.util.String2;
 import gov.noaa.pfel.coastwatch.griddata.OpendapHelper;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.erddap.dataset.EDD;
+import io.prometheus.metrics.model.snapshots.Unit;
 
 /**
  * This does a series of tasks.
@@ -238,11 +239,21 @@ public class TaskThread extends Thread {
                 + Calendar2.elapsedTimeString(tElapsedTime));
         String2.distributeTime(tElapsedTime, EDStatic.taskThreadSucceededDistribution24);
         String2.distributeTime(tElapsedTime, EDStatic.taskThreadSucceededDistributionTotal);
+        EDStatic.metrics
+            .taskThreadDuration
+            .labelValues(Metrics.ThreadStatus.success.name(), "" + taskType)
+            .observe(Unit.millisToSeconds(tElapsedTime));
 
       } catch (Throwable t) {
         long tElapsedTime = elapsedTime();
         String2.distributeTime(tElapsedTime, EDStatic.taskThreadFailedDistribution24);
         String2.distributeTime(tElapsedTime, EDStatic.taskThreadFailedDistributionTotal);
+        Object taskOA[] = EDStatic.taskList.get(EDStatic.nextTask.get() - 1);
+        Integer taskType = (Integer) taskOA[0];
+        EDStatic.metrics
+            .taskThreadDuration
+            .labelValues(Metrics.ThreadStatus.fail.name(), "" + taskType)
+            .observe(Unit.millisToSeconds(tElapsedTime));
         String subject =
             "TaskThread error: task #"
                 + (EDStatic.nextTask.get() - 1)

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/TouchThread.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/TouchThread.java
@@ -9,6 +9,7 @@ import com.cohort.util.Math2;
 import com.cohort.util.MustBe;
 import com.cohort.util.String2;
 import gov.noaa.pfel.coastwatch.util.SSR;
+import io.prometheus.metrics.model.snapshots.Unit;
 
 /**
  * This does a series of touches.
@@ -100,6 +101,10 @@ public class TouchThread extends Thread {
                   + (tElapsedTime > 10000 ? " (>10s!)" : ""));
           String2.distributeTime(tElapsedTime, EDStatic.touchThreadSucceededDistribution24);
           String2.distributeTime(tElapsedTime, EDStatic.touchThreadSucceededDistributionTotal);
+          EDStatic.metrics
+              .touchThreadDuration
+              .labelValues(Metrics.ThreadStatus.success.name())
+              .observe(Unit.millisToSeconds(tElapsedTime));
 
         } catch (InterruptedException e) {
           String2.log("%%% TouchThread was interrupted.");
@@ -120,6 +125,10 @@ public class TouchThread extends Thread {
                   + MustBe.throwableToString(e));
           String2.distributeTime(tElapsedTime, EDStatic.touchThreadFailedDistribution24);
           String2.distributeTime(tElapsedTime, EDStatic.touchThreadFailedDistributionTotal);
+          EDStatic.metrics
+              .touchThreadDuration
+              .labelValues(Metrics.ThreadStatus.fail.name())
+              .observe(Unit.millisToSeconds(tElapsedTime));
 
         } finally {
           // whether succeeded or failed

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
@@ -824,7 +824,7 @@ public class EDV {
       combinedAttributes.remove(DECIMAL_DIGITS);
     }
 
-    if (EDStatic.variablesMustHaveIoosCategory) {
+    if (EDStatic.config.variablesMustHaveIoosCategory) {
       String ic = combinedAttributes().getString("ioos_category");
       Test.ensureSomethingUnicode(ic, errorInMethod + "ioos_category");
       Test.ensureTrue(
@@ -1079,8 +1079,8 @@ public class EDV {
   }
 
   /**
-   * The destination units for this variable (presumably using the EDStatic.units_standard, e.g.,
-   * UDUNITS).
+   * The destination units for this variable (presumably using the EDStatic.config.units_standard,
+   * e.g., UDUNITS).
    *
    * @return the destination units for this variable (e.g., "m") (may be null).
    */
@@ -1096,7 +1096,7 @@ public class EDV {
   public String ucumUnits() {
     // not yet set?
     if ("\u0000".equals(ucumUnits)) {
-      if ("UDUNITS".equals(EDStatic.units_standard)) {
+      if ("UDUNITS".equals(EDStatic.config.units_standard)) {
         try {
           ucumUnits = Units2.udunitsToUcum(units()); // null returns null
         } catch (Throwable t) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDV.java
@@ -554,12 +554,12 @@ public class EDV {
     if (hasColorBarMinMax && tMin >= tMax) // this may change if flipped range is allowed
     throw new IllegalArgumentException(
           "colorBarMinimum=" + tMin + " must be less than colorBarMaximum=" + tMax + ".");
-    if (tPalette != null && String2.indexOf(EDStatic.palettes, tPalette) < 0)
+    if (tPalette != null && String2.indexOf(EDStatic.messages.palettes, tPalette) < 0)
       throw new IllegalArgumentException(
           "colorBarPalette="
               + tPalette
               + " must be one of "
-              + String2.toCSSVString(EDStatic.palettes)
+              + String2.toCSSVString(EDStatic.messages.palettes)
               + " (default='Rainbow').");
     if (tContinuous != null && !tContinuous.equals("true") && !tContinuous.equals("false"))
       throw new IllegalArgumentException(

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDVGridAxis.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/variable/EDVGridAxis.java
@@ -557,14 +557,17 @@ public class EDVGridAxis extends EDV {
    */
   public String spacingDescription(int language) {
     boolean isTimeStamp = this instanceof EDVTimeStampGridAxis;
-    if (sourceValues().size() == 1) return "(" + EDStatic.EDDGridJustOneValueAr[language] + ")";
+    if (sourceValues().size() == 1)
+      return "(" + EDStatic.messages.EDDGridJustOneValueAr[language] + ")";
     String s =
         isTimeStamp
             ? Calendar2.elapsedTimeString(Math.rint(averageSpacing()) * 1000)
             : "" + Math2.floatToDouble(averageSpacing());
     return s
         + " ("
-        + (isEvenlySpaced() ? EDStatic.EDDGridEvenAr[language] : EDStatic.EDDGridUnevenAr[language])
+        + (isEvenlySpaced()
+            ? EDStatic.messages.EDDGridEvenAr[language]
+            : EDStatic.messages.EDDGridUnevenAr[language])
         + ")";
   }
 
@@ -603,7 +606,9 @@ public class EDVGridAxis extends EDV {
         + tUnits
         + "<br>"
         + "with "
-        + (isEvenlySpaced() ? EDStatic.EDDGridEvenAr[language] : EDStatic.EDDGridUnevenAr[language])
+        + (isEvenlySpaced()
+            ? EDStatic.messages.EDDGridEvenAr[language]
+            : EDStatic.messages.EDDGridUnevenAr[language])
         + " spacing "
         + (isEvenlySpaced() ? "" : "~")
         + "= "

--- a/pom.xml
+++ b/pom.xml
@@ -1085,17 +1085,22 @@
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-core</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-model</artifactId>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
-            <version>1.3.3</version>
+            <version>1.3.5</version>
         </dependency>
         <dependency>
             <groupId>io.github.classgraph</groupId>

--- a/src/test/java/gov/noaa/pfel/coastwatch/util/PersistentTableTests.java
+++ b/src/test/java/gov/noaa/pfel/coastwatch/util/PersistentTableTests.java
@@ -58,7 +58,7 @@ class PersistentTableTests {
     Test.ensureTrue(longest <= 24, "");
 
     // make a new table
-    String name = EDStatic.fullTestCacheDirectory + "testPersistentTable.txt";
+    String name = EDStatic.config.fullTestCacheDirectory + "testPersistentTable.txt";
     File2.delete(name);
     int widths[] = {
       PersistentTable.BOOLEAN_LENGTH,

--- a/src/test/java/gov/noaa/pfel/erddap/LoadDatasetsTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/LoadDatasetsTests.java
@@ -27,7 +27,7 @@ public class LoadDatasetsTests {
     loadDatasets =
         new LoadDatasets(
             new Erddap(),
-            EDStatic.datasetsRegex,
+            EDStatic.config.datasetsRegex,
             File2.getBufferedInputStream(pathToDatasetsXml),
             true);
     loadDatasets.run();
@@ -47,7 +47,7 @@ public class LoadDatasetsTests {
     loadDatasets =
         new LoadDatasets(
             new Erddap(),
-            EDStatic.datasetsRegex,
+            EDStatic.config.datasetsRegex,
             File2.getBufferedInputStream(pathToDatasetsXml),
             true);
     loadDatasets.run();

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimensionTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridAggregateExistingDimensionTests.java
@@ -47,10 +47,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_speed\n"
@@ -69,10 +69,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className(),
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     int dataPo = results.indexOf("data:");
     expected =
         "netcdf EDDGridAggregateExistingDimension.nc {\n"
@@ -213,10 +213,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_direction\n"
@@ -235,10 +235,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_speed,wind_direction\n"
@@ -257,10 +257,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "4",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_direction,wind_speed\n"
@@ -278,10 +278,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "4",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     dataPo = results.indexOf("data:");
     results = results.substring(dataPo);
     expected =
@@ -339,10 +339,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "5",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_direction,wind_speed\n"
@@ -365,10 +365,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "6",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_direction,wind_speed\n"
@@ -391,10 +391,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             ndbcDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "7",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,wind_direction,wind_speed\n"
@@ -427,10 +427,10 @@ class EDDGridAggregateExistingDimensionTests {
             null,
             null,
             "time",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_rtofs",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "time\n" + "UTC\n" + "2009-07-01T00:00:00Z\n" + "2009-07-02T00:00:00Z\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
   }

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridCopyTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridCopyTests.java
@@ -61,10 +61,10 @@ class EDDGridCopyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -244,10 +244,10 @@ class EDDGridCopyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -295,10 +295,10 @@ class EDDGridCopyTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -328,10 +328,10 @@ class EDDGridCopyTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -358,7 +358,7 @@ class EDDGridCopyTests {
     String tName;
     EDDGrid eddGrid = null;
     String tDatasetID = "testOnlySince";
-    String copyDatasetDir = EDStatic.fullCopyDirectory + tDatasetID + "/";
+    String copyDatasetDir = EDStatic.config.fullCopyDirectory + tDatasetID + "/";
     int language = 0;
 
     try {
@@ -384,10 +384,11 @@ class EDDGridCopyTests {
             null,
             null,
             "time",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_time",
             ".csv");
-    String2.log("\n" + File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+    String2.log(
+        "\n" + File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     String2.pressEnterToContinue(
         "The time values shown should only include times since "
             + Calendar2.epochSecondsToIsoStringTZ(Calendar2.nowStringToEpochSeconds("now-3days"))

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromAudioFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromAudioFilesTests.java
@@ -367,7 +367,7 @@ class EDDGridFromAudioFilesTests {
     // delete cached info
     if (deleteCachedDatasetInfo) EDDGridFromAudioFiles.deleteCachedDatasetInfo("testGridWav");
     EDDGrid edd = (EDDGrid) EDDTestDataset.gettestGridWav();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected, dapQuery;
     int po;
     String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
@@ -64,10 +64,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "surf_el[(2008-06-12T00:00:00):1:(2008-06-12T00:00:00)][(10.0):100:(65.0)][(-150.0):100:(-100.0)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Carleton",
             ".nc");
-    String results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    String results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     String expected =
         "time =\n"
             + "  {1.2132288E9}\n"
@@ -110,10 +110,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_" + tid,
             ".dds");
-    String2.log(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+    String2.log(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
 
     String2.log("\n\n***** DAS ");
     tName =
@@ -122,10 +122,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_" + tid,
             ".das");
-    String2.log(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+    String2.log(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
 
     String2.log("\n\n***** NCDUMP ");
     tName =
@@ -134,10 +134,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlor_a[(2008-03-29T12:00:00):1:(2008-03-29T12:00:00)][(0.0):1:(0.0)][(16.995124378128825):100:(31.00905181853181)][(-99.01235553141787):100:(-78.99636386525192)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_" + tid,
             ".nc");
-    String2.log(NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, ""));
+    String2.log(NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, ""));
 
     String2.log("\n\n***** PNG ");
     tName =
@@ -146,10 +146,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlor_a[0][][][]&.colorBar=Rainbow|C|Log|.04|10|",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_" + tid + "_Map",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
   }
 
   @org.junit.jupiter.api.Test
@@ -493,10 +493,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // "Attributes {\n" +
@@ -541,10 +541,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset \\{\n"
@@ -572,10 +572,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Entire",
             ".html");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     // *** test getting das for 1 variable das isn't affected by userDapQuery
     String2.log("\n****************** EDDGridFromDap test 1 variable\n");
@@ -585,10 +585,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_1Variable",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // "Attributes {\n" +
@@ -617,10 +617,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_1Variable",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset \\{\n"
@@ -664,10 +664,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".asc");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -690,12 +690,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time,longitude\n"
             + "UTC,degrees_east\n"
@@ -712,12 +712,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".csvp");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time (UTC),longitude (degrees_east)\n"
             + "2002-07-08T00:00:00Z,360.0\n"
@@ -733,12 +733,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll.time[0:100:200],chlorophyll.longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_AxisG.A",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time,longitude\n"
             + "UTC,degrees_east\n"
@@ -755,12 +755,13 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".das");
     results =
         String2.annotatedString(
-            new String(ByteArray.fromFile(EDStatic.fullTestCacheDirectory + tName).toArray()));
+            new String(
+                ByteArray.fromFile(EDStatic.config.fullTestCacheDirectory + tName).toArray()));
     expected = // see OpendapHelper.EOL definition for comments
         // "Attributes {[10]\n" +
         // " time {[10]\n" +
@@ -790,12 +791,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".dds");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log(results);
     expected =
         "Dataset {[10]\n"
@@ -813,12 +814,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".dods");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log(results);
     expected =
         "Dataset {[10]\n"
@@ -838,12 +839,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\n"
             + "  \"table\": {\n"
@@ -869,12 +870,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]" + "&.jsonp=" + SSR.percentEncode(jsonp),
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         jsonp
             + "("
@@ -905,11 +906,11 @@ class EDDGridFromDapTests {
             null,
             null,
             matlabAxisQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".mat");
-    String2.log(".mat test file is " + EDStatic.fullTestCacheDirectory + tName);
-    results = File2.hexDump(EDStatic.fullTestCacheDirectory + tName, 1000000);
+    String2.log(".mat test file is " + EDStatic.config.fullTestCacheDirectory + tName);
+    results = File2.hexDump(EDStatic.config.fullTestCacheDirectory + tName, 1000000);
     String2.log(results);
     expected =
         "4d 41 54 4c 41 42 20 35   2e 30 20 4d 41 54 2d 66   MATLAB 5.0 MAT-f |\n"
@@ -943,7 +944,7 @@ class EDDGridFromDapTests {
         results.substring(0, 71 * 4) + results.substring(71 * 7), // remove the creation
         // dateTime
         expected,
-        "RESULTS(" + EDStatic.fullTestCacheDirectory + tName + ")=\n" + results);
+        "RESULTS(" + EDStatic.config.fullTestCacheDirectory + tName + ")=\n" + results);
     /* */
     // .nc
     String2.log("\n*** EDDGridFromDap test get .nc axis data\n");
@@ -953,10 +954,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     expected =
         "netcdf EDDGridFromDap_Axis.nc {\n"
             + "  dimensions:\n"
@@ -1053,10 +1054,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".ncHeader");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "netcdf EDDGridFromDap_Axis.nc {\n"
@@ -1108,14 +1109,14 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".ncoJson");
     // 2017-08-03 I tested the resulting file for validity at https://jsonlint.com/
-    String2.log(">> NCO JSON " + EDStatic.fullTestCacheDirectory + tName);
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    String2.log(">> NCO JSON " + EDStatic.config.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\n"
             + "  \"attributes\": {\n"
@@ -1221,12 +1222,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]&.jsonp=myFunctionName",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axisjp",
             ".ncoJson");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "myFunctionName("
             + "{\n"
@@ -1333,10 +1334,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_tg",
             ".timeGaps");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Time gaps greater than the median (8 days):\n"
             + "[21]=2002-12-23T00:00:00Z -> [22]=2003-01-05T00:00:00Z, gap=13 days\n"
@@ -1361,12 +1362,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".tsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time\tlongitude\n"
             + "UTC\tdegrees_east\n"
@@ -1383,12 +1384,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".tsvp");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time (UTC)\tlongitude (degrees_east)\n"
             + "2002-07-08T00:00:00Z\t360.0\n"
@@ -1404,12 +1405,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "latitude[0:10:40],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_LatAxis",
             ".xhtml");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
             + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n"
@@ -1466,12 +1467,12 @@ class EDDGridFromDapTests {
             null,
             null,
             tQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_LatAxis",
             ".htmlTable");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         EDStatic.startHeadHtml(
                 language, EDStatic.erddapUrl((String) null, language), "EDDGridFromDap_LatAxis")
@@ -1537,12 +1538,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "time[0:100:200],longitude[last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".xhtml");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<tr>\n"
             + "<th>time</th>\n"
@@ -1638,12 +1639,12 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".asc");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log("\n.asc results=\n" + results);
     expected =
         "Dataset {[10]\n"
@@ -1692,10 +1693,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // missing values are "NaN"
         /*
          * pre 2010-10-26 was:
@@ -1744,10 +1745,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll." + userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_DotNotation",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         /*
          * pre 2010-10-26 was:
@@ -1795,12 +1796,12 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".das");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     expected =
         // "Attributes {[10]\n" +
         // " time {[10]\n" +
@@ -1829,12 +1830,12 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".dds");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log(results);
     expected =
         "Dataset {[10]\n"
@@ -1859,12 +1860,12 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".dods");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log(results);
     expected =
         "Dataset {[10]\n"
@@ -1894,14 +1895,14 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Map", // must be Map
             // because .asc
             // already
             // used
             ".esriAscii");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // note that lon values have been shifted from 225 to -135
         "ncols 53\n"
             + "nrows 51\n"
@@ -1927,10 +1928,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // missing values are "null"
         "{\n"
             + "  \"table\": {\n"
@@ -1981,10 +1982,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".mat");
-    results = File2.hexDump(EDStatic.fullTestCacheDirectory + tName, 1000000);
+    results = File2.hexDump(EDStatic.config.fullTestCacheDirectory + tName, 1000000);
 
     // String2.log(results);
     expected =
@@ -2041,10 +2042,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     expected = // changed a little ("// (has coord.var)") when switched to netcdf-java 4.0,
         // 2009-02-23
         "netcdf EDDGridFromDap_Data.nc {\n"
@@ -2218,10 +2219,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".ncHeader");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     // if (true) System.exit(1);
     expected =
@@ -2273,12 +2274,12 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll[(2002-07-08):(2002-07-16)][][(29):100:(50)][(225):100:(247)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".ncoJson");
     // 2017-08-03 I tested the resulting file for validity at https://jsonlint.com/
-    String2.log(">> NCO JSON " + EDStatic.fullTestCacheDirectory + tName);
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    String2.log(">> NCO JSON " + EDStatic.config.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "{\n"
@@ -2464,10 +2465,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "chlorophyll[(2002-07-08):(2002-07-16)][][(29):100:(50)][(225):100:(247)]&.jsonp=myFunctionName",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Datajp",
             ".ncoJson");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "myFunctionName("
@@ -2655,10 +2656,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".tsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time\taltitude\tlatitude\tlongitude\tchlorophyll\n"
@@ -2693,10 +2694,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".xhtml");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -2757,10 +2758,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedg.className() + "Quotes",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     int po9 = results.indexOf("The 4th Pacific");
     String2.log("*** in results: " + results.substring(po9 - 10, po9 + 15));
     expected = " Proceedings of \"\"The 4th Pacific";
@@ -3559,10 +3560,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_scale",
             ".das");
-    String results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     String expected =
         "sses_standard_deviation {\n"
@@ -3592,10 +3593,10 @@ class EDDGridFromDapTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "eddGrid",
             ".asc");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -3632,10 +3633,10 @@ class EDDGridFromDapTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "eddGrid",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "{\n"
@@ -3670,10 +3671,10 @@ class EDDGridFromDapTests {
     // one time stuff
     // gridDataset = (EDDGridFromDap)oneFromDatasetsXml(null, "ncdcOisstAmsrAgg");
     // tName = gridDataset.makeNewFileForDapQuery(language, null, null, "",
-    // EDStatic.fullTestCacheDirectory,
+    // EDStatic.config.fullTestCacheDirectory,
     // gridDataset.className() + "ncdc", ".das");
     // String results =
-    // File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    // File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
 
     // soda
@@ -3686,10 +3687,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda202d",
             ".das");
-    String results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
 
     String sodaq = "time[(2001-12-15T00:00:00):100:(2001-12-15T00:00:00)]";
@@ -3699,10 +3700,10 @@ class EDDGridFromDapTests {
             null,
             null,
             sodaq,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda202dqt",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
 
     sodaq =
@@ -3730,10 +3731,10 @@ class EDDGridFromDapTests {
             null,
             null,
             sodaq,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda202dq",
             ".json");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
 
     gridDataset =
@@ -3744,10 +3745,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda202s",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
 
     gridDataset =
@@ -3758,10 +3759,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda203d",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
 
     gridDataset =
@@ -3772,10 +3773,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda203s",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
   }
 
@@ -3857,8 +3858,14 @@ class EDDGridFromDapTests {
     // .das das isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".das");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String lastTime = "" + eddGrid.axisVariables[eddGrid.timeIndex].lastDestinationValue();
     String lastTimeString =
         ((EDVTimeGridAxis) eddGrid.axisVariables[eddGrid.timeIndex]).destinationMaxString();
@@ -3992,8 +3999,14 @@ class EDDGridFromDapTests {
     // .dds dds isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     int tnTime = eddGrid.axisVariables[eddGrid.timeIndex].sourceValues().size();
     expected =
         "Dataset {\n"
@@ -4067,10 +4080,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "Lat",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     String2.log(results);
     expected = // note actual range is low to high
         "netcdf EDDGridFromDapLat.nc {\n"
@@ -4162,10 +4175,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected =
         "time,altitude,latitude,longitude,u\n"
@@ -4196,10 +4209,11 @@ class EDDGridFromDapTests {
             null,
             null,
             mapDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".png");
-    if (doGraphicsTests) Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    if (doGraphicsTests)
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     String transparentQuery =
         "u[(2008-08-06T00:00:00Z)][][][]"
@@ -4210,10 +4224,11 @@ class EDDGridFromDapTests {
             null,
             null,
             transparentQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Transparent",
             ".transparentPng");
-    if (doGraphicsTests) Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    if (doGraphicsTests)
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     String query180 =
         "u[(2008-08-06T00:00:00Z)][][][0:(179)]"
@@ -4224,17 +4239,18 @@ class EDDGridFromDapTests {
             null,
             null,
             query180,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".kml");
-    if (doGraphicsTests) Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    if (doGraphicsTests)
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     // currently doesn't work, either ERDDAP needs to rearrange lat and lon values
     // or GeotiffWritter needs to accept descending axis values.
     // tName = eddGrid.makeNewFileForDapQuery(language, null, null, query180,
-    // EDStatic.fullTestCacheDirectory,
+    // EDStatic.config.fullTestCacheDirectory,
     // eddGrid.className() + "_Map", ".geotif");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     tName =
         eddGrid.makeNewFileForDapQuery(
@@ -4242,10 +4258,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "u[(2008-08-06T00:00:00Z)][][0:50:(last)][0:50:(179)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".esriAscii");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     // It seems to toggle frequently between these similar results ...
     // changed slightly 2008-09-07! and 2008-09-24 2008-10-09 2008-10-13 2008-11-11
@@ -4387,8 +4403,14 @@ class EDDGridFromDapTests {
     // .das das isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".das");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + "  latitude {\n"
@@ -4472,8 +4494,14 @@ class EDDGridFromDapTests {
     // .dds dds isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  Float64 latitude[latitude = 6001];\n"
@@ -4496,10 +4524,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "Lat",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     results = String2.replaceAll(results, "\r", "");
     expected = // note actual range is low to high
         "netcdf EDDGridFromDapLat.nc {\n"
@@ -4568,10 +4596,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected =
         "latitude,longitude,topo\n"
@@ -4596,7 +4624,7 @@ class EDDGridFromDapTests {
         eddGrid.makeNewFileForDapQuery(
             language, null, null, mapDapQuery, obsDir, eddGrid.className() + "_Map", ".png");
     if (doGraphicsTests) {
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(
           tName,
           "EDDGridFromDapTestDescendingLat" + ".png",
@@ -4615,7 +4643,7 @@ class EDDGridFromDapTests {
             eddGrid.className() + "_Transparent",
             ".transparentPng");
     if (doGraphicsTests) {
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(
           tName,
           "EDDGridFromDapTestDescendingLatTP" + ".png",
@@ -4631,11 +4659,11 @@ class EDDGridFromDapTests {
             null,
             null,
             query180,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".kml");
     // if (doGraphicsTests) {
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     // }
 
     // 2013-10-21 this works with new GeotiffWriter (which rearranges lat values)
@@ -4645,11 +4673,11 @@ class EDDGridFromDapTests {
             null,
             null,
             query180stride,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".geotif");
     // if (doGraphicsTests) {
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     // }
 
     tName =
@@ -4658,10 +4686,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "topo[0:1000:last][0:1000:last]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Map",
             ".esriAscii");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected =
         "ncols 10\n"
@@ -4699,8 +4727,14 @@ class EDDGridFromDapTests {
     // .das das isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".das");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".das");
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected =
         "Attributes {\n"
             + "  time {\n"
@@ -4891,8 +4925,14 @@ class EDDGridFromDapTests {
     // .dds dds isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  Float64 time[time = 8161];\n"
@@ -4964,10 +5004,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "Alt",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected =
         "altitude\n"
@@ -5000,10 +5040,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected =
         "time, altitude, latitude, longitude, u_1205\n"
@@ -5061,10 +5101,10 @@ class EDDGridFromDapTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda224",
             ".htmlTable"); // was ok
-    String results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     String expected =
         EDStatic.startHeadHtml(
                 language, EDStatic.erddapUrl((String) null, language), "EDDGridFromDap_soda224")
@@ -5160,10 +5200,10 @@ class EDDGridFromDapTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda224",
             ".mat"); // threw an exception
-    results = File2.hexDump(EDStatic.fullTestCacheDirectory + tName, 1000000);
+    results = File2.hexDump(EDStatic.config.fullTestCacheDirectory + tName, 1000000);
     expected =
         "4d 41 54 4c 41 42 20 35   2e 30 20 4d 41 54 2d 66   MATLAB 5.0 MAT-f |\n"
             + "69 6c 65 2c 20 43 72 65   61 74 65 64 20 62 79 3a   ile, Created by: |\n"
@@ -5280,10 +5320,10 @@ class EDDGridFromDapTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_soda224",
             ".asc");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  GRID {\n"
@@ -5348,7 +5388,7 @@ class EDDGridFromDapTests {
                 null,
                 null,
                 query,
-                EDStatic.fullTestCacheDirectory,
+                EDStatic.config.fullTestCacheDirectory,
                 gridDataset.className() + "_soda224",
                 fileType);
       } catch (Throwable t) {
@@ -5545,10 +5585,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "testGridWithDepth2",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     po = results.indexOf("depth {");
     Test.ensureTrue(po >= 0, "results=\n" + results);
     expected =
@@ -5561,15 +5601,15 @@ class EDDGridFromDapTests {
             + //
             "    String axis \"Z\";\n"
             + //
-            (EDStatic.useSaxParser ? "    String grads_dim \"z\";\n" : "")
-            + (EDStatic.useSaxParser ? "    String grads_mapping \"levels\";\n" : "")
+            (EDStatic.config.useSaxParser ? "    String grads_dim \"z\";\n" : "")
+            + (EDStatic.config.useSaxParser ? "    String grads_mapping \"levels\";\n" : "")
             + "    String ioos_category \"Location\";\n"
             + "    String long_name \"Depth\";\n"
-            + (EDStatic.useSaxParser ? "    Float64 maximum 5375.0;\n" : "")
-            + (EDStatic.useSaxParser ? "    Float64 minimum 5.01;\n" : "")
-            + (EDStatic.useSaxParser ? "    String name \"Depth\";\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Float64 maximum 5375.0;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Float64 minimum 5.01;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    String name \"Depth\";\n" : "")
             + "    String positive \"down\";\n"
-            + (EDStatic.useSaxParser ? "    Float32 resolution 137.69205;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Float32 resolution 137.69205;\n" : "")
             + "    String standard_name \"depth\";\n"
             + "    String units \"m\";\n"
             + "  }";
@@ -5583,10 +5623,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "testGridWithDepth2",
             ".fgdc");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     po = results.indexOf("<vertdef>");
     Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
     expected =
@@ -5609,10 +5649,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "testGridWithDepth2",
             ".iso19115");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
 
     po = results.indexOf("codeListValue=\"vertical\">");
     Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
@@ -5686,9 +5726,9 @@ class EDDGridFromDapTests {
    * EDDGridFromDap gridDataset = (EDDGridFromDap)oneFromDatasetsXml(null,
    * "testGridWithDepth");
    * tName = gridDataset.makeNewFileForDapQuery(language, null, null, "",
-   * EDStatic.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
+   * EDStatic.config.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
    * ".das");
-   * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+   * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
    * tName);
    * po = results.indexOf("depth {");
    * Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
@@ -5710,9 +5750,9 @@ class EDDGridFromDapTests {
    *
    * //FGDC should deal with depth correctly
    * tName = gridDataset.makeNewFileForDapQuery(language, null, null, "",
-   * EDStatic.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
+   * EDStatic.config.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
    * ".fgdc");
-   * results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory +
+   * results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory +
    * tName);
    * po = results.indexOf("<vertdef>");
    * Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
@@ -5732,9 +5772,9 @@ class EDDGridFromDapTests {
    *
    * //ISO 19115 should deal with depth correctly
    * tName = gridDataset.makeNewFileForDapQuery(language, null, null, "",
-   * EDStatic.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
+   * EDStatic.config.fullTestCacheDirectory, "EDDGridLonPM180_testGridWithDepth",
    * ".iso19115");
-   * results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory +
+   * results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory +
    * tName);
    *
    * po = results.indexOf(
@@ -5795,7 +5835,7 @@ class EDDGridFromDapTests {
    * "results=\n" + results);
    *
    * //test WMS 1.1.0 elevation=-5
-   * tName = EDStatic.fullTestCacheDirectory + gridDataset.className() +
+   * tName = EDStatic.config.fullTestCacheDirectory + gridDataset.className() +
    * "testGridWithDepth110e5.png";
    * SSR.downloadFile(
    * "http://localhost:8080/cwexperimental/wms/testGridWithDepth/request?" +
@@ -5809,7 +5849,7 @@ class EDDGridFromDapTests {
    * Test.displayInBrowser("file://" + tName);
    *
    * //test WMS 1.1.0 elevation=default
-   * tName = EDStatic.fullTestCacheDirectory + gridDataset.className() +
+   * tName = EDStatic.config.fullTestCacheDirectory + gridDataset.className() +
    * "testGridWithDepth110edef.png";
    * SSR.downloadFile(
    * "http://localhost:8080/cwexperimental/wms/testGridWithDepth/request?" +
@@ -5852,7 +5892,7 @@ class EDDGridFromDapTests {
    * "results=\n" + results);
    *
    * //test WMS 1.3.0 elevation=-5
-   * tName = EDStatic.fullTestCacheDirectory + gridDataset.className() +
+   * tName = EDStatic.config.fullTestCacheDirectory + gridDataset.className() +
    * "testGridWithDepth130e5.png";
    * SSR.downloadFile(
    * "http://localhost:8080/cwexperimental/wms/testGridWithDepth/request?" +
@@ -5866,7 +5906,7 @@ class EDDGridFromDapTests {
    * Test.displayInBrowser("file://" + tName);
    *
    * //test WMS 1.3.0 elevation=default
-   * tName = EDStatic.fullTestCacheDirectory + gridDataset.className() +
+   * tName = EDStatic.config.fullTestCacheDirectory + gridDataset.className() +
    * "testGridWithDepth130edef.png";
    * SSR.downloadFile(
    * "http://localhost:8080/cwexperimental/wms/testGridWithDepth/request?" +
@@ -5900,10 +5940,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className(),
               ".das");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       String2.log(results);
       expected =
           "Attributes {\n"
@@ -5963,10 +6003,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className(),
               ".dds");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           "Dataset {\n"
               + "  Float64 time[time = 1];\n"
@@ -5991,10 +6031,10 @@ class EDDGridFromDapTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "XiRho",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected = "xi_rho\n" + "count\n" + "0\n" + "2\n" + "4\n";
       Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -6006,10 +6046,10 @@ class EDDGridFromDapTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "_NAV",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // from source
           // http://edac-dap2.northerngulfinstitute.org/thredds/dodsC/roms/al_roms/nep4_004.nc.ascii?zeta[0:1:0][0:1:2][0:1:2]
@@ -6043,10 +6083,10 @@ class EDDGridFromDapTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "_NAV2",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
     } catch (Throwable t) {
@@ -6079,10 +6119,10 @@ class EDDGridFromDapTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "_clim",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           "time,altitude,latitude,longitude,u\n"
               + "UTC,m,degrees_north,degrees_east,m s-1\n"
@@ -6154,14 +6194,14 @@ class EDDGridFromDapTests {
     // testVerboseOn();
     String2.log(
         "\n*** EDDGridFromDap.testbigRequest  partialRequestMaxBytes="
-            + EDStatic.partialRequestMaxBytes
+            + EDStatic.config.partialRequestMaxBytes
             + "\n nTimePoints="
             + nTimePoints
             + " estimated nPartialRequests="
-            + Math2.hiDiv(nTimePoints * 22000000, EDStatic.partialRequestMaxBytes));
+            + Math2.hiDiv(nTimePoints * 22000000, EDStatic.config.partialRequestMaxBytes));
     int language = 0;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.geterdBAssta5day();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName =
         eddGrid.makeNewFileForDapQuery(
             language,
@@ -6236,14 +6276,14 @@ class EDDGridFromDapTests {
     int language = 0;
     String msg =
         "\n*** EDDGridFromDap.testbigRequest  partialRequestMaxBytes="
-            + EDStatic.partialRequestMaxBytes
+            + EDStatic.config.partialRequestMaxBytes
             + "\n nTimePoints="
             + nTimePoints
             + " estimated nPartialRequests="
-            + Math2.hiDiv(nTimePoints * 22000000, EDStatic.partialRequestMaxBytes);
+            + Math2.hiDiv(nTimePoints * 22000000, EDStatic.config.partialRequestMaxBytes);
     String2.log(msg);
     EDDGrid eddGrid = (EDDGrid) EDDGridFromDap.oneFromDatasetsXml(null, "nceiPH53sstd1day");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName =
         eddGrid.makeNewFileForDapQuery(
             language,
@@ -6290,7 +6330,7 @@ class EDDGridFromDapTests {
     // EDD.testVerbose(false);
     int language = 0;
     EDDGridFromDap gridDataset = (EDDGridFromDap) EDDTestDataset.geterdMHchla8day();
-    String fileName = EDStatic.fullTestCacheDirectory + "gridTestSpeedDAF.txt";
+    String fileName = EDStatic.config.fullTestCacheDirectory + "gridTestSpeedDAF.txt";
     Writer writer = File2.getBufferedFileWriterUtf8(fileName);
     gridDataset.writeDapHtmlForm(language, null, "", writer);
 
@@ -6318,7 +6358,7 @@ class EDDGridFromDapTests {
     // setup and warmup
     // EDD.testVerbose(false);
     EDDGridFromDap gridDataset = (EDDGridFromDap) EDDTestDataset.geterdMHchla8day();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String baseFileName = "gridTestSpeedMAG";
 
     // time it
@@ -6331,7 +6371,16 @@ class EDDGridFromDapTests {
           new OutputStreamSourceSimple(
               new BufferedOutputStream(new FileOutputStream(dir + fileName)));
       gridDataset.respondToGraphQuery(
-          0, null, null, "", "", "", oss, EDStatic.fullTestCacheDirectory, fileName, ".graph");
+          0,
+          null,
+          null,
+          "",
+          "",
+          "",
+          oss,
+          EDStatic.config.fullTestCacheDirectory,
+          fileName,
+          ".graph");
       Test.ensureTrue(File2.delete(dir + fileName), "");
     }
     time2 = System.currentTimeMillis() - time2;
@@ -6407,18 +6456,18 @@ class EDDGridFromDapTests {
             null,
             null,
             "topo[0:20:last][0:20:last]&.draw=surface&.vars=longitude|latitude|topo",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "descendingAxisGeotif",
             ".geotif");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     // NOT FINISHED ADDING FEATURE
     // descending Lat axis AND &.size=width|height
     // gridDataset = (EDDGridFromDap)oneFromDatasetsXml(null, "usgsCeCrm10");
     // tName = gridDataset.makeNewFileForDapQuery(language, null, null,
     // "topo[(23):(19)][(-161):(-155)]&.draw=surface&.vars=longitude|latitude|topo&.size=200|300",
-    // EDStatic.fullTestCacheDirectory, "descendingAxisGeotifSize", ".geotif");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // EDStatic.config.fullTestCacheDirectory, "descendingAxisGeotifSize", ".geotif");
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     // Mercator Lat axis
     // 2013-10-21 this still fails. Bizarre error is
@@ -6444,10 +6493,10 @@ class EDDGridFromDapTests {
               null,
               "tos[(2010-12-16T12)][(-89.5):(89.5)][(0.5):(359.5)]"
                   + "&.draw=surface&.vars=longitude|latitude|tos",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               "LonBelowAbove180",
               ".geotif");
-      Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     } catch (Throwable t) {
       error = t.toString();
     }
@@ -6478,10 +6527,10 @@ class EDDGridFromDapTests {
               null,
               "tos[(2000-11-12T12)][(-81.5):(89.5)][(0.5):(179.5)]"
                   + "&.draw=surface&.vars=longitude|latitude|tos",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               "MercatorAxisGeotif",
               ".geotif");
-      Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     } catch (Throwable t) {
       error = t.toString();
     }
@@ -6514,10 +6563,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_testNcml",
             ".ncml");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<\\?xml version=\"1.0\" encoding=\"UTF-8\"\\?>\n"
             + "<netcdf xmlns=\"https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" location=\"http://127.0.0.1:8080/griddap/erdBAssta5day\">\n"
@@ -6916,12 +6965,18 @@ class EDDGridFromDapTests {
       String baseName = gridDataset.className() + "_434_Map";
       String tName =
           gridDataset.makeNewFileForDapQuery(
-              language, null, null, mapDapQuery, EDStatic.fullTestCacheDirectory, baseName, ".png");
-      Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+              language,
+              null,
+              null,
+              mapDapQuery,
+              EDStatic.config.fullTestCacheDirectory,
+              baseName,
+              ".png");
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       // I can't use testImagesIdentical because the source data is changes every day
       // and old data isn't available.
       // Image2.testImagesIdentical(
-      // EDStatic.fullTestCacheDirectory + tName,
+      // EDStatic.config.fullTestCacheDirectory + tName,
       // String2.unitTestImagesDir() + baseName + ".png",
       // File2.getSystemTempDirectory() + baseName + "_diff.png");
       // String2.pressEnterToContinue();
@@ -6962,7 +7017,7 @@ class EDDGridFromDapTests {
     String tName =
         gridDataset.makeNewFileForDapQuery(
             language, null, null, mapDapQuery, obsDir, baseName, ".png");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
     // some color backgrounds have a problem
@@ -6973,7 +7028,7 @@ class EDDGridFromDapTests {
     tName =
         gridDataset.makeNewFileForDapQuery(
             language, null, null, mapDapQuery, obsDir, baseName, ".png");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
     String2.log("\nANTIALIASING PROBLEM SOLVED ITSELF 2018-06-20");
@@ -6987,7 +7042,7 @@ class EDDGridFromDapTests {
     // testVerboseOn();
     int language = 0;
     EDDGrid gridDataset = (EDDGrid) EDDTestDataset.geterdBAssta5day();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results = "shouldn't be this", expected;
     int po;
 
@@ -7212,7 +7267,7 @@ class EDDGridFromDapTests {
   void testValidMinMax() throws Throwable {
     // String2.log("\n\n*** EDDGridFromDap.testValidMinMax");
     String results, expected, tName, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     int language = 0;
 
     // ncdump of source file
@@ -7232,10 +7287,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_vmm",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "  sea_surface_temperature {\n"
             + "    Float32 _FillValue -327.68;\n"
@@ -7823,10 +7878,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_gdx4",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  Float64 time[time = 1975];\n"
@@ -7953,10 +8008,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_gdx4",
             ".nccsvMetadata");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     results =
         results.replaceAll("20\\d{2}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z http", "[DATE_TIME] http");
     results =
@@ -8925,10 +8980,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "UInt16",
             ".dds");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     results = results.replaceAll("time = \\d{3,4}", "time = ###");
     expected =
         "Dataset {\n"
@@ -8964,10 +9019,10 @@ class EDDGridFromDapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "UInt16",
             ".das");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     results = results.replaceAll("\\d{8}_\\d{8}", "[DATE_DATE]");
     results =
         results.replaceAll(
@@ -9427,10 +9482,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "uint16",
               ".nccsvMetadata");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       results =
           results.replaceAll(
               "(2019\\-12\\-17|2022\\-03\\-23)", // flips between 2019-12-17 and
@@ -9607,10 +9662,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "uint16",
               ".das");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       results =
           results.replaceAll("2\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z http", "[TODAY] http");
       results = results.replaceAll("20\\d{6}", "[DATE]");
@@ -9783,10 +9838,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "uint16",
               ".dds");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       results = results.replaceAll("\\[time = \\d*\\]", "[time = [N_TIME]]");
       expected = // difference from testUInt16File: lat lon are double here, not float
           "Dataset {\n"
@@ -9822,10 +9877,10 @@ class EDDGridFromDapTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "uint16",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       String2.log(results);
       expected =
           // ugly lat and lon values (clearly float -> double)
@@ -9862,10 +9917,10 @@ class EDDGridFromDapTests {
               null,
               null,
               "qual_sst4[0][][]",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddGrid.className() + "uint16",
               ".png");
-      Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
 
     } catch (Throwable t) {
       Test.knownProblem(
@@ -9918,10 +9973,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "scale1offset0",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected = // source is byte, with double scale_factor=1 and add_offset=0
         "Dataset {\n"
@@ -9949,10 +10004,10 @@ class EDDGridFromDapTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "scale1offset0",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     expected = // source is byte, with double scale_factor=1 and add_offset=0
         "  data:\n"
             + "    time = \n"
@@ -10809,7 +10864,7 @@ class EDDGridFromDapTests {
     // String2.log("\n*** EDDGridFromDap.testActualRange");
     int language = 0;
     // testVerboseOn();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
 
     EDDGrid edd = (EDDGrid) EDDTestDataset.gettestActualRange();
@@ -11142,7 +11197,7 @@ class EDDGridFromDapTests {
     // String2.log("\n*** EDDGridFromDap.testActualRange2");
     int language = 0;
     // testVerboseOn();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
 
     EDDGrid edd = (EDDGrid) EDDTestDataset.gettestActualRange2();
@@ -11340,7 +11395,7 @@ class EDDGridFromDapTests {
     String partName = which + "_" + Calendar2.getCompactCurrentISODateTimeStringLocal();
 
     EDDGridFromDap.generateDatasetsXmlFromThreddsCatalog(
-        EDStatic.fullLogsDirectory + "UAFdatasets" + partName + ".xml",
+        EDStatic.config.fullLogsDirectory + "UAFdatasets" + partName + ".xml",
         EDDGridFromDap.UAFSubThreddsCatalogs[which],
         ".*",
         ".*", // pathRegex

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTableTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromEDDTableTests.java
@@ -215,7 +215,7 @@ class EDDGridFromEDDTableTests {
     // String2.log("\n*** EDDGridFromEDDTable.testBasic\n");
     // testVerboseOn();
     String tName, results, expected;
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
     int po;
     int language = 0;
     EDDGrid edd = (EDDGrid) EDDTestDataset.gettestGridFromTable();

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopoTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromEtopoTests.java
@@ -46,10 +46,10 @@ class EDDGridFromEtopoTests {
             null,
             null,
             "altitude[(-90):500:(90)][(-180):500:(180)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             data180.className() + "_Entire",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     expected =
         // " latitude = 11;\n" + // (has coord.var)\n" + //changed when switched to
         // netcdf-java 4.0, 2009-02-23
@@ -187,10 +187,10 @@ class EDDGridFromEtopoTests {
             null,
             null,
             "altitude[(-90):2000:(90)][(0):2000:(360)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             data360.className() + "_Entire",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "latitude,longitude,altitude\n"
             + "degrees_north,degrees_east,m\n"
@@ -268,10 +268,10 @@ class EDDGridFromEtopoTests {
             null,
             null,
             "altitude[(-90):2000:(90)][(0):2000:(360)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             data360.className() + "_timeGaps",
             ".timeGaps");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "Time gaps: (none, because there is no time axis variable)\n" + "nGaps=0\n";
     Test.ensureEqual(results, expected, "RESULTS=\n" + results);
 
@@ -288,14 +288,14 @@ class EDDGridFromEtopoTests {
               obsDir,
               baseName,
               ".png");
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
       baseName = data360.className() + "_Map360";
       tName =
           data360.makeNewFileForDapQuery(
               language, null, null, "altitude[(-90):(90)][(0):(360)]", obsDir, baseName, ".png");
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
       baseName = data360.className() + "_TopoUnder";
@@ -309,7 +309,7 @@ class EDDGridFromEtopoTests {
               obsDir,
               baseName,
               ".png");
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
       // same data subset. Is cached file used?
@@ -324,7 +324,7 @@ class EDDGridFromEtopoTests {
               obsDir,
               baseName,
               ".png");
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
       Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
     }
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromMergeIRFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromMergeIRFilesTests.java
@@ -182,7 +182,7 @@ class EDDGridFromMergeIRFilesTests {
     EDDGrid edd = (EDDGrid) EDDTestDataset.getmergeIR();
     EDDGrid eddZ = (EDDGrid) EDDTestDataset.getmergeIRZ();
     EDDGrid eddgz = (EDDGrid) EDDTestDataset.getmergeIRgz();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected, dapQuery;
     int po;
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesTests.java
@@ -44,12 +44,12 @@ class EDDGridFromNcFilesTests {
   @BeforeAll
   static void init() {
     Initialization.edStatic();
-    initialUpdateRss = EDStatic.updateSubsRssOnFileChanges;
+    initialUpdateRss = EDStatic.config.updateSubsRssOnFileChanges;
   }
 
   @AfterEach
   void cleanup() {
-    EDStatic.updateSubsRssOnFileChanges = initialUpdateRss;
+    EDStatic.config.updateSubsRssOnFileChanges = initialUpdateRss;
   }
 
   /** This prints time, lat, and lon values from an .ncml dataset. */
@@ -223,10 +223,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_nccsvMeta",
             ".nccsvMetadata");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "*GLOBAL*,Conventions,\"COARDS, CF-1.6, ACDD-1.3, NCCSV-1.2\"\n"
@@ -368,10 +368,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_nccsvAxis",
             ".nccsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "*GLOBAL*,Conventions,\"COARDS, CF-1.6, ACDD-1.3, NCCSV-1.2\"\n"
@@ -485,10 +485,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_nccsvData",
             ".nccsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "*GLOBAL*,Conventions,\"COARDS, CF-1.6, ACDD-1.3, NCCSV-1.2\"\n"
@@ -681,10 +681,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -850,10 +850,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -900,10 +900,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -935,10 +935,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csvp");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -956,10 +956,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv0");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = csvExpected;
     // verified with
@@ -975,10 +975,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -999,10 +999,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".tsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -1035,10 +1035,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".tsvp");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // verified with
@@ -1056,10 +1056,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".tsv0");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = tsvExpected;
     // verified with
@@ -1206,10 +1206,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // 2020-10-02 lots of small changes to source metadata
         "Attributes {\n"
@@ -1360,10 +1360,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -1390,10 +1390,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         /*
@@ -1512,10 +1512,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -1691,10 +1691,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_privateAwsS3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // note that the dataset in erddap has altitude manually adjusted to be 10m.
@@ -1750,10 +1750,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_CwHdfEntire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -1804,9 +1804,9 @@ class EDDGridFromNcFilesTests {
             + "    String autonav_performed \"true\";\n"
             + "    Int32 autonav_quality 2;\n"
             + "    String cdm_data_type \"Grid\";\n"
-            + (EDStatic.useSaxParser ? "    Int32 cols 1140;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Int32 cols 1140;\n" : "")
             + "    String Conventions \"COARDS, CF-1.6, ACDD-1.3\";\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    String cwhdf_version \"3.4\";\n"
                     + "    Float64 et_affine 0.0, -1470.0, 1470.0, 0.0, -9778346.500515733, 4398734.085407009;\n"
                     + "    Int32 gctp_datum 12;\n"
@@ -1837,20 +1837,20 @@ class EDDGridFromNcFilesTests {
             + "particular purpose, or assumes any legal liability for the accuracy,\n"
             + "completeness, or usefulness, of this information.\";\n"
             + "    String origin \"USDOC/NOAA/NESDIS CoastWatch\";\n"
-            + (EDStatic.useSaxParser ? "    Int32 pass_date 13990;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Int32 pass_date 13990;\n" : "")
             + "    String pass_type \"day\";\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    Float64 polygon_latitude 36.89432948408865, 36.89432948408865, 36.89432948408865, 36.89432948408865, 36.89432948408865, 33.51643401115052, 29.999999999936534, 26.35308766180611, 22.586165505358508, 22.586165505358508, 22.586165505358508, 22.586165505358508, 22.586165505358508, 26.35308766180611, 29.999999999936534, 33.51643401115052, 36.89432948408865;\n"
                     + "    Float64 polygon_longitude -87.8403811482992, -84.08019057414958, -80.32000000000001, -76.5598094258504, -72.79961885170081, -72.79961885170081, -72.79961885170081, -72.79961885170081, -72.79961885170081, -76.5598094258504, -80.32000000000001, -84.08019057414958, -87.8403811482992, -87.8403811482992, -87.8403811482992, -87.8403811482992, -87.8403811482992;\n"
                 : "")
             + "    String projection \"Mercator\";\n"
             + "    String projection_type \"mapped\";\n"
-            + (EDStatic.useSaxParser ? "    Int32 rows 1248;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Int32 rows 1248;\n" : "")
             + "    String satellite \"noaa-18\";\n"
             + "    String sensor \"avhrr\";\n"
             + "    String sourceUrl \"(local files)\";\n"
             + "    String standard_name_vocabulary \"CF Standard Name Table v70\";\n"
-            + (EDStatic.useSaxParser ? "    Float64 start_time 65502.0;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Float64 start_time 65502.0;\n" : "")
             + "    String summary \"???\";\n"
             + "    String title \"Test of CoastWatch HDF files\";\n"
             + "  }\n"
@@ -1869,10 +1869,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_CwHdfEntire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -1904,10 +1904,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_CwHdfData1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "rows,cols,sst\n"
@@ -4835,10 +4835,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroupsA_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -4967,10 +4967,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroupsA_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -4999,10 +4999,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroupsA_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "axis0,axis1,axis2,axis3,Aquarius_Flags_rad_rfi_flags\n"
@@ -5318,10 +5318,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -5517,10 +5517,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -5587,10 +5587,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Navigation_axis0,Navigation_axis1,Navigation_axis2,Aquarius_Flags_radiometer_flags,Block_Attributes_rad_samples,Navigation_cellatfoot,Navigation_cellonfoot,Navigation_scat_latfoot,Navigation_scat_lonfoot\n"
@@ -5837,10 +5837,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -5962,10 +5962,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -6018,10 +6018,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,Synthetic_032_1_Y_Depth_Averaged_Velocity,Synthetic_032_1_Y_Wind_Velocity,Synthetic_032_1_Water_Elevation,Synthetic_032_1_X_Depth_Averaged_Velocity,Synthetic_032_1_X_Wind_Velocity,Synthetic_032_1_Atmospheric_Pressure\n"
@@ -6270,10 +6270,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -6392,10 +6392,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -6448,10 +6448,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_testGroups2_Data1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,Synthetic_035_3_X_Depth_Averaged_Velocity,Synthetic_035_3_X_Wind_Velocity,Synthetic_035_3_Y_Depth_Averaged_Velocity,Synthetic_035_3_Y_Wind_Velocity,Synthetic_035_3_Water_Elevation,Synthetic_035_3_Atmospheric_Pressure\n"
@@ -6670,10 +6670,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "VHMAX[(2019-07-03T00:00:00Z):1:(2019-07-03T00:00:00Z)][(25):1:(25.01)][(52):1:(52.01)]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_TestLong2Grid",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time,latitude,longitude,VHMAX\n"
             + "UTC,degrees_north,degrees_east,m\n"
@@ -6716,10 +6716,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_42",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -6867,10 +6867,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_42",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -6899,10 +6899,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribData1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,height_above_ground,latitude,longitude,wind_speed\n"
@@ -6972,10 +6972,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_42",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -7397,10 +7397,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_42",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -7523,10 +7523,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribData1_42",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,Wind_speed\n"
@@ -7613,10 +7613,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_43",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // 2013-09-03 The details of the GRIB attributes change frequently!
         "Attributes {\n"
@@ -7766,10 +7766,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_43",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -7798,10 +7798,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribData1_43",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,height_above_ground,latitude,longitude,wind_speed\n"
@@ -7850,10 +7850,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_43",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -8213,10 +8213,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribEntire_43",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -8339,10 +8339,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_GribData1_43",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,Wind_speed_surface\n"
@@ -8782,7 +8782,7 @@ class EDDGridFromNcFilesTests {
     // The SAX parser doesn't throw errors during dataset construction to this level.
     // Even during the parse one logic. So just make sure we didn't get a dataset back.
     // TODO maybe check explicitly for that error somehow?
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(eddGrid, null, "Dataset should be null from exception during construction.");
     } else {
       Test.ensureEqual(
@@ -8811,7 +8811,7 @@ class EDDGridFromNcFilesTests {
     // The SAX parser doesn't throw errors during dataset construction to this level.
     // Even during the parse one logic. So just make sure we didn't get a dataset back.
     // TODO maybe check explicitly for that error somehow?
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(eddGrid, null, "Dataset should be null from exception during construction.");
     } else {
       Test.ensureTrue(
@@ -8843,7 +8843,7 @@ class EDDGridFromNcFilesTests {
     // The SAX parser doesn't throw errors during dataset construction to this level.
     // Even during the parse one logic. So just make sure we didn't get a dataset back.
     // TODO maybe check explicitly for that error somehow?
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(eddGrid, null, "Dataset should be null from exception during construction.");
     } else {
       Test.ensureTrue(
@@ -8872,7 +8872,7 @@ class EDDGridFromNcFilesTests {
     // The SAX parser doesn't throw errors during dataset construction to this level.
     // Even during the parse one logic. So just make sure we didn't get a dataset back.
     // TODO maybe check explicitly for that error somehow?
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(eddGrid, null, "Dataset should be null from exception during construction.");
     } else {
       Test.ensureTrue(
@@ -8892,7 +8892,7 @@ class EDDGridFromNcFilesTests {
   void testTimePrecisionMillis() throws Throwable {
     String2.log("\n*** EDDGridFromNcFiles.testTimePrecisionMillis()\n");
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestTimePrecisionMillis();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String aq = "[(1984-02-01T12:00:59.001Z):1:(1984-02-01T12:00:59.401Z)]";
     String userDapQuery = "ECEF_X" + aq + ",IB_time" + aq;
     String fName = "testTimePrecisionMillis";
@@ -9165,7 +9165,7 @@ class EDDGridFromNcFilesTests {
   void testSimpleTestNc() throws Throwable {
     String2.log("\n*** EDDGridFromNcFiles.testSimpleTestNc()\n");
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestSimpleTestNc();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String obsDir = Image2Tests.urlToAbsolutePath(Image2Tests.OBS_DIR);
     String userDapQuery =
         "hours[1:2],minutes[1:2],seconds[1:2],millis[1:2],bytes[1:2],"
@@ -9630,7 +9630,7 @@ class EDDGridFromNcFilesTests {
             ".png");
     // Test.displayInBrowser("file://" + tDir + tName); //Known problem, so don't
     // switch to testImagesIdentical
-    // String tDir = EDStatic.fullTestCacheDirectory;
+    // String tDir = EDStatic.config.fullTestCacheDirectory;
     Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
 
     // Test.knownProblem("SgtGraph DOESN'T SUPPORT TWO TIME AXES !!!!",
@@ -9648,7 +9648,7 @@ class EDDGridFromNcFilesTests {
   void testSimpleTestNc2() throws Throwable {
     String2.log("\n*** EDDGridFromNcFiles.testSimpleTestNc2()\n");
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestSimpleTestNc();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String userDapQuery = "bytes[2:3],doubles[2:3],Strings[2:3]";
     String fName = "testSimpleTestNc2";
     String tName, results, ts, expected;
@@ -10137,10 +10137,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_trtf",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -10266,10 +10266,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_trtf",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -10305,10 +10305,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className() + "_trtf",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,sss\n"
@@ -10359,7 +10359,7 @@ class EDDGridFromNcFilesTests {
     // load dataset
     // testVerboseOn();
     String tName, results, expected;
-    String cDir = EDStatic.fullTestCacheDirectory;
+    String cDir = EDStatic.config.fullTestCacheDirectory;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.geterdATssta3day();
     Table table;
     PrimitiveArray pa1, pa2;
@@ -10369,7 +10369,7 @@ class EDDGridFromNcFilesTests {
     tName =
         eddGrid.makeNewFileForDapQuery(
             language, null, null, "time", cDir, eddGrid.className() + "_tmnd0", ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "time\n" + "UTC\n" + "2004-02-18T12:00:00Z\n" + "2004-03-20T12:00:00Z\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -10830,8 +10830,14 @@ class EDDGridFromNcFilesTests {
     // .das das isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".das");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".das");
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected =
         "Attributes {\n"
             + "  time {\n"
@@ -10953,8 +10959,14 @@ class EDDGridFromNcFilesTests {
     // .dds dds isn't affected by userDapQuery
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // difference from testUInt16Dap: lat lon are float here, not double
         "Dataset {\n"
             + "  Float64 time[time = 1];\n"
@@ -10988,10 +11000,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected = // difference from testUInt16Dap: lat lon are float here, not double
         "time,latitude,longitude,sst,sst_quality\n"
@@ -11033,10 +11045,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     String2.log(results);
     expected = // difference from testUInt16Dap: lat lon are float here, not double
         "netcdf EDDGridFromNcFiles.nc {\n"
@@ -11226,7 +11238,7 @@ class EDDGridFromNcFilesTests {
             Image2Tests.urlToAbsolutePath(Image2Tests.OBS_DIR),
             baseName,
             ".png");
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     Image2Tests.testImagesIdentical(tName, baseName + ".png", baseName + "_diff.png");
   }
 
@@ -11241,7 +11253,7 @@ class EDDGridFromNcFilesTests {
     String tName, results, tResults, expected, userDapQuery;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.geterdSW1chlamday();
     String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String testName = "EDDGridFromNcFiles_Axis0Time";
     int language = 0;
 
@@ -11485,7 +11497,7 @@ class EDDGridFromNcFilesTests {
     String tName, results, tResults, expected, userDapQuery;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestSpecialAxis0FileNameInt();
     String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String testName = "EDDGridFromNcFiles_Axis0FileNameInt";
     int language = 0;
 
@@ -11711,7 +11723,7 @@ class EDDGridFromNcFilesTests {
     String tName, results, tResults, expected, userDapQuery;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestSpecialAxis0PathNameInt();
     String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String testName = "EDDGridFromNcFiles_Axis0PathNameInt";
     int language = 0;
 
@@ -11943,7 +11955,7 @@ class EDDGridFromNcFilesTests {
     String id = "testSpecialAxis0GlobalDouble";
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestSpecialAxis0GlobalDouble();
     String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String testName = "EDDGridFromNcFiles_Axis0GlobalDouble";
 
     // *** test getting das for entire dataset
@@ -12165,7 +12177,7 @@ class EDDGridFromNcFilesTests {
 
     String tName, results, tResults, expected, userDapQuery;
 
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String id = "erdMH1chlamday";
     if (deleteCachedDatasetInfo) EDD.deleteCachedDatasetInfo(id);
 
@@ -12388,7 +12400,7 @@ class EDDGridFromNcFilesTests {
 
     String tName, results, tResults, expected, userDapQuery;
 
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String id = "nceiPH53sstd1day";
     if (deleteCachedDatasetInfo) EDD.deleteCachedDatasetInfo(id);
 
@@ -13161,10 +13173,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery, // DataType=ubyte
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".asc");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  GRID {\n"
@@ -13193,10 +13205,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery, // DataType=ubyte
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "rgb,eightbitcolor,palette\n"
             + "count,count,\n"
@@ -13217,10 +13229,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     results = results.replaceAll("2\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z ", "[TODAY] ");
     expected =
         "Attributes {\n"
@@ -13293,10 +13305,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  GRID {\n"
@@ -13318,10 +13330,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".htmlTable");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<table class=\"erd commonBGColor nowrap\">\n"
             + "<tr>\n"
@@ -13376,10 +13388,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".itx");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     results = String2.replaceAll(results, '\r', '\n');
     expected =
         "IGOR\n"
@@ -13424,10 +13436,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".json");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\n"
             + "  \"table\": {\n"
@@ -13455,10 +13467,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".jsonlCSV1");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "[\"rgb\", \"eightbitcolor\", \"palette\"]\n"
             + "[0, 146, 252]\n"
@@ -13476,10 +13488,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".jsonlKVP");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\"rgb\":0, \"eightbitcolor\":146, \"palette\":252}\n"
             + "{\"rgb\":0, \"eightbitcolor\":147, \"palette\":0}\n"
@@ -13496,10 +13508,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".nccsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     results = results.replaceAll("2\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z ", "[TODAY] ");
     expected =
         "*GLOBAL*,Conventions,\"CF-1.6, COARDS, ACDD-1.3, NCCSV-1.2\"\n"
@@ -13572,10 +13584,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".ncml");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
             + "<netcdf xmlns=\"https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" location=\"http://localhost:8080/griddap/testUnsignedGrid\">\n"
@@ -13647,10 +13659,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".tsv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "rgb\teightbitcolor\tpalette\n"
             + "count\tcount\t\n"
@@ -13669,10 +13681,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testUnsignedGrid",
             ".xhtml");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "<table class=\"erd commonBGColor nowrap\">\n"
             + "<tr>\n"
@@ -13739,7 +13751,7 @@ class EDDGridFromNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestGridNThreads();
     StringBuilder bigResults = new StringBuilder("\nEDDGridFromNcFiles.testNThreads finished.\n");
 
@@ -13811,10 +13823,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testStructure",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "axis0,ArrayOfStructures_a_name,ArrayOfStructures_c_name,ArrayOfStructures_b_name\n"
             + "count,,,\n"
@@ -13837,10 +13849,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "ArrayOfStructures_b_name[4:2:8]",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testStructure_b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "axis0,ArrayOfStructures_b_name\n" + "count,\n" + "4,16.0\n" + "6,36.0\n" + "8,64.0\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
@@ -13852,10 +13864,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testStructure",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     results = results.replaceAll("2\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z ", "[TODAY] ");
     expected =
         "Attributes {\n"
@@ -13908,10 +13920,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_testStructure",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  Int32 axis0[axis0 = 10];\n"
@@ -13961,10 +13973,10 @@ class EDDGridFromNcFilesTests {
         null,
         null,
         "",
-        EDStatic.fullTestCacheDirectory,
+        EDStatic.config.fullTestCacheDirectory,
         edd.className() + "_testStructurePrivate",
         ".das");
-    // String2.log(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+    // String2.log(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
     // tName));
     // String2.pressEnterToContinue(
     // "EDDGridFromNcFiles.testStructurePrivate()\n" +
@@ -13976,10 +13988,10 @@ class EDDGridFromNcFilesTests {
         null,
         null,
         "",
-        EDStatic.fullTestCacheDirectory,
+        EDStatic.config.fullTestCacheDirectory,
         edd.className() + "_testStructurePrivate",
         ".dds");
-    // String2.log(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+    // String2.log(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
     // tName));
     // String2.pressEnterToContinue(
     // "EDDGridFromNcFiles.testStructurePrivate()\n" +
@@ -13991,10 +14003,10 @@ class EDDGridFromNcFilesTests {
         null,
         null,
         "Yaw[0:500:3500],latitude[0:500:3500],longitude[0:500:3500]",
-        EDStatic.fullTestCacheDirectory,
+        EDStatic.config.fullTestCacheDirectory,
         edd.className() + "_testStructurePrivate",
         ".csv");
-    // String2.log(File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+    // String2.log(File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
     // tName));
     // String2.pressEnterToContinue(
     // "EDDGridFromNcFiles.testStructurePrivate()\n" +
@@ -14067,13 +14079,13 @@ class EDDGridFromNcFilesTests {
     String datasetId = "testGriddedNcFiles";
     EDDGridFromNcFiles eddGrid = (EDDGridFromNcFiles) EDDTestDataset.gettestGriddedNcFiles();
     String dataDir = eddGrid.fileDir;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String axisQuery = "time[]";
     String dataQuery = "x_wind[][][100][100]";
     String tName, results, expected;
     int language = 0;
     // This is set back to the initial value in the @After for the class.
-    EDStatic.updateSubsRssOnFileChanges = allowRssUpdates;
+    EDStatic.config.updateSubsRssOnFileChanges = allowRssUpdates;
     Erddap.rssHashMap.remove(datasetId);
 
     // *** read the original data
@@ -14468,7 +14480,7 @@ class EDDGridFromNcFilesTests {
 
     EDDGridFromNcFiles eddGrid = (EDDGridFromNcFiles) EDDTestDataset.gettestGriddedNcFiles();
     String dataDir = eddGrid.fileDir;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String axisQuery = "time[]";
     String dataQuery = "x_wind[][][100][100]";
     String tName, results, expected;
@@ -14899,9 +14911,9 @@ class EDDGridFromNcFilesTests {
      * //*** test getting das for entire dataset
      * String2.log("\n*** testCwHdf test das dds for entire dataset\n");
      * tName = eddGrid.makeNewFileForDapQuery(language, null, null, "",
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * eddGrid.className() + "_CwHdfEntire", ".das");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * //String2.log(results);
      * expected =
@@ -14998,9 +15010,9 @@ class EDDGridFromNcFilesTests {
      *
      * //*** test getting dds for entire dataset
      * tName = eddGrid.makeNewFileForDapQuery(language, null, null, "",
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * eddGrid.className() + "_CwHdfEntire", ".dds");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * //String2.log(results);
      * expected =
@@ -15029,9 +15041,9 @@ class EDDGridFromNcFilesTests {
      * String2.log("\n*** testCwHdf test read from one file\n");
      * userDapQuery = "sst[600:2:606][500:503]";
      * tName = eddGrid.makeNewFileForDapQuery(language, null, null, userDapQuery,
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * eddGrid.className() + "_CwHdfData1", ".csv");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * //String2.log(results);
      * expected =
@@ -15070,7 +15082,7 @@ class EDDGridFromNcFilesTests {
     // String2.log("\n*** EDDGridFromNcFiles.testIgor()\n");
     // testVerboseOn();
     String tName, results, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int po;
     int language = 0;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getjplMURSST41();
@@ -15422,7 +15434,7 @@ class EDDGridFromNcFilesTests {
     // String id = "testGroups";
     // EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestGroups();
     // String today = Calendar2.getCurrentISODateTimeStringZulu().substring(0, 10);
-    // String tDir = EDStatic.fullTestCacheDirectory;
+    // String tDir = EDStatic.config.fullTestCacheDirectory;
     // String testName = "EDDGridFromNcFiles_groups";
   }
 
@@ -15479,7 +15491,7 @@ class EDDGridFromNcFilesTests {
       // request status.html
       SSR.getUrlResponseStringUnchanged(EDStatic.erddapUrl + "/status.html");
       // Math2.sleep(1000);
-      // Test.displayInBrowser("file://" + EDStatic.bigParentDirectory +
+      // Test.displayInBrowser("file://" + EDStatic.config.bigParentDirectory +
       // "logs/log.txt");
 
       // String2.pressEnterToContinue(
@@ -15522,9 +15534,9 @@ class EDDGridFromNcFilesTests {
             + fileType
             + ")"
             + "\n  partialRequestMaxBytes="
-            + EDStatic.partialRequestMaxBytes
+            + EDStatic.config.partialRequestMaxBytes
             + " estimated nPartialRequests="
-            + Math2.hiDiv(nTimePoints * 4320 * 8640, EDStatic.partialRequestMaxBytes)
+            + Math2.hiDiv(nTimePoints * 4320 * 8640, EDStatic.config.partialRequestMaxBytes)
             + "\n  expected size="
             + expectedBytes
             + "  expected time~="
@@ -15535,7 +15547,7 @@ class EDDGridFromNcFilesTests {
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getnceiPH53sstd1day();
     String query = "sea_surface_temperature[0:" + (nTimePoints - 1) + "][][]";
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName;
 
     // tName = eddGrid.makeNewFileForDapQuery(language, null, null, query,
@@ -15970,7 +15982,7 @@ class EDDGridFromNcFilesTests {
     int language = 0;
 
     String tName, results, tResults, expected, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String id = "testEDDGridCopyFiles";
     if (deleteDataFiles) {
       File2.deleteAllFiles("/u00/data/points/testEDDGridCopyFiles/", true, true);
@@ -16210,7 +16222,7 @@ class EDDGridFromNcFilesTests {
   void testCacheFiles(boolean deleteDataFiles) throws Throwable {
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String id = "testEDDGridCacheFiles";
     EDDGridFromNcFiles.deleteCachedDatasetInfo(id); // always
     if (deleteDataFiles)
@@ -16467,7 +16479,7 @@ class EDDGridFromNcFilesTests {
 
     String tName, results, tResults, expected, userDapQuery;
 
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String id = "testMinimalReadSource";
     EDDGridFromNcFiles.deleteCachedDatasetInfo(id); // always
 
@@ -16933,7 +16945,7 @@ class EDDGridFromNcFilesTests {
   void testIslandShift() throws Throwable {
     int language = 0;
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestIslandShift();
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
 
     for (int i = 1; i <= 4; i++) {
       String baseName = "EDDGridFromNcFiles_testIslandShift_" + SgtMap.drawLandMask_OPTIONS.get(i);
@@ -16968,10 +16980,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             zarrGrid.className() + "_Compressed",
             ".das");
-    String results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String expected =
         "Attributes {\n"
             + //
@@ -17171,10 +17183,10 @@ class EDDGridFromNcFilesTests {
             null,
             null,
             "null_compressor%5B0:1:0%5D%5B0:1:199%5D,comp_filt_Adler_shuffle_deflate%5B0:1:0%5D%5B0:1:199%5D,comp_filt_shuffle_deflate%5B0:1:0%5D%5B0:1:199%5D,compressed_adler32%5B0:1:0%5D%5B0:1:199%5D,compressed_crc32%5B0:1:0%5D%5B0:1:199%5D,compressed_deflate1%5B0:1:0%5D%5B0:1:199%5D,compressed_deflate9%5B0:1:0%5D%5B0:1:199%5D,compressed_scaleOffset%5B0:1:0%5D%5B0:1:199%5D,compressed_shuffle%5B0:1:0%5D%5B0:1:199%5D,filtered_adler32%5B0:1:0%5D%5B0:1:199%5D,filtered_adler_shuffle%5B0:1:0%5D%5B0:1:199%5D",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             zarrGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "dim0,dim1,null_compressor,comp_filt_Adler_shuffle_deflate,comp_filt_shuffle_deflate,compressed_adler32,compressed_crc32,compressed_deflate1,compressed_deflate9,compressed_scaleOffset,compressed_shuffle,filtered_adler32,filtered_adler_shuffle\n"
             + //

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesUnpackedTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromNcFilesUnpackedTests.java
@@ -378,8 +378,14 @@ class EDDGridFromNcFilesUnpackedTests {
     String2.log("\n*** test das dds for entire dataset\n");
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".das");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -492,8 +498,14 @@ class EDDGridFromNcFilesUnpackedTests {
     // *** test getting dds for entire dataset
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, eddGrid.className(), ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            eddGrid.className(),
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -520,10 +532,10 @@ class EDDGridFromNcFilesUnpackedTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,analysed_sst\n"
@@ -573,7 +585,7 @@ class EDDGridFromNcFilesUnpackedTests {
     NcHelper.debugMode = true;
     boolean oAttDebugMode = Attributes.debugMode;
     Attributes.debugMode = true;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
 
     // DumpString
     results = NcHelper.ncdump(fileDir + fileName, "-h");
@@ -1190,7 +1202,7 @@ class EDDGridFromNcFilesUnpackedTests {
         Path.of(EDDGridFromNcFilesUnpackedTests.class.getResource("/largeFiles/nc/").toURI())
                 .toString()
             + "/";
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     boolean oDebugMode = NcHelper.debugMode;
     NcHelper.debugMode = true;
 
@@ -1524,7 +1536,7 @@ class EDDGridFromNcFilesUnpackedTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     String fileDir =
         Path.of(EDDGridFromNcFilesUnpackedTests.class.getResource("/data/unpacked/").toURI())
                 .toString()

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridLon0360Tests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridLon0360Tests.java
@@ -33,7 +33,7 @@ class EDDGridLon0360Tests {
     int language = 0;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettest_nesdisVHNchlaWeekly_Lon0360();
     /* */
@@ -398,7 +398,7 @@ class EDDGridLon0360Tests {
     int language = 0;
     String tName, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getecocast_Lon0360();
     tName =
@@ -448,7 +448,7 @@ class EDDGridLon0360Tests {
     int language = 0;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettest_etopo180_Lon0360();
 
@@ -697,7 +697,7 @@ class EDDGridLon0360Tests {
     // debugMode = true;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     EDDGrid eddGrid;
 
     // test notApplicable (dataset maxLon already <180)

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180Tests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridLonPM180Tests.java
@@ -36,7 +36,7 @@ class EDDGridLonPM180Tests {
     // testVerboseOn();
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int language = 0;
 
     EDDGrid eddGrid =
@@ -213,7 +213,7 @@ class EDDGridLonPM180Tests {
     int language = 0;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.geterdRWdhws1day_LonPM180();
 
@@ -416,7 +416,7 @@ class EDDGridLonPM180Tests {
     int language = 0;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettest_erdMHsstnmday_LonPM180();
 
@@ -652,7 +652,7 @@ class EDDGridLonPM180Tests {
     String results, expected;
 
     // set badFileFlag (to delete the badFiles.nc file and reload the dataset)
-    File2.writeToFile88591(EDStatic.fullBadFilesFlagDirectory + datasetID, "doesn't matter");
+    File2.writeToFile88591(EDStatic.config.fullBadFilesFlagDirectory + datasetID, "doesn't matter");
 
     // wait 10 seconds and test that all times are present
     String2.log(
@@ -675,7 +675,7 @@ class EDDGridLonPM180Tests {
         dirIndex, fileName, lastMod, "for EDDGridLonPM180.testBadFilesFlag()");
 
     // set regular flag
-    File2.writeToFile88591(EDStatic.fullResetFlagDirectory + datasetID, "doesn't matter");
+    File2.writeToFile88591(EDStatic.config.fullResetFlagDirectory + datasetID, "doesn't matter");
 
     // wait 10 seconds and test that that time point is gone
     String2.log(
@@ -686,7 +686,7 @@ class EDDGridLonPM180Tests {
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // set badFileFlag (to delete the badFiles.nc file and reload the dataset)
-    File2.writeToFile88591(EDStatic.fullBadFilesFlagDirectory + datasetID, "doesn't matter");
+    File2.writeToFile88591(EDStatic.config.fullBadFilesFlagDirectory + datasetID, "doesn't matter");
 
     // wait 10 seconds and test that all times are present
     String2.log(
@@ -709,7 +709,7 @@ class EDDGridLonPM180Tests {
     String startTime = Calendar2.getCurrentISODateTimeStringLocalTZ();
     Math2.sleep(1000);
     File2.writeToFile88591(
-        EDStatic.fullHardFlagDirectory + "hawaii_d90f_20ee_c4cb_LonPM180", "test");
+        EDStatic.config.fullHardFlagDirectory + "hawaii_d90f_20ee_c4cb_LonPM180", "test");
     String2.log(
         "I just set a hardFlag for hawaii_d90f_20ee_c4cb_LonPM180.\n"
             + "Now I'm waiting 10 seconds.");
@@ -719,7 +719,7 @@ class EDDGridLonPM180Tests {
         SSR.getUrlResponseStringUnchanged("http://localhost:8080/cwexperimental/status.html");
     Math2.sleep(2000);
     // read the log file
-    String tLog = File2.readFromFileUtf8(EDStatic.fullLogsDirectory + "log.txt")[1];
+    String tLog = File2.readFromFileUtf8(EDStatic.config.fullLogsDirectory + "log.txt")[1];
     String expected = // ***
         /*
          * "deleting cached dataset info for datasetID=hawaii_d90f_20ee_c4cb_LonPM180Child\n"
@@ -733,7 +733,7 @@ class EDDGridLonPM180Tests {
          * "\n" +
          * "\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\n"
          * +
-         * "LoadDatasets.run EDStatic.developmentMode=true ..........T..............\n"
+         * "LoadDatasets.run EDStatic.config.developmentMode=true ..........T..............\n"
          * +
          * "  datasetsRegex=\\(hawaii_d90f_20ee_c4cb_LonPM180\\) inputStream=null majorLoad=false"
          * ;
@@ -749,7 +749,7 @@ class EDDGridLonPM180Tests {
             + "\\*\\*\\* RunLoadDatasets is starting a new hardFlag LoadDatasets thread at (..........T..............)\n"
             + "\n"
             + "\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\n"
-            + "LoadDatasets.run EDStatic.developmentMode=true ..........T..............\n"
+            + "LoadDatasets.run EDStatic.config.developmentMode=true ..........T..............\n"
             + "  datasetsRegex=\\(hawaii_d90f_20ee_c4cb_LonPM180\\) inputStream=null majorLoad=false";
 
     int po = Math.max(0, tLog.lastIndexOf(expected.substring(0, 78)));
@@ -884,7 +884,7 @@ class EDDGridLonPM180Tests {
     int language = 0;
     String tName, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettestPM180LonValidMinMax();
     tName =

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridSideBySideTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridSideBySideTests.java
@@ -39,7 +39,7 @@ class EDDGridSideBySideTests {
     int language = 0;
     String tName, baseName, results, expected;
     String dapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
 
     // *** NDBC is also IMPORTANT UNIQUE TEST of >1 variable in a file
     EDDGrid qsWind8 = (EDDGrid) EDDTestDataset.geterdQSwind8day();
@@ -281,7 +281,7 @@ class EDDGridSideBySideTests {
     int language = 0;
     String tName, results, expected;
     String dapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     Test.ensureEqual(Calendar2.epochSecondsToIsoStringTZ(1.1306736E9), "2005-10-30T12:00:00Z", "");
 
     EDDGrid qs1 = (EDDGrid) EDDTestDataset.geterdQSstress1day();
@@ -394,9 +394,9 @@ class EDDGridSideBySideTests {
      * EDDGrid qsx1 = (EDDGrid)oneFromDatasetsXml(null, "erdQStaux1day");
      * dapQuery = "taux[(1.130328E9):(1.1309328E9)][0][(-20)][(40)]";
      * tName = qsx1.makeNewFileForDapQuery(language, null, null, dapQuery,
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * qsz1.className() + "sbsx", ".csv");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * //String2.log(results);
      * expected =
@@ -415,9 +415,9 @@ class EDDGridSideBySideTests {
      * EDDGrid qsy1 = (EDDGrid)oneFromDatasetsXml(null, "erdQStauy1day");
      * dapQuery = "tauy[(1.130328E9):(1.1309328E9)][0][(-20)][(40)]";
      * tName = qsy1.makeNewFileForDapQuery(language, null, null, dapQuery,
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * qsy1.className() + "sbsy", ".csv");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * //String2.log(results);
      * expected =
@@ -493,8 +493,14 @@ class EDDGridSideBySideTests {
         "analysed_sst_a[1][(10):100:(12)][(-20):100:(-18)],analysed_sst_b[1][(10):100:(12)][(-20):100:(-18)]";
     tName =
         eddGrid.makeNewFileForDapQuery(
-            language, null, null, dapQuery, EDStatic.fullTestCacheDirectory, "sbsDupNames", ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            dapQuery,
+            EDStatic.config.fullTestCacheDirectory,
+            "sbsDupNames",
+            ".csv");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // note that all _a and _b values are the same
         "time,latitude,longitude,analysed_sst_a,analysed_sst_b\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
@@ -240,7 +240,7 @@ class EDDGridTests {
             "testGeotif",
             ".geotif");
 
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     Image2Tests.testImagesIdentical(
         tName, "EDDGrid_testGeotif" + ".tif", "EDDGrid_testGeotif" + "_diff.png");
   }
@@ -662,7 +662,7 @@ class EDDGridTests {
    *
    * @param eddGrid EDDGrid that saveAsImage is called on.
    * @param dir Directory used for temporary/cache files.
-   * @param requestUrl The part of the user's request, after EDStatic.baseUrl, before '?'.
+   * @param requestUrl The part of the user's request, after EDStatic.config.baseUrl, before '?'.
    * @param userDapQuery An OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
    *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @param fileTypeName File type being requested (eg: .transparentPng)
@@ -789,7 +789,7 @@ class EDDGridTests {
 
     // *** check netcdf response
     String2.log("\n+++ GetCoverage\n" + wcsQuery1);
-    fileName = EDStatic.fullTestCacheDirectory + "testWcsBA_2.nc";
+    fileName = EDStatic.config.fullTestCacheDirectory + "testWcsBA_2.nc";
     String endOfRequest = "myEndOfRequest";
     eddGrid.wcsGetCoverage(
         0,
@@ -805,7 +805,7 @@ class EDDGridTests {
 
     // *** check png response
     String2.log("\n+++ GetCoverage\n" + wcsQuery1);
-    fileName = EDStatic.fullTestCacheDirectory + "testWcsBA_3.png";
+    fileName = EDStatic.config.fullTestCacheDirectory + "testWcsBA_3.png";
     eddGrid.wcsGetCoverage(
         0,
         "someIPAddress",
@@ -845,7 +845,7 @@ class EDDGridTests {
     EDDGrid gridDataset = (EDDGrid) EDDTestDataset.getetopo180();
     String tName;
     int language = 0;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
 
     // *** test getting graphs
     String2.log("\n****************** EDDGrid test get graphs\n");

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRowsTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableAggregateRowsTests.java
@@ -27,7 +27,7 @@ class EDDTableAggregateRowsTests {
     String results, query, tName, expected;
     // DasDds.main(new String[]{"miniNdbc410", "-verbose"});
     EDDTable tedd = (EDDTable) EDDTestDataset.getminiNdbc410();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int tPo;
     int language = 0;
 
@@ -418,7 +418,7 @@ class EDDTableAggregateRowsTests {
     String results, query, tName, expected;
     // DasDds.main(new String[]{"miniNdbc410", "-verbose"});
     EDDTable tedd = (EDDTable) EDDTestDataset.getTS_SLEV_TAD();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int tPo;
     int language = 0;
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableCopyTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableCopyTests.java
@@ -28,7 +28,7 @@ class EDDTableCopyTests {
     int language = 0;
 
     String tName, results, expected, expected2, expected3, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     int tPo;
     // String mapDapQuery = "longitude,latitude,NO3,time&latitude>0&time>=2002-08-03";
     userDapQuery = "longitude,NO3,time,ship&latitude%3E0&time%3E=2002-08-03";
@@ -566,10 +566,10 @@ class EDDTableCopyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -595,10 +595,10 @@ class EDDTableCopyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -621,10 +621,10 @@ class EDDTableCopyTests {
             null,
             null,
             "pi&distinct()",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet1Var",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String2.log(results);
     expected = "pi\n" + "\n" + "BARRY BEREJIKIAN\n" + "CEDAR CHITTENDEN\n";
     Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
@@ -641,10 +641,10 @@ class EDDTableCopyTests {
             null,
             null,
             "pi,common_name&distinct()",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet2var",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // this will change
         "pi,common_name\n"
             + ",\n"
@@ -684,10 +684,10 @@ class EDDTableCopyTests {
             null,
             null,
             "pi,common_name,surgery_id&distinct()",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet3var",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "pi,common_name,surgery_id\n" + ",,\n";
     Test.ensureEqual(results.substring(0, expected.length()), expected, "\nresults=\n" + results);
@@ -709,10 +709,10 @@ class EDDTableCopyTests {
             null,
             null,
             "&pi=\"BARRY BEREJIKIAN\"&common_name=\"STEELHEAD\"&surgery_id=2846",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_postDet1tag",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,time,common_name,pi,project,surgery_id,tag_id_code,tag_sn\n"
@@ -735,10 +735,10 @@ class EDDTableCopyTests {
             null,
             null,
             tQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_peb_constrained",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,time,common_name,pi,project,surgery_id,tag_id_code,tag_sn\n"
             + "degrees_east,degrees_north,UTC,,,,,,\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiFilesTests.java
@@ -61,10 +61,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -216,10 +216,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -249,10 +249,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,altitude,time,station,wd,wspd,atmp,wtmp\n"
@@ -277,10 +277,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     // same expected
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -293,10 +293,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,altitude,time,station,wd,wspd,atmp,wtmp\n"
@@ -315,10 +315,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_4",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,altitude,time,station,wd,wspd,atmp,wtmp\n"
@@ -336,10 +336,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_5",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,altitude,time,station,atmp,wtmp\n"
@@ -384,10 +384,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fv" + test,
               ".das");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected =
           "Attributes {\n"
               + " s {\n"
@@ -509,10 +509,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "&time<2013-04-05T17",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fva" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected =
           "ship_call_sign,time,latitude,longitude0360,longitude,seaTemperature,seaTemperatureF\n"
               + ",UTC,degrees_north,degrees_east,degrees_east,degree_C,degree_F\n"
@@ -529,10 +529,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "ship_call_sign&ship_call_sign!=\"zztop\"",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fvb" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected = "ship_call_sign\n" + "\n" + "WTDL\n";
       Test.ensureEqual(results, expected, "test=" + test + " results=\n" + results);
 
@@ -543,10 +543,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "longitude0360,longitude&time<2013-04-05T17",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fva" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected =
           "longitude0360,longitude\n"
               + "degrees_east,degrees_east\n"
@@ -563,10 +563,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "time,longitude&time<2013-04-05T17",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fva" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected =
           "time,longitude\n"
               + "UTC,degrees_east\n"
@@ -583,10 +583,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "longitude&time<2013-04-05T17",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fva" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected =
           "longitude\n"
               + "degrees_east\n"
@@ -603,10 +603,10 @@ class EDDTableFromAsciiFilesTests {
               null,
               null,
               "seaTemperatureF&time<2013-04-05T17",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_fva" + test,
               ".csv");
-      results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+      results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
       expected = "seaTemperatureF\n" + "degree_F\n" + "62.78\n" + "62.6\n" + "62.42\n" + "64.22\n";
       Test.ensureEqual(results, expected, "test=" + test + " results=\n" + results);
 
@@ -645,7 +645,7 @@ class EDDTableFromAsciiFilesTests {
         Calendar2.getCurrentISODateTimeStringZulu().substring(0, 14); // 14 is enough to check
     // hour. Hard
     // to check min:sec.
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "testTableAscii2";
     EDDTableFromAsciiFiles.deleteCachedDatasetInfo(id);
@@ -991,10 +991,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestAwsS3StandadizeWhat",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1026,10 +1026,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "&time=2010-01-01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestAwsS3StandadizeWhat",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "time,data\n" + "UTC,\n" + "2010-01-01T00:00:00Z,1\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -1040,10 +1040,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "&time=2010-01-03",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestAwsS3StandadizeWhat2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "time,data\n" + "UTC,\n" + "2010-01-03T00:00:00Z,3\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
   }
@@ -1212,7 +1212,7 @@ class EDDTableFromAsciiFilesTests {
     // EDD.debugMode = false;
     // EDDTableFromFilesCallable.debugMode = true;
     String tName, results, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     // one time: make csv version of ndbc2/nrt directory in ndbcMet2Csv
     /*
@@ -2190,7 +2190,7 @@ class EDDTableFromAsciiFilesTests {
       // request status.html
       SSR.getUrlResponseStringUnchanged(EDStatic.erddapUrl + "/status.html");
       Math2.sleep(1000);
-      Test.displayInBrowser("file://" + EDStatic.bigParentDirectory + "logs/log.txt");
+      Test.displayInBrowser("file://" + EDStatic.config.bigParentDirectory + "logs/log.txt");
 
       String2.pressEnterToContinue(
           "Look at log.txt to see if update was run and successfully "
@@ -2340,10 +2340,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestStandadizeWhat",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -2375,10 +2375,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "&time=2010-01-01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestStandadizeWhat",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "time,data\n" + "UTC,\n" + "2010-01-01T00:00:00Z,1\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -2389,10 +2389,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "&time=2010-01-03",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_TestStandadizeWhat2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "time,data\n" + "UTC,\n" + "2010-01-03T00:00:00Z,3\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
   }
@@ -3014,10 +3014,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ttr",
             ".das");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3045,10 +3045,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "time&orderByMinMax(\"time\")",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ttr",
             ".csv");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected = "time\n" + "UTC\n" + "1957-08-13T00:00:00Z\n" + "2007-04-28T00:00:00Z\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
   }
@@ -3072,10 +3072,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ttr2",
             ".das");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3103,10 +3103,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             "time&orderByMinMax(\"time\")",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ttr",
             ".csv");
-    results = File2.readFromFile88591(EDStatic.fullTestCacheDirectory + tName)[1];
+    results = File2.readFromFile88591(EDStatic.config.fullTestCacheDirectory + tName)[1];
     expected = "time\n" + "UTC\n" + "2000-09-07T00:00:00Z\n" + "2016-07-26T00:00:00Z\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
 
@@ -3130,7 +3130,7 @@ class EDDTableFromAsciiFilesTests {
     int language = 0;
     int po;
     String tName, results, expected, userDapQuery;
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     // test Calendar2.unitsSinceToEpochSeconds() with timeZone
     TimeZone timeZone = TimeZone.getTimeZone("US/Pacific");
@@ -3186,7 +3186,7 @@ class EDDTableFromAsciiFilesTests {
     tName =
         eddTable.makeNewFileForDapQuery(
             language, null, null, userDapQuery, testDir, eddTable.className() + "_tz_all", ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -3296,10 +3296,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,a,b\n"
@@ -3352,10 +3352,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_3",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -3420,10 +3420,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n"
@@ -3446,10 +3446,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n"
@@ -3474,10 +3474,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv2b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n"
@@ -3498,10 +3498,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "a,time,m\n" + ",UTC,m\n" + ",,NaN\n" + ",2008-07-29T16:50:00Z,NaN\n" + ",,NaN\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -3514,10 +3514,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv3b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n"
@@ -3540,10 +3540,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv4",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "a,time,m\n" + ",UTC,m\n" + "k,2010-12-07T20:00:00Z,11\n"; // local +8 hrs
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -3556,10 +3556,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv4aa",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n" + ",UTC,m\n" + ",,NaN\n" + "d,,4\n" + ",,NaN\n" + "i,,NaN\n" + "j,,NaN\n";
@@ -3573,10 +3573,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv4b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "a,time,m\n" + ",UTC,m\n" + "k,2010-12-07T20:00:00Z,11\n"; // local +8 hrs
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -3589,10 +3589,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv4c",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "a,time,m\n" + ",UTC,m\n" + "a,2004-09-13T14:15:00Z,1\n"; // local +8 hrs
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -3605,10 +3605,10 @@ class EDDTableFromAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_mv5",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "a,time,m\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiFilesTests.java
@@ -2455,7 +2455,7 @@ class EDDTableFromAsciiFilesTests {
             + "\" active=\"true\">\n"
             + "    <defaultGraphQuery>&amp;.marker=1|5</defaultGraphQuery>\n"
             + "    <fileDir>"
-            + File2.addSlash(dataDir)
+            + File2.addSlash(dataDir.replace(".", "\\."))
             + "26938/</fileDir>\n"
             + "    <fileNameRegex>???</fileNameRegex>\n"
             + "    <charset>ISO-8859-1</charset>\n"
@@ -2614,7 +2614,7 @@ class EDDTableFromAsciiFilesTests {
             + "\" active=\"true\">\n"
             + "    <defaultGraphQuery>&amp;.marker=1|5</defaultGraphQuery>\n"
             + "    <fileDir>"
-            + File2.addSlash(dataDir)
+            + File2.addSlash(dataDir.replace(".", "\\."))
             + "26938/</fileDir>\n"
             + "    <fileNameRegex>AFSC_RACE_FBEP_Hurst__Distributional_patterns_of_0-group_Pacific_cod__Gadus_macrocephalus__in_the_eastern_Bering_Sea_under_variable_recruitment_and_thermal_conditions\\.csv</fileNameRegex>\n"
             + "    <charset>ISO-8859-1</charset>\n"
@@ -3681,7 +3681,7 @@ class EDDTableFromAsciiFilesTests {
             + "\" active=\"true\">\n"
             + "    <defaultGraphQuery>&amp;.marker=1|5</defaultGraphQuery>\n"
             + "    <fileDir>"
-            + File2.addSlash(dataDir)
+            + File2.addSlash(dataDir.replace(".", "\\."))
             + "27377/</fileDir>\n"
             + "    <fileNameRegex>???</fileNameRegex>\n"
             + "    <charset>ISO-8859-1</charset>\n"
@@ -3884,7 +3884,7 @@ class EDDTableFromAsciiFilesTests {
             + "\" active=\"true\">\n"
             + "    <defaultGraphQuery>&amp;.marker=1|5</defaultGraphQuery>\n"
             + "    <fileDir>"
-            + File2.addSlash(dataDir)
+            + File2.addSlash(dataDir.replace(".", "\\."))
             + "27377/</fileDir>\n"
             + "    <fileNameRegex>dummy\\.csv</fileNameRegex>\n"
             + "    <charset>ISO-8859-1</charset>\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOSTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAsciiServiceNOSTests.java
@@ -108,10 +108,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected = // this changes every day
           // 9414290,San
           // Francisco,CA,1854-06-30T00:00:00Z,FTPC1,"NWLON,PORTS",-122.4659,37.8063," +
@@ -169,10 +169,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // 9414290,San
           // Francisco,CA,1854-06-30T00:00:00Z,FTPC1,"NWLON,PORTS",-122.4659,37.8063,2015-02-02T21:00:00Z,MLLW,1,WL,1.097
@@ -237,10 +237,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected = // changes every day
           // 9414290,San
           // Francisco,CA,1854-06-30T00:00:00Z,FTPC1,"NWLON,PORTS",-122.4659,37.8063,2014-12-25T21:00:00Z,MLLW,1.841,0.048,0,0,0,0
@@ -303,10 +303,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,"NWLON,PORTS",-71.4011,41.8067,2014-12-25T14:00:00Z,MLLW,1.641,0.002,0,0
@@ -368,10 +368,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // number of lines in results varies
       String sar[] = String2.split(results, '\n');
       expected =
@@ -407,10 +407,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // number of lines in results varies
       String sar[] = String2.split(results, '\n');
       expected =
@@ -450,10 +450,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,"NWLON,PORTS",-71.4006,41.8067,2015-02-08T00:00:00Z,MLLW,0.597
@@ -514,10 +514,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,"NWLON,PORTS",-71.4006,41.8067,2015-02-08T00:00:00Z,MLLW,0.597
@@ -576,10 +576,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,\"NWLON,PORTS\",-71.4006,41.8067,2015-02-02T00:00:00Z,1,AT,-1.0,0,0,0
@@ -638,10 +638,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,\"NWLON,PORTS\",-71.4006,41.8067,2015-02-02T00:00:00Z,1,BP,1019.5,0,0,0
@@ -707,10 +707,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // 8452660,Newport,RI,1930-09-11T00:00:00Z,NWPR1,"NWLON,PORTS",-71.3267,41.505,2014-12-25T00:00:00Z,1,CN,31.16,0,0,0
           // 8452660,Newport,RI,1930-09-11T00:00:00Z,NWPR1,"NWLON,PORTS",-71.3261,41.5044,2014-12-25T00:00:00Z,1,CN,31.16,0,0,0
@@ -777,10 +777,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // 9752619,"Isabel Segunda, Vieques
           // Island",PR,2007-09-13T00:00:00Z,VQSP4,COASTAL,-65.444,18.153,2015-02-02T00:00:00Z,1,J1,0.0,0,0
@@ -836,10 +836,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // 9063063,Cleveland,OH,1860-01-01T00:00:00Z,CNDO1,NWLON,-81.6355,41.5409,2015-02-02T00:00:00Z,1,RH,91.4,0,0,0
           "stationID,stationName,state,dateEstablished,shefID,deployment,longitude,latitude,time,dcp,sensor,RH,X,N,R\n"
@@ -897,10 +897,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,\"NWLON,PORTS\",-71.4006,41.8067,2010-10-24T00:00:00Z,1,WT,14.8,0,0,0
@@ -959,10 +959,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // eg
           // 8454000,Providence,RI,1938-06-03T00:00:00Z,FOXR1,\"NWLON,PORTS\",-71.4006,41.8067,2015-02-02T00:00:00Z,1,WS,1.86,22.72,3.2,0,0
@@ -1022,10 +1022,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           "stationID,stationName,state,dateEstablished,shefID,deployment,longitude,latitude,time,Vis\n"
               + ",,,UTC,,,degrees_east,degrees_north,UTC,nautical_miles\n";
@@ -1060,10 +1060,10 @@ class EDDTableFromAsciiServiceNOSTests {
               null,
               null,
               query,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               edd.className() + "_" + edd.datasetID(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           // db0301,Philadelphia,2003-03-25T00:00:00Z,-75.1396,39.9462,2010-11-21T00:03:00Z,1.526,199.0
           "stationID,stationName,dateEstablished,longitude,latitude,time,CS,CD\n"
@@ -1118,9 +1118,9 @@ class EDDTableFromAsciiServiceNOSTests {
      * query = "&stationID=\"1612340\"&datum=\"MLLW\"&time>=" + daysAgo72 +
      * "00:00&time<=" + daysAgo70 + "00:00";
      * tName = edd.makeNewFileForDapQuery(language, null, null, query,
-     * EDStatic.fullTestCacheDirectory,
+     * EDStatic.config.fullTestCacheDirectory,
      * edd.className() + "_" + edd.datasetID(), ".csv");
-     * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+     * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
      * tName);
      * expected =
      * "zztop\n";

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAudioFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAudioFilesTests.java
@@ -201,7 +201,7 @@ class EDDTableFromAudioFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String today =
         Calendar2.getCurrentISODateTimeStringZulu().substring(0, 12); // 12 is enough to check date
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAwsXmlFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromAwsXmlFilesTests.java
@@ -778,10 +778,10 @@ class EDDTableFromAwsXmlFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -1151,10 +1151,10 @@ class EDDTableFromAwsXmlFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -1220,10 +1220,10 @@ class EDDTableFromAwsXmlFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "fileName,station_id,station,city_state_zip,city_state,site_url,altitude,time,aux_temp,aux_temp_rate,dew_point,feels_like,gust_time,gust_direction,gust_speed,humidity,humidity_high,humidity_low,humidity_rate,indoor_temp,indoor_temp_rate,light,light_rate,moon_phase_moon_phase_img,moon_phase,pressure,pressure_high,pressure_low,pressure_rate,rain_month,rain_rate,rain_rate_max,rain_today,rain_year,temp,temp_high,temp_low,temp_rate,sunrise,sunset,wet_bulb,wind_speed,wind_speed_avg,wind_direction,wind_direction_avg\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandraTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromCassandraTests.java
@@ -629,7 +629,7 @@ class EDDTableFromCassandraTests {
     int language = 0;
     long cumTime = 0;
     String query;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
     int po;
     String tDatasetID = "cass_bobKeyspace_bobTable";
@@ -1207,7 +1207,7 @@ class EDDTableFromCassandraTests {
     int language = 0;
     long cumTime = 0;
     String query = null;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
     String tDatasetID = "cassTestFraction";
 
@@ -1310,7 +1310,7 @@ class EDDTableFromCassandraTests {
     int language = 0;
     long cumTime = 0;
     String query;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
     int po;
     String tDatasetID = "cass1Device";
@@ -1718,7 +1718,7 @@ class EDDTableFromCassandraTests {
     // debugMode = true;
     long cumTime = 0;
     String query;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String tName, results, expected;
     int po;
     String tDatasetID = "cass_bobKeyspace_staticTest";

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromColumnarAsciiFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromColumnarAsciiFilesTests.java
@@ -41,7 +41,7 @@ class EDDTableFromColumnarAsciiFilesTests {
     String startUrl =
         "https://sbclter.msi.ucsb.edu/external/InformationManagement/eml_2018_erddap/knb-lter-sbc."
             + which; // original test: .17
-    EDStatic.developmentMode = true;
+    EDStatic.config.developmentMode = true;
     String results =
         EDDTableFromColumnarAsciiFiles.generateDatasetsXmlFromEML(
                 false, // pauseForErrors,
@@ -68,7 +68,7 @@ class EDDTableFromColumnarAsciiFilesTests {
                   "-1"
                 }, // accessibleTo, local time_zone, defaultStandardizeWhat
                 false); // doIt loop?
-    EDStatic.developmentMode = false;
+    EDStatic.config.developmentMode = false;
 
     Test.ensureEqual(gdxResults, results, "Unexpected results from GenerateDatasetsXml.doIt.");
 
@@ -848,10 +848,10 @@ class EDDTableFromColumnarAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_eml_1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "site_code,time,NH4_uM,NO3_uM,PO4_uM,TDN_uM,TDP_uM,TPC_uM,TPN_uM,TPP_uM,TSS_mg_per_L,Spec_Cond_uS_per_cm\n"
             + ",UTC,micromole per liter,micromole per liter,micromole per liter,micromole per liter,micromole per liter,micromole per liter,micromole per liter,micromole per liter,milligram per liter,siemens per centimeter\n"
@@ -1134,10 +1134,10 @@ class EDDTableFromColumnarAsciiFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "aString,aChar,aBoolean,aByte,aShort,anInt,aLong,aFloat,aDouble\n"
             + ",,,,,,,,\n"
@@ -1171,7 +1171,7 @@ class EDDTableFromColumnarAsciiFilesTests {
             .substring(0, 14); // 14 is enough to check hour. Hard
     // to
     // check min:sec.
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "testTableColumnarAscii";
     EDDTableFromColumnarAsciiFiles.deleteCachedDatasetInfo(id);
@@ -1394,7 +1394,7 @@ class EDDTableFromColumnarAsciiFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     String dataDir =
         Path.of(EDDTableFromColumnarAsciiFilesTests.class.getResource("/data/").toURI()).toString();
@@ -1549,7 +1549,7 @@ class EDDTableFromColumnarAsciiFilesTests {
     int language = 0;
     // testVerboseOn();
     String tName, results, expected, userDapQuery;
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     // one time
     results =

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequenceTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequenceTests.java
@@ -584,10 +584,10 @@ class EDDTableFromDapSequenceTests {
               null,
               null,
               tq,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               tedd.className() + "_GraphArgo",
               ".png");
-      // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     }
 
     if (false) {
@@ -609,10 +609,10 @@ class EDDTableFromDapSequenceTests {
               null,
               null,
               tq,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               tedd.className() + "_GraphArgo30",
               ".png");
-      Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+      Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     }
   }
 
@@ -639,20 +639,20 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             tq,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_Argo",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     tName =
         tedd.makeNewFileForDapQuery(
             language,
             null,
             null,
             tq,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_Argo",
             ".csv");
-    String results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     // String expected =
     // "";
@@ -729,10 +729,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdac",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     Test.ensureEqual(results, expected, "results=\n" + results);
 
@@ -743,10 +743,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery + "&station=\"T402\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdacNonTime",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // basicQuery + String> String< constraints that shouldn't change the results
@@ -756,10 +756,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery + "&station>\"T3\"&station<\"T5\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdacGTLT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // REGEX: If dataset is setup with sourceCanConstraintStringRegex ~=, THIS WORKS
@@ -774,10 +774,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery + "&station=~\"T40.\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdacRegex",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // REGEX: If dataset is setup with sourceCanConstraintStringRegex ~=, THIS
@@ -793,10 +793,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery + "&station=~\"(T402|t403)\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdacRegex",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "results=\n" + results);
 
     // basicQuery + time= (a string= test) constraint that shouldn't change the
@@ -807,10 +807,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery + "&time=2002-06-25T14:55:00Z",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_psdacTime",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "results=\n" + results);
   }
 
@@ -831,10 +831,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_newport",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
   }
@@ -951,10 +951,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             baseQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             tedd.className() + "_CalCaltch",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = "\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
   }
@@ -981,10 +981,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_FP_EQ",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // pre 2015-12-28 was sorted lexically, now case insensitive. pre 2013-05-28
         // wasn't sorted
         "longitude,latitude,time,common_name\n"
@@ -1032,10 +1032,10 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_RWL",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // trouble: java.time (was Joda) doesn't like space-padded hour values
 
     expected = "zztop\n";
@@ -1069,10 +1069,10 @@ class EDDTableFromDapSequenceTests {
             "longitude,latitude,time&time=%221992-01-01T00:00:00Z%22"
                 + "&longitude>=-132.0&longitude<=-112.0&latitude>=30.0&latitude<=50.0"
                 + "&distinct()&.draw=markers&.colorBar=|D||||",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_SVGraph",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
   }
 
   /** Test that info from subsetVariables gets back to variable's ranges */
@@ -1098,12 +1098,12 @@ class EDDTableFromDapSequenceTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             edd.className() + "_Entire",
             ".das");
     String results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     String tResults;
     String expected =
         "Attributes {[10]\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabaseTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromDatabaseTests.java
@@ -43,7 +43,7 @@ class EDDTableFromDatabaseTests {
     password = "MyPassword";
     String connectionProps[] =
         new String[] {"user", EDDTableFromDatabase.testUser, "password", password};
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int language = 0;
 
     // list catalogs
@@ -313,7 +313,7 @@ class EDDTableFromDatabaseTests {
     // testVerboseOn();
     int language = 0;
     long eTime;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results, expected;
 
     EDDTableFromDatabase tedd =
@@ -854,7 +854,7 @@ class EDDTableFromDatabaseTests {
   @TagMissingDataset
   void testNonExistentVariable() throws Throwable {
     String2.log("\n*** EDDTableFromDatabase.testNonExistentVariable()");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results = "not set";
     int language = 0;
     try {
@@ -886,7 +886,7 @@ class EDDTableFromDatabaseTests {
   @TagMissingDataset
   void testNonExistentTable() throws Throwable {
     String2.log("\n*** EDDTableFromDatabase.testNonExistentTable()");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results = "not set";
     int language = 0;
     try {

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGridTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromEDDGridTests.java
@@ -29,7 +29,7 @@ class EDDTableFromEDDGridTests {
     String id = "erdMBsstdmday_AsATable";
     int language = 0;
     EDDTable tedd = (EDDTable) EDDTableFromEDDGrid.oneFromDatasetsXml(null, id);
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     /* */
     // das
     tName =

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromErddapTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromErddapTests.java
@@ -487,10 +487,10 @@ class EDDTableFromErddapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // see OpendapHelper.EOL for comments
         "Attributes {\n"
@@ -528,10 +528,10 @@ class EDDTableFromErddapTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -578,10 +578,10 @@ class EDDTableFromErddapTests {
             null,
             null,
             "&id=%22ae1001c011%22", // "&id=\"ae1001c011\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Data",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "prof,id,cast,cruise,time,longitude,lon360,latitude,depth,ocean_temperature_1,ocean_temperature_2,ocean_dissolved_oxygen_concentration_1_mLperL,ocean_dissolved_oxygen_concentration_2_mLperL,photosynthetically_active_radiation,ocean_chlorophyll_a_concentration_factoryCal,ocean_chlorophyll_fluorescence_raw,ocean_practical_salinity_1,ocean_practical_salinity_2,ocean_sigma_t,sea_water_nutrient_bottle_number,sea_water_phosphate_concentration,sea_water_silicate_concentration,sea_water_nitrate_concentration,sea_water_nitrite_concentration,sea_water_ammonium_concentration,ocean_dissolved_oxygen_concentration_1_mMperkg,ocean_dissolved_oxygen_concentration_2_mMperkg,ocean_oxygen_saturation_1\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNamesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNamesTests.java
@@ -595,7 +595,7 @@ class EDDTableFromFileNamesTests {
     // debugMode = true;
     // testVerboseOn();
     int language = 0;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results, expected, query, tName;
 
     EDDTable tedd = (EDDTable) EDDTestDataset.gettestFileNames();
@@ -853,7 +853,7 @@ class EDDTableFromFileNamesTests {
   void testAwsS3() throws Throwable {
     // String2.log("\n*** EDDTableFromFileNames.testAwsS3\n");
     // testVerboseOn();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results, expected, query, tName;
     int language = 0;
 
@@ -1380,7 +1380,7 @@ class EDDTableFromFileNamesTests {
     String2.log(msg);
     Test.ensureTrue(time < expTime * 2, "Too slow: " + msg);
     Object o2[];
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     Table fileTable;
     StringArray subDirs;
     int fileTableNRows;

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromHttpGetTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromHttpGetTests.java
@@ -1068,7 +1068,7 @@ class EDDTableFromHttpGetTests {
     String dataDir =
         Path.of(EDDTestDataset.class.getResource("/data/points/testFromHttpGet/").toURI())
             .toString();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String today =
         Calendar2.getCurrentISODateTimeStringZulu()
             .substring(0, 14); // 14 is enough to check hour. Hard to
@@ -1307,7 +1307,7 @@ class EDDTableFromHttpGetTests {
             "2,station2_2016-05.jsonl,532,-1.0,station2,station2,0,2016-05-29T02:00:00Z,2016-05-29T03:00:00Z,0,10.2,10.2,0,-150.3,-150.3,0,16.2,16.3,0,17.2,17.3,0,1.531153321058E9,1.531153324151E9,0,JohnSmith,JohnSmith,0,0,0,0\n";
     Test.ensureLinesMatch(results, expected, "");
 
-    EDStatic.developmentMode = true;
+    EDStatic.config.developmentMode = true;
     // push a bunch of data into the dataset: 2 stations, 2 time periods
     for (int i = 0; i < 4; i++) {
       // apr
@@ -1378,7 +1378,7 @@ class EDDTableFromHttpGetTests {
               eddTable.className() + "_insert4_" + i,
               ".insert");
     }
-    EDStatic.developmentMode = false;
+    EDStatic.config.developmentMode = false;
 
     // look at last response file
     results = File2.directReadFrom88591File(dir + tName);
@@ -1546,7 +1546,7 @@ class EDDTableFromHttpGetTests {
             + "\\d{2}:\\d{2}\\.\\d{3}Z,JohnSmith,0\n";
     Test.ensureLinesMatch(results, versioningExpected, "\nresults=\n" + results);
 
-    EDStatic.developmentMode = true;
+    EDStatic.config.developmentMode = true;
     // overwrite and delete a bunch of data
     for (int i = 0; i < 2; i++) {
       // overwrite the first 2
@@ -1611,7 +1611,7 @@ class EDDTableFromHttpGetTests {
               eddTable.className() + "_delete8_" + i,
               ".delete");
     }
-    EDStatic.developmentMode = false;
+    EDStatic.config.developmentMode = false;
 
     // .csv all data (with processing)
     userDapQuery = "";

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromHyraxFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromHyraxFilesTests.java
@@ -376,7 +376,7 @@ class EDDTableFromHyraxFilesTests {
       // delete the last file in the collection
       if (deleteCachedInfoAndOneFile) {
         EDDTableFromHyraxFiles.deleteCachedDatasetInfo(id);
-        File2.delete(EDStatic.fullCopyDirectory + id + "/" + deletedFile);
+        File2.delete(EDStatic.config.fullCopyDirectory + id + "/" + deletedFile);
         Math2.sleep(1000);
       }
 
@@ -386,7 +386,7 @@ class EDDTableFromHyraxFilesTests {
         // String2.pressEnterToContinue(
         // "\n****** BOB! ******\n" +
         // "This test just deleted a file:\n" +
-        // EDStatic.fullCopyDirectory + id + "/" + deletedFile + "\n" +
+        // EDStatic.config.fullCopyDirectory + id + "/" + deletedFile + "\n" +
         // "The background task to re-download it should have already started.\n" +
         // "The remote dataset is really slow.\n" +
         // "Wait for it to finish background tasks.\n\n");
@@ -411,10 +411,10 @@ class EDDTableFromHyraxFilesTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Entire",
               ".das");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "Attributes {\n"
@@ -589,10 +589,10 @@ class EDDTableFromHyraxFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -622,10 +622,10 @@ class EDDTableFromHyraxFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_stationList",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,time,uwnd,vwnd,wspd,upstr,vpstr,nobs\n"
@@ -665,10 +665,10 @@ class EDDTableFromHyraxFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_1StationGTLT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,time,upstr,vpstr\n"
             + "degrees_east,degrees_north,UTC,m2/s2,m2/s2\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromInvalidCRAFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromInvalidCRAFilesTests.java
@@ -27,7 +27,7 @@ class EDDTableFromInvalidCRAFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String testCacheDir = EDStatic.fullTestCacheDirectory;
+    String testCacheDir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "testInvalidCRAFiles";
     EDDTableFromInvalidCRAFiles.deleteCachedDatasetInfo(id);

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromJsonlCSVFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromJsonlCSVFilesTests.java
@@ -249,7 +249,7 @@ class EDDTableFromJsonlCSVFilesTests {
     // *****************\n");
     // testVerboseOn();
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String today =
         Calendar2.getCurrentISODateTimeStringZulu()
             .substring(0, 14); // 14 is enough to check hour. Hard to
@@ -493,7 +493,7 @@ class EDDTableFromJsonlCSVFilesTests {
     // *****************\n");
     // testVerboseOn();
     String tName, results, expected;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int language = 0;
 
     String id = "testBase64Image";

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromMultidimNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromMultidimNcFilesTests.java
@@ -896,7 +896,7 @@ class EDDTableFromMultidimNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "argoFloats";
     if (deleteCachedInfo) EDD.deleteCachedDatasetInfo(id);
@@ -2549,7 +2549,7 @@ class EDDTableFromMultidimNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "testTreatDimensionsAs";
     if (deleteCachedInfo) EDD.deleteCachedDatasetInfo(id);
@@ -2933,7 +2933,7 @@ class EDDTableFromMultidimNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     String id = "testTreatDimensionsAs2";
     if (deleteCachedInfo) EDD.deleteCachedDatasetInfo(id);
@@ -3487,7 +3487,7 @@ class EDDTableFromMultidimNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDTable eddTable = (EDDTable) EDDTestDataset.gettestLong();
 
@@ -3996,7 +3996,7 @@ class EDDTableFromMultidimNcFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     // test the floats work as expected
     float f = String2.parseFloat("-3.4E38");
@@ -4082,7 +4082,7 @@ class EDDTableFromMultidimNcFilesTests {
   void testCharAsString(boolean deleteCachedInfo) throws Throwable {
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     // print dumpString of one of the data files
     // String2.log(NcHelper.ncdump(EDStatic.unitTestDataDir +
     // "nccf/testCharAsString/7900364_prof.nc", "-h"));
@@ -4826,7 +4826,7 @@ class EDDTableFromMultidimNcFilesTests {
   void testScriptOnlyRequest() throws Throwable {
 
     EDDTableFromMultidimNcFiles edd = (EDDTableFromMultidimNcFiles) EDDTestDataset.getTS_ATMP_AAD();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     // edd.makeNewFileForDapQuery(0, null, null, )
     String fileTypeExtension = ".csv";
     String fileName = "testScriptOnlyRequest" + fileTypeExtension;

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcCFFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcCFFilesTests.java
@@ -1175,10 +1175,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_test1a",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "line_station,longitude,latitude,altitude,time,obsScientific,obsValue,obsUnits\n"
@@ -1197,10 +1197,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_test1b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "line_station\n"
@@ -1236,10 +1236,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_test1Kevin20130109a",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "traj,obs,time,longitude,latitude,temp,ve,vn\n"
@@ -1257,10 +1257,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_test1Kevin20130109a",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "traj,obs,time,longitude,latitude,temp,ve,vn\n"
@@ -1292,7 +1292,7 @@ class EDDTableFromNcCFFilesTests {
     // boolean oTableDebug = Table.debugMode; Table.debugMode = true;
 
     String tName, results, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     EDDTable eddTable = (EDDTable) EDDTestDataset.getpmelTaoMonPos();
     Table table;
 
@@ -1406,7 +1406,7 @@ class EDDTableFromNcCFFilesTests {
           "java.lang.RuntimeException: datasets.xml error on line #\\d{1,7}: An <att> tag doesn't have a \"name\" attribute.",
           "");
     }
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(
           eddTable, null, "Dataset should be null from exception during construction.");
     }
@@ -1420,7 +1420,7 @@ class EDDTableFromNcCFFilesTests {
           "java.lang.RuntimeException: datasets.xml error on line #\\d{1,7}: An <att> tag doesn't have a \"name\" attribute.",
           "");
     }
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(
           eddTable, null, "Dataset should be null from exception during construction.");
     }
@@ -1475,10 +1475,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_bridger",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -1505,10 +1505,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_bridger",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     boolean simplifiedTimeBlocks =
         results.indexOf("Float64 actual_range 56463.676934285555, 56683.652143735904") > -1;
@@ -1701,10 +1701,10 @@ class EDDTableFromNcCFFilesTests {
             + "    String creator_email \"nealp@maine.edu,ljm@umeoce.maine.edu,bfleming@umeoce.maine.edu\";\n"
             + "    String creator_name \"Neal Pettigrew\";\n"
             + "    String creator_url \"http://gyre.umeoce.maine.edu\";\n"
-            + (EDStatic.useSaxParser ? "    Int32 delta_t 30;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Int32 delta_t 30;\n" : "")
             + "    String depth_datum \"Sea Level\";\n"
             + "    Float64 Easternmost_Easting -70.42755;\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    Float64 ending_julian_day_number 56683.64583333349;\n"
                     + "    String ending_julian_day_string \"2014-01-26 15:30:00\";\n"
                 : "")
@@ -1734,7 +1734,7 @@ class EDDTableFromNcCFFilesTests {
             + "    String institution \"Department of Physical Oceanography, School of Marine Sciences, University of Maine\";\n"
             + "    String institution_url \"http://gyre.umeoce.maine.edu\";\n"
             + "    Int32 instrument_number 0;\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    String julian_day_convention \"Julian date convention begins at 00:00:00 UTC on 17 November 1858 AD\";\n"
                 : "")
             + "    String keywords \"accelerometer, b01, buoy, chemistry, chlorophyll, circulation, conductivity, control, currents, data, density, department, depth, dominant, dominant_wave_period data_quality, Earth Science > Oceans > Ocean Chemistry > Chlorophyll, Earth Science > Oceans > Ocean Chemistry > Oxygen, Earth Science > Oceans > Ocean Circulation > Ocean Currents, Earth Science > Oceans > Ocean Optics > Turbidity, Earth Science > Oceans > Ocean Pressure > Sea Level Pressure, Earth Science > Oceans > Ocean Temperature > Water Temperature, Earth Science > Oceans > Ocean Waves > Significant Wave Height, Earth Science > Oceans > Ocean Waves > Swells, Earth Science > Oceans > Ocean Waves > Wave Period, Earth Science > Oceans > Ocean Winds > Surface Winds, Earth Science > Oceans > Salinity/Density > Conductivity, Earth Science > Oceans > Salinity/Density > Density, Earth Science > Oceans > Salinity/Density > Salinity, height, level, maine, marine, name, o2, ocean, oceanography, oceans, optics, oxygen, period, physical, pressure, quality, salinity, school, sciences, sea, seawater, sensor, significant, significant_height_of_wind_and_swell_waves, significant_wave_height data_quality, station, station_name, surface, surface waves, swell, swells, temperature, time, turbidity, university, water, wave, waves, wind, winds\";\n"
@@ -1774,7 +1774,7 @@ class EDDTableFromNcCFFilesTests {
             + "    String sourceUrl \"\\(local files\\)\";\n"
             + "    Float64 Southernmost_Northing 43.18019;\n"
             + "    String standard_name_vocabulary \"CF-1.6\";\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    Float64 starting_julian_day_number 56463.66666666651;\n"
                     + "    String starting_julian_day_string \"2013-06-20 16:00:00\";\n"
                 : "")
@@ -1805,10 +1805,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_bridger1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "station,longitude,latitude,depth,time,time_created,time_modified,significant_wave_height,significant_wave_height_qc,dominant_wave_period,dominant_wave_period_qc\n"
@@ -1826,10 +1826,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_bridger2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "station,longitude,latitude,depth,time,time_created,time_modified,significant_wave_height,significant_wave_height_qc,dominant_wave_period,dominant_wave_period_qc\n"
@@ -1846,10 +1846,10 @@ class EDDTableFromNcCFFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_bridger3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "station\n" + "\n" + "B01\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -1877,7 +1877,7 @@ class EDDTableFromNcCFFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String testCacheDir = EDStatic.fullTestCacheDirectory;
+    String testCacheDir = EDStatic.config.fullTestCacheDirectory;
     String scalarVars = ",crs,WODf,WODfd";
 
     // From Ajay Krishnan, NCEI/NODC, from

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
@@ -962,7 +962,7 @@ class EDDTableFromNcFilesTests {
             + "    String cf_role \"timeseries_id\";\n"
             + "    String ioos_category \"Identifier\";\n"
             + "    String long_name \"Station Identifier\";\n"
-            + (EDStatic.useSaxParser ? "    String units \"unitless\";\n" : "")
+            + (EDStatic.config.useSaxParser ? "    String units \"unitless\";\n" : "")
             + "  }\n"
             + "  longitude {\n"
             + "    String _CoordinateAxisType \"Lon\";\n"
@@ -1014,12 +1014,12 @@ class EDDTableFromNcFilesTests {
             + "  common_name {\n"
             + "    String ioos_category \"Taxonomy\";\n"
             + "    String long_name \"Common Name\";\n"
-            + (EDStatic.useSaxParser ? "    String units \"unitless\";\n" : "")
+            + (EDStatic.config.useSaxParser ? "    String units \"unitless\";\n" : "")
             + "  }\n"
             + "  species_name {\n"
             + "    String ioos_category \"Taxonomy\";\n"
             + "    String long_name \"Species Name\";\n"
-            + (EDStatic.useSaxParser ? "    String units \"unitless\";\n" : "")
+            + (EDStatic.config.useSaxParser ? "    String units \"unitless\";\n" : "")
             + "  }\n"
             + "  size {\n"
             + "    Int16 _FillValue 32767;\n"
@@ -1075,7 +1075,9 @@ class EDDTableFromNcFilesTests {
     // today + " " + EDStatic.erddapUrl + //in tests, always use non-https url
     expected =
         "/tabledap/erdCinpKfmSFNH.das\";\n"
-            + (EDStatic.useSaxParser ? "    String id \"KFMSizeFrequencyNaturalHabitat\";\n" : "")
+            + (EDStatic.config.useSaxParser
+                ? "    String id \"KFMSizeFrequencyNaturalHabitat\";\n"
+                : "")
             + "    String infoUrl \"https://www.nps.gov/chis/naturescience/index.htm\";\n"
             + "    String institution \"CINP\";\n"
             + "    String keywords \"aquatic, atmosphere, biology, biosphere, channel, cinp, coastal, common, depth, Earth Science > Biosphere > Aquatic Ecosystems > Coastal Habitat, Earth Science > Biosphere > Aquatic Ecosystems > Marine Habitat, ecosystems, forest, frequency, habitat, height, identifier, islands, kelp, marine, monitoring, name, natural, size, species, station, taxonomy, time\";\n"
@@ -1138,7 +1140,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "id,longitude,latitude,depth,time,common_name,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "unitless,degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : ",degrees_east,degrees_north,m,UTC,,,mm\n")
             + "Santa Barbara (Webster's Arch),-119.05,33.4666666666667,14.0,2005-07-01T00:00:00Z,Bat star,Asterina miniata,57\n"
@@ -1171,7 +1173,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "id,longitude,latitude,depth,time,common_name,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "unitless,degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : ",degrees_east,degrees_north,m,UTC,,,mm\n")
             + "Santa Barbara (Webster's Arch),-119.05,33.4666666666667,14.0,2005-07-01T00:00:00Z,Bat star,Asterina miniata,57\n"
@@ -1198,7 +1200,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "id,longitude,latitude,depth,time,common_name,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "unitless,degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : ",degrees_east,degrees_north,m,UTC,,,mm\n")
             + "San Miguel (Hare Rock),-120.35,34.05,5.0,2005-07-01T00:00:00Z,Red abalone,Haliotis rufescens,13\n"
@@ -1227,7 +1229,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "id,longitude,latitude,depth,time,common_name,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "unitless,degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : ",degrees_east,degrees_north,m,UTC,,,mm\n")
             + "San Miguel (Miracle Mile),-120.4,34.0166666666667,10.0,2005-07-01T00:00:00Z,Red abalone,Haliotis rufescens,207\n"
@@ -1256,7 +1258,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "id,longitude,latitude,depth,time,common_name,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "unitless,degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : ",degrees_east,degrees_north,m,UTC,,,mm\n")
             + "San Miguel (Hare Rock),-120.35,34.05,5.0,2005-07-01T00:00:00Z,Red abalone,Haliotis rufescens,13\n";
@@ -1278,7 +1280,7 @@ class EDDTableFromNcFilesTests {
     // String2.log(results);
     expected =
         "longitude,latitude,depth,time,id,species_name,size\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "degrees_east,degrees_north,m,UTC,unitless,unitless,mm\n"
                 : "degrees_east,degrees_north,m,UTC,,,mm\n")
             + "-120.35,34.05,5.0,2005-07-01T00:00:00Z,San Miguel (Hare Rock),Haliotis rufescens,13\n";
@@ -10895,7 +10897,7 @@ class EDDTableFromNcFilesTests {
     // set hardFlag
     String startTime = Calendar2.getCurrentISODateTimeStringLocalTZ();
     Math2.sleep(1000);
-    File2.writeToFileUtf8(EDStatic.fullHardFlagDirectory + "testTimeSince19000101", "test");
+    File2.writeToFileUtf8(EDStatic.config.fullHardFlagDirectory + "testTimeSince19000101", "test");
     String2.log(
         "I just set a hardFlag for testTimeSince19000101.\n" + "Now I'm waiting 10 seconds.");
     Math2.sleep(10000);
@@ -10903,7 +10905,7 @@ class EDDTableFromNcFilesTests {
     String tIndex = SSR.getUrlResponseStringUnchanged("http://localhost:8080/erddap/status.html");
     Math2.sleep(5000);
     // read the log file
-    String tLog = File2.readFromFileUtf8(EDStatic.fullLogsDirectory + "log.txt")[1];
+    String tLog = File2.readFromFileUtf8(EDStatic.config.fullLogsDirectory + "log.txt")[1];
     String expected = // ***
         "unloading datasetID=testTimeSince19000101\n"
             + "\\*\\*\\* deleting cached dataset info for datasetID=testTimeSince19000101\n"
@@ -10911,7 +10913,7 @@ class EDDTableFromNcFilesTests {
             + "\\*\\*\\* RunLoadDatasets is starting a new hardFlag LoadDatasets thread at (..........T..............)\n"
             + "\n"
             + "\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\\*\n"
-            + "LoadDatasets.run EDStatic.developmentMode=true ..........T..............\n"
+            + "LoadDatasets.run EDStatic.config.developmentMode=true ..........T..............\n"
             + "  datasetsRegex=\\(testTimeSince19000101\\) inputStream=null majorLoad=false";
 
     int po = Math.max(0, tLog.lastIndexOf(expected.substring(0, 40)));
@@ -12616,7 +12618,7 @@ class EDDTableFromNcFilesTests {
                 "time,wtmp,station,longitude,latitude,wd,wspd,gst,wvht,dpd,apd,mwd,"
                     + "bar,atmp,dewp,vis,ptdy,tide,wspu,wspv&station=\"41006\""
                     + "&time>0."); // random integer will be appended to avoid cached response
-    String baseOut = EDStatic.fullTestCacheDirectory + "EDDTableFromNcFilesTestSpeed";
+    String baseOut = EDStatic.config.fullTestCacheDirectory + "EDDTableFromNcFilesTestSpeed";
     ArrayList al;
     int timeOutSeconds = 120;
     String extensions[] =
@@ -17054,10 +17056,10 @@ class EDDTableFromNcFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             zarr.className() + "_testData",
             ".das");
-    String results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    String results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     String expected =
         "Attributes {\n"
             + //
@@ -17184,10 +17186,10 @@ class EDDTableFromNcFilesTests {
             null,
             null,
             "dim0,dim1,dim2,dim3,group_with_dims_var4D&dim0%3E=0&dim0%3C=0&dim3%3E=4&dim3%3C=6&dim2%3E=9&dim2%3C=10",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             zarr.className(),
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "dim0,dim1,dim2,dim3,group_with_dims_var4D\n"
             + //

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNccsvFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNccsvFilesTests.java
@@ -318,7 +318,7 @@ class EDDTableFromNccsvFilesTests {
     // testVerboseOn();
     int language = 0;
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String today =
         Calendar2.getCurrentISODateTimeStringZulu()
             .substring(0, 14); // 14 is enough to check hour. Hard to
@@ -1083,7 +1083,7 @@ class EDDTableFromNccsvFilesTests {
     int language = 0;
     String tName, results, tResults, expected;
     EDV edv;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String today =
         Calendar2.getCurrentISODateTimeStringZulu()
             .substring(0, 14); // 14 is enough to check hour. Hard to
@@ -2954,8 +2954,8 @@ class EDDTableFromNccsvFilesTests {
      * "longitude,latitude,time&time=%221992-01-01T00:00:00Z%22" +
      * "&longitude>=-132.0&longitude<=-112.0&latitude>=30.0&latitude<=50.0" +
      * "&distinct()&.draw=markers&.colorBar=|D||||",
-     * EDStatic.fullTestCacheDirectory, edd.className() + "_SVGraph", ".png");
-     * Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+     * EDStatic.config.fullTestCacheDirectory, edd.className() + "_SVGraph", ".png");
+     * Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
      *
      * } catch (Throwable t) {
      * throw new

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromOBISTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromOBISTests.java
@@ -157,12 +157,12 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               obis.className(),
               ".das");
       results =
           String2.annotatedString(
-              File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+              File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
       // String2.log(results);
       expected =
           "Attributes {[10]\n"
@@ -429,10 +429,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               obis.className(),
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           // 2010-07-20 -132.4223 changed to -132.422 in 3 places
@@ -470,10 +470,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               obis.className() + "latlon",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude, latitude, time, ID, Genus, Species\n"
@@ -511,9 +511,9 @@ class EDDTableFromOBISTests {
        * "&longitude>-134&longitude<-131&latitude>53&latitude<55&time<1973-01-01";
        * //Carcharodon";
        * tName = obis.makeNewFileForDapQuery(null, null, userDapQuery,
-       * EDStatic.fullTestCacheDirectory,
+       * EDStatic.config.fullTestCacheDirectory,
        * obis.className() + "latlon", ".csv");
-       * results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory +
+       * results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory +
        * tName);
        * //String2.log(results);
        * Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -529,10 +529,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               obis.className() + "latlon",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -546,10 +546,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               obis.className() + "latlon",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
@@ -584,10 +584,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               fishbase.className() + "FishBaseGraph",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude, latitude, time, ID, Genus, Species, Citation\n"
@@ -606,10 +606,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               "longitude,latitude&Genus=Carcharodon&longitude!=NaN",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               fishbase.className() + "Map",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude, latitude\n"
@@ -746,10 +746,10 @@ class EDDTableFromOBISTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               dukeSeamap.className() + "duke",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude, latitude, time, ID, Genus, Species, Citation\n"
@@ -787,10 +787,10 @@ class EDDTableFromOBISTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             argos.className() + "Argos",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromParquetFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromParquetFilesTests.java
@@ -444,7 +444,7 @@ class EDDTableFromParquetFilesTests {
   @ValueSource(booleans = {true, false})
   void testBasic(boolean deleteCachedDatasetInfo) throws Throwable {
     String tName, results, tResults, expected, userDapQuery;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     int language = 0;
 
     String id = "testParquet";

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromSOSTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromSOSTests.java
@@ -53,10 +53,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:8419317\"&time>=2006-01-01T00&time<=2006-01-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosATemp",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,air_temperature,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,degree_C,\n"
@@ -80,10 +80,10 @@ class EDDTableFromSOSTests {
             null,
             null, // 1612340, NaN, 2008-10-26
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:1612340\"&time>=2008-10-26T00&time<2008-10-26T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosATemp",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,air_temperature,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,degree_C,\n"
@@ -110,10 +110,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosATemp",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -241,10 +241,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               "&time>=2008-10-26T00&time<=2008-10-26T01&orderBy(\"station_id,time\")",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_nosSosATempAllStations",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected =
           "longitude,latitude,station_id,altitude,time,sensor_id,air_temperature,quality_flags\n"
               + "degrees_east,degrees_north,,m,UTC,,degree_C,\n"
@@ -294,10 +294,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "longitude,latitude,station_id&orderBy(\"station_id\")",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosATempStationList",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id\n"
             + "degrees_east,degrees_north,\n"
@@ -339,10 +339,10 @@ class EDDTableFromSOSTests {
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:8447386\""
                 + "&time>=2006-01-01T00&time<=2006-01-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosPressure",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,air_pressure,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,millibars,\n"
@@ -376,10 +376,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9491094\"&time>=2008-09-01T00&time<=2008-09-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosPressure",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,air_pressure,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,millibars,\n"
@@ -407,10 +407,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosPressure",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -539,10 +539,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:8452660\"&time>=2013-09-01T00&time<=2013-09-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosCond",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,conductivity,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,mS cm-1,\n"
@@ -570,10 +570,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosCond",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -687,7 +687,7 @@ class EDDTableFromSOSTests {
                 null,
                 null,
                 preQuery + stations[i] + postQuery,
-                EDStatic.fullTestCacheDirectory,
+                EDStatic.config.fullTestCacheDirectory,
                 eddTable.className() + "_testFindValidStation",
                 ".csv");
         String2.pressEnterToContinue("SUCCESS with station=" + stations[i]);
@@ -736,11 +736,11 @@ class EDDTableFromSOSTests {
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:lc0301\""
                 + "&time>=2013-09-01T00:03&time<=2013-09-01T00:03", // It was hard to find a request
             // that had data
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosCurrents",
             ".csv");
 
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,sensor_depth,direction_of_sea_water_velocity,sea_water_speed,platform_orientation,platform_pitch_angle,platform_roll_angle,sea_water_temperature,orientation,sampling_rate,reporting_interval,processing_level,bin_size,first_bin_center,number_of_bins,bin\n"
             + "degrees_east,degrees_north,,m,UTC,,m,degrees_true,cm s-1,degrees_true,degrees,degrees,degree_C,,Hz,s,,m,m,,count\n"
@@ -805,10 +805,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosCurrents",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1099,10 +1099,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosSalinity",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1166,10 +1166,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:8452660\"&time>=2013-09-01T00&time<=2013-09-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosSalinity",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         // station 8419317: salinity is low because this is in estuary/river, not in
         // ocean
@@ -1390,10 +1390,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9468756\"&time>=2009-04-06T00&time<=2009-04-06T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWind",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,wind_from_direction,wind_speed,wind_speed_of_gust\n"
             + "degrees_east,degrees_north,,m,UTC,,degrees_true,m s-1,m s-1\n"
@@ -1421,10 +1421,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWind",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1551,10 +1551,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWLevel",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1661,10 +1661,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9454050\"&time>=2013-09-01T00&time<=2013-09-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWLevel",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         /*
          * //pre 2009-11-15 and post 2009-12-13
@@ -1784,10 +1784,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWTemp",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -1882,10 +1882,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:8311062\"&time>=2008-08-01T14:00&time<2008-08-01T15:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWTemp",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         /*
          * "longitude,latitude,station_id,altitude,time,sensor_id,sea_water_temperature\n"
@@ -1934,10 +1934,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9432780\"&time>=2008-09-01T14:00&time<2008-09-01T15:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWTemp",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,sea_water_temperature,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,degree_C,\n"
@@ -1961,10 +1961,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "altitude,longitude,latitude&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9432780\"&time>=2008-09-01T14:00&time<2008-09-01T15:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWTemp1",
             ".geoJson");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\n"
             + "  \"type\": \"MultiPoint\",\n"
@@ -1992,10 +1992,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:NOAA.NOS.CO-OPS:9432780\"&time>=2008-09-01T14:00&time<2008-09-01T15:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_nosSosWTemp2",
             ".geoJson");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "{\n"
             + "  \"type\": \"FeatureCollection\",\n"
@@ -2156,10 +2156,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test1",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -2491,10 +2491,10 @@ class EDDTableFromSOSTests {
                 +
                 // 2019-03-19 was -87.94,29.16 now -87.944,29.108
                 "&longitude=-87.944&latitude>=29.1&latitude<29.2&time>=2008-06-01T14:00&time<=2008-06-01T14:30",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,bin,direction_of_sea_water_velocity,sea_water_speed,upward_sea_water_velocity,error_velocity,platform_orientation,platform_pitch_angle,platform_roll_angle,sea_water_temperature,pct_good_3_beam,pct_good_4_beam,pct_rejected,pct_bad,echo_intensity_beam1,echo_intensity_beam2,echo_intensity_beam3,echo_intensity_beam4,correlation_magnitude_beam1,correlation_magnitude_beam2,correlation_magnitude_beam3,correlation_magnitude_beam4,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,count,degrees_true,cm/s,cm/s,cm/s,degrees_true,degree,degree,Cel,percent,percent,percent,percent,count,count,count,count,count,count,count,count,\n"
@@ -2524,10 +2524,10 @@ class EDDTableFromSOSTests {
                 // 2019-03-19 was -87.94 now -87.944
                 "&longitude=-87.944&latitude>=29.1&latitude<29.2&time>=2008-06-01T14:00&time<=2008-06-01T14:30"
                 + "&quality_flags=~\"3;.*\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test1",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,bin,direction_of_sea_water_velocity,sea_water_speed,upward_sea_water_velocity,error_velocity,platform_orientation,platform_pitch_angle,platform_roll_angle,sea_water_temperature,pct_good_3_beam,pct_good_4_beam,pct_rejected,pct_bad,echo_intensity_beam1,echo_intensity_beam2,echo_intensity_beam3,echo_intensity_beam4,correlation_magnitude_beam1,correlation_magnitude_beam2,correlation_magnitude_beam3,correlation_magnitude_beam4,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,count,degrees_true,cm/s,cm/s,cm/s,degrees_true,degree,degree,Cel,percent,percent,percent,percent,count,count,count,count,count,count,count,count,\n"
@@ -2554,10 +2554,10 @@ class EDDTableFromSOSTests {
             null,
             "&station_id=~\"(urn:ioos:station:wmo:41035|urn:ioos:station:wmo:42376)\""
                 + "&time>=2008-06-01T14:00&time<=2008-06-01T14:15",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test1b",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         // Before revamping 2008-10, test returned values below. NOW DIFFERENT!
         // "urn:ioos:station:wmo:41035,-77.28,34.48,-1.6,2008-06-01T14:00:00Z,223,3.3\n"
@@ -2609,10 +2609,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:41012\"&time>=2008-06-01T00&time<=2008-06-01T01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test2",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,bin,direction_of_sea_water_velocity,sea_water_speed,upward_sea_water_velocity,error_velocity,platform_orientation,platform_pitch_angle,platform_roll_angle,sea_water_temperature,pct_good_3_beam,pct_good_4_beam,pct_rejected,pct_bad,echo_intensity_beam1,echo_intensity_beam2,echo_intensity_beam3,echo_intensity_beam4,correlation_magnitude_beam1,correlation_magnitude_beam2,correlation_magnitude_beam3,correlation_magnitude_beam4,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,count,degrees_true,cm/s,cm/s,cm/s,degrees_true,degree,degree,Cel,percent,percent,percent,percent,count,count,count,count,count,count,count,count,\n"
@@ -2657,10 +2657,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&time>=2008-06-14T00&time<=2008-06-14T02&altitude=-25",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_test3",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,bin,direction_of_sea_water_velocity,sea_water_speed,upward_sea_water_velocity,error_velocity,platform_orientation,platform_pitch_angle,platform_roll_angle,sea_water_temperature,pct_good_3_beam,pct_good_4_beam,pct_rejected,pct_bad,echo_intensity_beam1,echo_intensity_beam2,echo_intensity_beam3,echo_intensity_beam4,correlation_magnitude_beam1,correlation_magnitude_beam2,correlation_magnitude_beam3,correlation_magnitude_beam4,quality_flags\n"
             + "degrees_east,degrees_north,,m,UTC,,count,degrees_true,cm/s,cm/s,cm/s,degrees_true,degree,degree,Cel,percent,percent,percent,percent,count,count,count,count,count,count,count,count,\n"
@@ -2680,10 +2680,10 @@ class EDDTableFromSOSTests {
             null,
             "station_id,longitude,latitude,altitude,time,zztop"
                 + "&station_id=\"urn:ioos:network:noaa.nws.ndbc:all\"&time=2008-06-14T00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbc_testError",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
   }
 
   /**
@@ -2711,10 +2711,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosSalinity",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -2845,10 +2845,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:46013\"&time>=2008-08-01&time<2008-08-02",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosSalinity",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,sea_water_salinity\n"
             + "degrees_east,degrees_north,,m,UTC,,PSU\n"
@@ -2863,10 +2863,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&time>=2010-05-27T00:00:00Z&time<=2010-05-27T01:00:00Z",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosSalinityAll",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // 46081 appeared 2010-07-20, anrn6 and apqf1 disappeared 2010-10-10
         "longitude,latitude,station_id,altitude,time,sensor_id,sea_water_salinity\n"
             + "degrees_east,degrees_north,,m,UTC,,PSU\n"
@@ -2914,10 +2914,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:41012\"&time>=2002-06-01",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_LongTime",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
 
     int nb = Math.min(results.length(), 500);
     String2.log(
@@ -3006,10 +3006,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWLevel",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3137,10 +3137,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:55015\"&time>=2008-08-01T14:00&time<=2008-08-01T15:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWLevel",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "longitude,latitude,station_id,altitude,time,sensor_id,averaging_interval\n"
             + "degrees_east,degrees_north,,m,UTC,,s\n"
@@ -3177,10 +3177,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWTemp",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3307,10 +3307,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:46013\"&time>=2008-08-01T14:00&time<2008-08-01T20:00",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWTemp",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // 2021-12-13 lon, lat, alt all changed slightly 2019-03-19 was -0.6, now -1.0
         "longitude,latitude,station_id,altitude,time,sensor_id,sea_water_temperature\n"
             + "degrees_east,degrees_north,,m,UTC,,degree_C\n"
@@ -3346,22 +3346,22 @@ class EDDTableFromSOSTests {
     EDDTableFromSOS.timeParts = true;
     tName =
         eddTable.makeNewFileForDapQuery(
-            language, null, null, query, EDStatic.fullTestCacheDirectory, name, ".csv");
+            language, null, null, query, EDStatic.config.fullTestCacheDirectory, name, ".csv");
 
     EDDTableFromSOS.timeParts = false;
     tName =
         eddTable.makeNewFileForDapQuery(
-            language, null, null, query, EDStatic.fullTestCacheDirectory, name, ".csv");
+            language, null, null, query, EDStatic.config.fullTestCacheDirectory, name, ".csv");
 
     EDDTableFromSOS.timeParts = true;
     tName =
         eddTable.makeNewFileForDapQuery(
-            language, null, null, query, EDStatic.fullTestCacheDirectory, name, ".csv");
+            language, null, null, query, EDStatic.config.fullTestCacheDirectory, name, ".csv");
 
     EDDTableFromSOS.timeParts = false;
     tName =
         eddTable.makeNewFileForDapQuery(
-            language, null, null, query, EDStatic.fullTestCacheDirectory, name, ".csv");
+            language, null, null, query, EDStatic.config.fullTestCacheDirectory, name, ".csv");
 
     EDDTableFromSOS.timeParts = false;
   }
@@ -3391,10 +3391,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWaves",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3674,10 +3674,10 @@ class EDDTableFromSOSTests {
             null,
             "&station_id=\"urn:ioos:station:wmo:46013\"&time>=2008-08-01T14&time<=2008-08-01T17"
                 + "&calculation_method>=\"A\"&calculation_method<=\"Lonh\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWaves",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         // was
         // "longitude,latitude,station_id,altitude,time,SignificantWaveHeight,DominantWavePeriod,AverageWavePeriod,SwellHeight,SwellPeriod,WindWaveHeight,WindWavePeriod,WaterTemperature,WaveDuration,CalculationMethod,SamplingRate,NumberOfFrequencies,CenterFrequencies,Bandwidths,SpectralEnergy,MeanWaveDirectionPeakPeriod,SwellWaveDirection,WindWaveDirection,MeanWaveDirection,PrincipalWaveDirection,PolarCoordinateR1,PolarCoordinateR2,DirectionalWaveParameter,FourierCoefficientA1,FourierCoefficientA2,FourierCoefficientB1,FourierCoefficientB2\n"
@@ -3753,10 +3753,10 @@ class EDDTableFromSOSTests {
                 // UNKNOWN!
                 // but fixed 2010-06-22
                 "&calculation_method=~\"(zztop|Long.*)\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWaves",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     Test.ensureEqual(results, expected, "RESULTS=\n" + results);
 
     // test error
@@ -3768,10 +3768,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               "&station_id=\"urn:ioos:station:wmo:46013\"&time>=2008-08-01&time<=2008-09-05",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_ndbcSosWaves30",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       expected = "shouldn't get here";
       Test.ensureEqual(results, expected, "RESULTS=\n" + results);
 
@@ -3830,10 +3830,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWind",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Attributes {\n"
             + " s {\n"
@@ -3986,10 +3986,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"urn:ioos:station:wmo:41004\"&time>=2008-08-01T00:00&time<=2008-08-01T04",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ndbcSosWind",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // 2019-03-19 was alt 5.0, now 4.0
         "longitude,latitude,station_id,altitude,time,sensor_id,wind_from_direction,wind_speed,wind_speed_of_gust,upward_air_velocity\n"
             + "degrees_east,degrees_north,,m,UTC,,degrees_true,m s-1,m s-1,m s-1\n"
@@ -4031,8 +4031,8 @@ class EDDTableFromSOSTests {
      * now http://oceandata.gmri.org/cgi-bin/sos/V1.0/oostethys_sos.cgi
      */
     int language = 0;
-    boolean oSosActive = EDStatic.sosActive;
-    EDStatic.sosActive = true;
+    boolean oSosActive = EDStatic.config.sosActive;
+    EDStatic.config.sosActive = true;
     String tName, results, expected, userDapQuery;
     EDDTable eddTable = (EDDTable) EDDTestDataset.getgomoosBuoy();
 
@@ -4105,10 +4105,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.datasetID() + "_Data",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         // before 2010-02-11 was
         // "longitude,latitude,altitude,time,station_id,sea_water_temperature,sea_water_salinity\n"
@@ -4219,10 +4219,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "longitude,latitude&longitude>-70",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "MapNT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // this changes a little periodically (NOT GOOD, stations have 1 point (which
         // applies to historic data and changes!)
@@ -4390,10 +4390,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "longitude,latitude&time=2007-12-11",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "MapWT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // changed a little on 2008-02-28, 2008-05-19, 2008-09-24, 2008-10-09 2009-01-12
@@ -4440,10 +4440,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"A01\"&time=2007-12-11",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "MapWTAV",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = // changed a little on 2008-02-28, 2008-05-19, 2008-09-24, 2008-10-09 2009-01-12
         // -70.5658->-70.5655 42.5226->42.5232
@@ -4472,7 +4472,7 @@ class EDDTableFromSOSTests {
             + "-70.5652267750436,42.5227725835475,A01,-58.0,2007-12-11T00:00:00Z,NaN,NaN,323.0,NaN,NaN,NaN,NaN,NaN,3.956008,NaN,NaN,NaN,NaN,NaN,NaN\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
-    EDStatic.sosActive = oSosActive;
+    EDStatic.config.sosActive = oSosActive;
     // debugMode = oDebugMode;
   }
 
@@ -4488,8 +4488,8 @@ class EDDTableFromSOSTests {
     // String2.log("\n*** EDDTableFromSOS.testNeracoos");
     // testVerboseOn();
     int language = 0;
-    boolean oSosActive = EDStatic.sosActive;
-    EDStatic.sosActive = true;
+    boolean oSosActive = EDStatic.config.sosActive;
+    EDStatic.config.sosActive = true;
     String tName, results, expected, userDapQuery;
 
     EDDTable eddTable = (EDDTable) EDDTestDataset.getneracoosSos();
@@ -4557,10 +4557,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.datasetID() + "_Data",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         // before 2010-07-08 when I started using ALL_PLATFORMS and BBOX,
         // there was no data for D01 in the response
@@ -4595,10 +4595,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "longitude,latitude,station_id&longitude>-70",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "NeraNT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // "longitude,latitude,station_id\n" +
@@ -4667,10 +4667,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "longitude,latitude&time=2007-12-11",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "NeraWT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // before 2010-07-08 when I started using ALL_PLATFORMS and BBOX,
@@ -4695,10 +4695,10 @@ class EDDTableFromSOSTests {
             null,
             null,
             "&station_id=\"A01\"&time=2007-12-11",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "neraAV",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "longitude,latitude,station_id,altitude,time,air_temperature,chlorophyll,direction_of_sea_water_velocity,dominant_wave_period,sea_level_pressure,sea_water_density,sea_water_electrical_conductivity,sea_water_salinity,sea_water_speed,sea_water_temperature,wave_height,visibility_in_air,wind_from_direction,wind_gust,wind_speed\n"
@@ -4724,7 +4724,7 @@ class EDDTableFromSOSTests {
             + "-70.5652267750436,42.5227725835475,A01,-54.0,2007-12-11T00:00:00Z,NaN,NaN,220.0,NaN,NaN,NaN,NaN,NaN,0.72111,NaN,NaN,NaN,NaN,NaN,NaN\n"
             + "-70.5652267750436,42.5227725835475,A01,-58.0,2007-12-11T00:00:00Z,NaN,NaN,323.0,NaN,NaN,NaN,NaN,NaN,3.956008,NaN,NaN,NaN,NaN,NaN,NaN\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
-    EDStatic.sosActive = oSosActive;
+    EDStatic.config.sosActive = oSosActive;
     // debugMode = oDebugMode;
   }
 
@@ -4741,8 +4741,8 @@ class EDDTableFromSOSTests {
     // testVerboseOn();
 
     int language = 0;
-    boolean oSosActive = EDStatic.sosActive;
-    EDStatic.sosActive = true;
+    boolean oSosActive = EDStatic.config.sosActive;
+    EDStatic.config.sosActive = true;
     // boolean oDebugMode = debugMode;
     // debugMode = true;
     try {
@@ -4757,16 +4757,16 @@ class EDDTableFromSOSTests {
               null,
               null,
               "&time=2009-07-11", // &station_id=\"A01\"",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "tamu",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected = "zztop\n";
       Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
     } finally {
-      EDStatic.sosActive = oSosActive;
+      EDStatic.config.sosActive = oSosActive;
       // debugMode = oDebugMode;
     }
   }
@@ -5659,10 +5659,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Entire",
               ".das");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "  wspv {\n"
@@ -5688,10 +5688,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Entire",
               ".dds");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "Dataset {\n"
@@ -5745,10 +5745,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Data1",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude, latitude, altitude, time, station_id, wvht, dpd, wtmp, dewp\n"
@@ -5768,10 +5768,10 @@ class EDDTableFromSOSTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Data2",
               ".csv");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected = "longitude,latitude,altitude,time,station_id,wvht,dpd,wtmp,dewp\n";
       Test.ensureTrue(results.indexOf(expected) >= 0, "\nresults=\n" + results);
@@ -5797,11 +5797,11 @@ class EDDTableFromSOSTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Data3",
               ".csv");
       String2.log("queryTime=" + (System.currentTimeMillis() - time));
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude,latitude,altitude,time,station_id,wvht,dpd,wtmp,dewp\n"
@@ -5837,11 +5837,11 @@ class EDDTableFromSOSTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Data4",
               ".csv");
       String2.log("queryTime=" + (System.currentTimeMillis() - time));
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude,latitude,altitude,station_id,wvht,dpd,wtmp,dewp\n"
@@ -5875,11 +5875,11 @@ class EDDTableFromSOSTests {
               null,
               null,
               userDapQuery,
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_Data5",
               ".csv");
       String2.log("queryTime=" + (System.currentTimeMillis() - time));
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       expected =
           "longitude,latitude,wtmp\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromThreddsFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromThreddsFilesTests.java
@@ -56,10 +56,10 @@ class EDDTableFromThreddsFilesTests {
               null,
               null,
               "",
-              EDStatic.fullTestCacheDirectory,
+              EDStatic.config.fullTestCacheDirectory,
               eddTable.className() + "_ShipEntire",
               ".das");
-      results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+      results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
       // String2.log(results);
       boolean with = false; // 2014-01-09 several lines disappeared, 2016-09-16 returned, ...
       // disappeared,
@@ -701,10 +701,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ShipEntire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -749,10 +749,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_ShipCruiseList",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected = "cruise_id\n" + "\n" + "Cruise_id undefined for now\n";
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
@@ -766,10 +766,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Ship1StationGTLT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "time,latitude,longitude,airPressure,airTemperature,flag\n"
@@ -1231,10 +1231,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -1378,10 +1378,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -1408,10 +1408,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_stationList",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "station\n"
@@ -1460,10 +1460,10 @@ class EDDTableFromThreddsFilesTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_1StationGTLT",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     // one depth, by hand via DAP form: (note that depth is already negative!)
     // Lat, 37.13015 Time=1122592440 depth=-12 Lon=-122.361253

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromWFSFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromWFSFilesTests.java
@@ -842,7 +842,7 @@ class EDDTableFromWFSFilesTests {
 
     // ensure LatDegree=latitude and LongDegree=longitude
     Table table = new Table();
-    table.readASCII(EDStatic.fullCopyDirectory + edd.datasetID() + "/data.tsv", 0, 2);
+    table.readASCII(EDStatic.config.fullCopyDirectory + edd.datasetID() + "/data.tsv", 0, 2);
     PrimitiveArray pa1 = new FloatArray(table.getColumn("aasg:BoreholeTemperature/aasg:LatDegree"));
     PrimitiveArray pa2 =
         new FloatArray(table.getColumn("aasg:BoreholeTemperature/aasg:Shape/gml:Point/latitude"));
@@ -876,8 +876,14 @@ class EDDTableFromWFSFilesTests {
     // *** .das
     tName =
         tedd.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, "kgsBoreTempWVTRUE", ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            "kgsBoreTempWVTRUE",
+            ".das");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -1242,8 +1248,14 @@ class EDDTableFromWFSFilesTests {
     // *** .dds
     tName =
         tedd.makeNewFileForDapQuery(
-            language, null, null, "", EDStatic.fullTestCacheDirectory, "kgsBoreTempWVTRUE", ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            "kgsBoreTempWVTRUE",
+            ".dds");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "Dataset {\n"
             + "  Sequence {\n"
@@ -1319,10 +1331,10 @@ class EDDTableFromWFSFilesTests {
             null,
             null,
             "&APINo=\"4700102422\"",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "kgsBoreTempWVTRUE",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "ObservationURI,WellName,APINo,HeaderURI,OtherName,Label,Operator,time,EndedDrillingDate,WellType,StatusDate,ReleaseDate,Field,County,State,UTM_E,UTM_N,latitude,longitude,SRS,LocationUncertaintyStatement,LocationUncertaintyRadius,DrillerTotalDepth,DepthReferencePoint,LengthUnits,WellBoreShape,TrueVerticalDepth,ElevationKB,ElevationDF,ElevationGL,FormationTD,BitDiameterTD,MaximumRecordedTemperature,MeasuredTemperature,CorrectedTemperature,TemperatureUnits,CirculationDuration,MeasurementProcedure,DepthOfMeasurement,MeasurementDateTime,MeasurementFormation,MeasurementSource,RelatedResource,CasingBottomDepthDriller,CasingTopDepth,CasingPipeDiameter,CasingWeight,CasingThickness,pH,InformationSource,Shape_gml_Point_latitude,Shape_gml_Point_longitude,LeaseName,LeaseOwner,LeaseNo,TimeSinceCirculation,Status,CommodityOfInterest,Function,Production,ProducingInterval,Notes\n"

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableTests.java
@@ -29,7 +29,7 @@ class EDDTableTests {
   void testSosNdbcMet() throws Throwable {
     String2.log("\n*** EDDTable.testSosNdbcMet()");
     EDDTable eddTable = (EDDTable) EDDTable.oneFromDatasetsXml(null, "cwwcNDBCMet");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String sosQuery, fileName, results, expected;
     int language = 0;
     java.io.StringWriter writer;
@@ -2141,10 +2141,10 @@ class EDDTableTests {
             null,
             null,
             dapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_testSos5png",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + fileName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + fileName);
 
     // *** #6 all stations, 1 obsProp,
     String sosQuery6csv = // no obsProp
@@ -2209,10 +2209,10 @@ class EDDTableTests {
             null,
             null,
             dapQuery6[0],
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddTable.className() + "_testSos6png",
             ".png");
-    Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + fileName);
+    Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + fileName);
     /*  */
 
   }
@@ -2223,7 +2223,7 @@ class EDDTableTests {
   void testSosCurrents() throws Throwable {
     String2.log("\n*** EDDTable.testSosCurrents()");
     EDDTable eddTable = (EDDTable) EDDTable.oneFromDatasetsXml(null, "ndbcSosCurrents");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String sosQuery, fileName, results, expected;
     int language = 0;
     java.io.StringWriter writer;
@@ -2450,7 +2450,7 @@ class EDDTableTests {
   void testSosGomoos() throws Throwable {
     String2.log("\n*** EDDTable.testSosGomoos()");
     EDDTable eddTable = (EDDTable) EDDTable.oneFromDatasetsXml(null, "gomoosBuoy");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String sosQuery, fileName, results, expected;
     int language = 0;
     java.io.StringWriter writer;
@@ -2496,7 +2496,7 @@ class EDDTableTests {
   void testSosOostethys() throws Throwable {
     String2.log("\n*** EDDTable.testSosOostethys()");
     EDDTable eddTable = (EDDTable) EDDTable.oneFromDatasetsXml(null, "cwwcNDBCMet");
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String sosQuery, fileName, results, expected;
     int language = 0;
     java.io.StringWriter writer;
@@ -2668,7 +2668,7 @@ class EDDTableTests {
   @org.junit.jupiter.api.Test
   void testCharacters() throws Throwable {
     EDDTable eddTable = (EDDTable) EDDTestDataset.gettest_chars();
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String results, expected;
     int language = 0;
 
@@ -2693,12 +2693,12 @@ class EDDTableTests {
   void testLargeResults() throws Throwable {
     int language = 0;
     String tName, results, expected, userDapQuery;
-    String testDir = EDStatic.fullTestCacheDirectory;
+    String testDir = EDStatic.config.fullTestCacheDirectory;
 
     EDDTable eddTable = (EDDTable) EDDTestDataset.gettestTableColumnarAscii();
 
     // This is to force there to be multiple passes for each column when writing the nc file.
-    EDStatic.partialRequestMaxCells = 5;
+    EDStatic.config.partialRequestMaxCells = 5;
     userDapQuery = "";
     tName =
         eddTable.makeNewFileForDapQuery(
@@ -2747,6 +2747,6 @@ class EDDTableTests {
     results = results.substring(resultsStart);
     Test.ensureEqual(results, expected, "\nresults=\n" + results);
 
-    EDStatic.partialRequestMaxCells = EDStatic.DEFAULT_partialRequestMaxCells;
+    EDStatic.config.partialRequestMaxCells = EDStatic.config.DEFAULT_partialRequestMaxCells;
   }
 }

--- a/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/handler/TopLevelHandlerTests.java
@@ -58,7 +58,7 @@ public class TopLevelHandlerTests {
     context.setMajorLoad(false);
     context.setErddap(new Erddap());
     context.setLastLuceneUpdate(0);
-    context.setDatasetsRegex(EDStatic.datasetsRegex);
+    context.setDatasetsRegex(EDStatic.config.datasetsRegex);
     context.setReallyVerbose(false);
 
     factory = SAXParserFactory.newInstance();
@@ -102,7 +102,7 @@ public class TopLevelHandlerTests {
 
   @Test
   void unusualActivityTest() {
-    assertEquals(EDStatic.unusualActivity, 25);
+    assertEquals(EDStatic.config.unusualActivity, 25);
   }
 
   @Test

--- a/src/test/java/gov/noaa/pfel/erddap/util/SubscriptionsTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/util/SubscriptionsTests.java
@@ -35,7 +35,7 @@ class SubscriptionsTests {
     Test.ensureTrue(Integer.valueOf(17).equals(Integer.valueOf(17)), "");
 
     // test empty system
-    String ffName = EDStatic.fullTestCacheDirectory + "subscriptionsV1.txt";
+    String ffName = EDStatic.config.fullTestCacheDirectory + "subscriptionsV1.txt";
     File2.delete(ffName);
     Subscriptions sub = new Subscriptions(ffName, 72, EDStatic.erddapHttpsUrl);
     Test.ensureEqual(sub.persistentTable.nRows(), 0, "");

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -144,7 +144,7 @@ class JettyTests {
   @ValueSource(booleans = {false, true})
   @TagJetty
   void testCorsFilter(boolean enableCors) throws Exception {
-    EDStatic.enableCors = enableCors;
+    EDStatic.config.enableCors = enableCors;
 
     HttpClient client = HttpClient.newHttpClient();
     URI uri = server.getURI().resolve("/erddap/index.html");
@@ -162,12 +162,12 @@ class JettyTests {
   }
 
   private void validateCorsHeaders(HttpResponse<?> response) {
-    if (EDStatic.enableCors && response.request().method().equalsIgnoreCase("OPTIONS")) {
+    if (EDStatic.config.enableCors && response.request().method().equalsIgnoreCase("OPTIONS")) {
       assertEquals(204, response.statusCode());
     } else {
       assertEquals(200, response.statusCode());
     }
-    if (EDStatic.enableCors) {
+    if (EDStatic.config.enableCors) {
       assertTrue(response.headers().firstValue("Access-Control-Allow-Origin").isPresent());
       assertEquals("*", response.headers().firstValue("Access-Control-Allow-Origin").get());
       assertTrue(response.headers().firstValue("Access-Control-Allow-Methods").isPresent());
@@ -176,7 +176,7 @@ class JettyTests {
           response.headers().firstValue("Access-Control-Allow-Methods").get());
       assertTrue(response.headers().firstValue("Access-Control-Allow-Headers").isPresent());
       assertEquals(
-          EDStatic.corsAllowHeaders,
+          EDStatic.config.corsAllowHeaders,
           response.headers().firstValue("Access-Control-Allow-Headers").get());
     } else {
       assertFalse(response.headers().firstValue("Access-Control-Allow-Origin").isPresent());
@@ -212,7 +212,7 @@ class JettyTests {
     assertEquals("ERDDAP_version_string=" + EDStatic.erddapVersion + "\n", response.body());
 
     // test json response using Accept header including deployment info
-    EDStatic.deploymentInfo = "integration testing with jetty";
+    EDStatic.config.deploymentInfo = "integration testing with jetty";
     response =
         client.send(
             HttpRequest.newBuilder(server.getURI().resolve("/erddap/version"))
@@ -227,7 +227,7 @@ class JettyTests {
     assertTrue(jsonResponse.has("version_full"));
     assertEquals(EDStatic.erddapVersion, jsonResponse.getString("version_full"));
     assertTrue(jsonResponse.has("deployment_info"));
-    assertEquals(EDStatic.deploymentInfo, jsonResponse.getString("deployment_info"));
+    assertEquals(EDStatic.config.deploymentInfo, jsonResponse.getString("deployment_info"));
 
     // test json response using query parameter including deployment info
     response =
@@ -4958,7 +4958,7 @@ class JettyTests {
     String2.log("\n*** Erddap.testBasic");
     int po;
     int language = 0;
-    EDStatic.sosActive =
+    EDStatic.config.sosActive =
         false; // currently, never true because sos is unfinished //some other tests may have
     // left this as true
 
@@ -6140,22 +6140,22 @@ class JettyTests {
         "{\n"
             + "  \"table\": {\n"
             + "    \"columnNames\": [\"griddap\", \"Subset\", \"tabledap\", \"Make A Graph\", "
-            + (EDStatic.sosActive ? "\"sos\", " : "")
-            + (EDStatic.wcsActive ? "\"wcs\", " : "")
-            + (EDStatic.wmsActive ? "\"wms\", " : "")
-            + (EDStatic.filesActive ? "\"files\", " : "")
-            + (EDStatic.authentication.length() > 0 ? "\"Accessible\", " : "")
+            + (EDStatic.config.sosActive ? "\"sos\", " : "")
+            + (EDStatic.config.wcsActive ? "\"wcs\", " : "")
+            + (EDStatic.config.wmsActive ? "\"wms\", " : "")
+            + (EDStatic.config.filesActive ? "\"files\", " : "")
+            + (EDStatic.config.authentication.length() > 0 ? "\"Accessible\", " : "")
             + "\"Title\", \"Summary\", \"FGDC\", \"ISO 19115\", \"Info\", \"Background Info\", \"RSS\", "
-            + (EDStatic.subscriptionSystemActive ? "\"Email\", " : "")
+            + (EDStatic.config.subscriptionSystemActive ? "\"Email\", " : "")
             + "\"Institution\", \"Dataset ID\"],\n"
             + "    \"columnTypes\": [\"String\", \"String\", \"String\", \"String\", "
-            + (EDStatic.sosActive ? "\"String\", " : "")
-            + (EDStatic.wcsActive ? "\"String\", " : "")
-            + (EDStatic.wmsActive ? "\"String\", " : "")
-            + (EDStatic.filesActive ? "\"String\", " : "")
-            + (EDStatic.authentication.length() > 0 ? "\"String\", " : "")
+            + (EDStatic.config.sosActive ? "\"String\", " : "")
+            + (EDStatic.config.wcsActive ? "\"String\", " : "")
+            + (EDStatic.config.wmsActive ? "\"String\", " : "")
+            + (EDStatic.config.filesActive ? "\"String\", " : "")
+            + (EDStatic.config.authentication.length() > 0 ? "\"String\", " : "")
             + "\"String\", \"String\", \"String\", \"String\", \"String\", \"String\", \"String\", "
-            + (EDStatic.subscriptionSystemActive ? "\"String\", " : "")
+            + (EDStatic.config.subscriptionSystemActive ? "\"String\", " : "")
             + "\"String\", \"String\"],\n"
             + "    \"rows\": [\n";
     Test.ensureEqual(results.substring(0, expected.length()), expected, "results=\n" + results);
@@ -6170,14 +6170,14 @@ class JettyTests {
             + "\"http://localhost:"
             + PORT
             + "/erddap/tabledap/erdGlobecBottle.graph\", "
-            + (EDStatic.sosActive ? "\"\", " : "")
+            + (EDStatic.config.sosActive ? "\"\", " : "")
             + // currently, it isn't made available via sos
-            (EDStatic.wcsActive ? "\"\", " : "")
-            + (EDStatic.wmsActive ? "\"\", " : "")
-            + (EDStatic.filesActive
+            (EDStatic.config.wcsActive ? "\"\", " : "")
+            + (EDStatic.config.wmsActive ? "\"\", " : "")
+            + (EDStatic.config.filesActive
                 ? "\"http://localhost:" + PORT + "/erddap/files/erdGlobecBottle/\", "
                 : "")
-            + (EDStatic.authentication.length() > 0 ? "\"public\", " : "")
+            + (EDStatic.config.authentication.length() > 0 ? "\"public\", " : "")
             + "\"GLOBEC NEP Rosette Bottle Data (2002)\", \"GLOBEC (GLOBal "
             + "Ocean ECosystems Dynamics) NEP (Northeast Pacific)\\nRosette Bottle Data from "
             + "New Horizon Cruise (NH0207: 1-19 August 2002).\\nNotes:\\nPhysical data "
@@ -6223,7 +6223,7 @@ class JettyTests {
             "\"http://localhost:"
             + PORT
             + "/erddap/rss/erdGlobecBottle.rss\", "
-            + (EDStatic.subscriptionSystemActive
+            + (EDStatic.config.subscriptionSystemActive
                 ? "\"http://localhost:"
                     + PORT
                     + "/erddap/subscriptions/add.html?datasetID=erdGlobecBottle&showErrors=false&email=\", "
@@ -6348,7 +6348,7 @@ class JettyTests {
     Test.ensureTrue(results.indexOf("directory") >= 0, "results=\n" + results);
     Test.ensureTrue(results.indexOf("ERDDAP, Version") >= 0, "results=\n" + results);
 
-    String localName = EDStatic.fullTestCacheDirectory + "46012_2005.csv";
+    String localName = EDStatic.config.fullTestCacheDirectory + "46012_2005.csv";
     File2.delete(localName);
     SSR.downloadFile( // throws Exception if trouble
         EDStatic.erddapUrl + "/files/testTableAscii/subdir/46012_2005.csv",
@@ -6359,7 +6359,7 @@ class JettyTests {
     File2.delete(localName);
 
     // sos
-    if (EDStatic.sosActive) {
+    if (EDStatic.config.sosActive) {
       results =
           SSR.getUrlResponseStringUnchanged(
               EDStatic.erddapUrl + "/sos/index.html?" + EDStatic.defaultPIppQuery);
@@ -6417,7 +6417,7 @@ class JettyTests {
     }
 
     // wcs
-    if (EDStatic.wcsActive) {
+    if (EDStatic.config.wcsActive) {
       results =
           SSR.getUrlResponseStringUnchanged(
               EDStatic.erddapUrl + "/wcs/index.html?" + EDStatic.defaultPIppQuery);
@@ -6479,7 +6479,7 @@ class JettyTests {
     }
 
     // wms
-    if (EDStatic.wmsActive) {
+    if (EDStatic.config.wmsActive) {
       results =
           SSR.getUrlResponseStringUnchanged(
               EDStatic.erddapUrl + "/wms/index.html?" + EDStatic.defaultPIppQuery);
@@ -6567,7 +6567,7 @@ class JettyTests {
         "results=\n" + results);
 
     // subscriptions
-    if (EDStatic.subscriptionSystemActive) {
+    if (EDStatic.config.subscriptionSystemActive) {
       results = SSR.getUrlResponseStringUnchanged(EDStatic.erddapUrl + "/subscriptions/index.html");
       Test.ensureTrue(results.indexOf("Add a new subscription") >= 0, "results=\n" + results);
       Test.ensureTrue(results.indexOf("Validate a subscription") >= 0, "results=\n" + results);
@@ -6611,7 +6611,7 @@ class JettyTests {
     }
 
     // slideSorter
-    if (EDStatic.slideSorterActive) {
+    if (EDStatic.config.slideSorterActive) {
       results = SSR.getUrlResponseStringUnchanged(EDStatic.erddapUrl + "/slidesorter.html");
       Test.ensureTrue(
           results.indexOf(
@@ -6669,21 +6669,21 @@ class JettyTests {
             + "/erddap/tabledap/index.csv?"
             + EDStatic.defaultPIppQuery
             + "\n"
-            + (EDStatic.sosActive
+            + (EDStatic.config.sosActive
                 ? "sos,http://localhost:"
                     + PORT
                     + "/erddap/sos/index.csv?"
                     + EDStatic.defaultPIppQuery
                     + "\n"
                 : "")
-            + (EDStatic.wcsActive
+            + (EDStatic.config.wcsActive
                 ? "wcs,http://localhost:"
                     + PORT
                     + "/erddap/wcs/index.csv?"
                     + EDStatic.defaultPIppQuery
                     + "\n"
                 : "")
-            + (EDStatic.wmsActive
+            + (EDStatic.config.wmsActive
                 ? "wms,http://localhost:"
                     + PORT
                     + "/erddap/wms/index.csv?"
@@ -6746,7 +6746,7 @@ class JettyTests {
             + PORT
             + "/erddap/tabledap/index.htmlTable?page=1&amp;itemsPerPage=1000</a>\n"
             + "</tr>\n"
-            + (EDStatic.sosActive
+            + (EDStatic.config.sosActive
                 ? "<tr>\n"
                     + "<td>sos\n"
                     + "<td><a href=\"http&#x3a;&#x2f;&#x2f;localhost&#x3a;8080&#x2f;erddap&#x2f;sos&#x2f;index&#x2e;htmlTable&#x3f;page&#x3d;1&#x26;itemsPerPage&#x3d;1000\">http://localhost:"
@@ -6788,23 +6788,25 @@ class JettyTests {
             + "      [\"tabledap\", \"http://localhost:"
             + PORT
             + "/erddap/tabledap/index.json?page=1&itemsPerPage=1000\"]"
-            + (EDStatic.sosActive || EDStatic.wcsActive || EDStatic.wmsActive ? "," : "")
+            + (EDStatic.config.sosActive || EDStatic.config.wcsActive || EDStatic.config.wmsActive
+                ? ","
+                : "")
             + "\n"
-            + (EDStatic.sosActive
+            + (EDStatic.config.sosActive
                 ? "      [\"sos\", \"http://localhost:"
                     + PORT
                     + "/erddap/sos/index.json?page=1&itemsPerPage=1000\"]"
-                    + (EDStatic.wcsActive || EDStatic.wmsActive ? "," : "")
+                    + (EDStatic.config.wcsActive || EDStatic.config.wmsActive ? "," : "")
                     + "\n"
                 : "")
-            + (EDStatic.wcsActive
+            + (EDStatic.config.wcsActive
                 ? "      [\"wcs\", \"http://localhost:"
                     + PORT
                     + "/erddap/wcs/index.json?page=1&itemsPerPage=1000\"]"
-                    + (EDStatic.wmsActive ? "," : "")
+                    + (EDStatic.config.wmsActive ? "," : "")
                     + "\n"
                 : "")
-            + (EDStatic.wmsActive
+            + (EDStatic.config.wmsActive
                 ? "      [\"wms\", \"http://localhost:"
                     + PORT
                     + "/erddap/wms/index.json?page=1&itemsPerPage=1000\"]\n"
@@ -6836,17 +6838,17 @@ class JettyTests {
             + "tabledap[9]http://localhost:"
             + PORT
             + "/erddap/tabledap/index.tsv?page=1&itemsPerPage=1000[10]\n"
-            + (EDStatic.sosActive
+            + (EDStatic.config.sosActive
                 ? "sos[9]http://localhost:"
                     + PORT
                     + "/erddap/sos/index.tsv?page=1&itemsPerPage=1000[10]\n"
                 : "")
-            + (EDStatic.wcsActive
+            + (EDStatic.config.wcsActive
                 ? "wcs[9]http://localhost:"
                     + PORT
                     + "/erddap/wcs/index.tsv?page=1&itemsPerPage=1000[10]\n"
                 : "")
-            + (EDStatic.wmsActive
+            + (EDStatic.config.wmsActive
                 ? "wms[9]http://localhost:"
                     + PORT
                     + "/erddap/wms/index.tsv?page=1&itemsPerPage=1000[10]\n"
@@ -6905,7 +6907,7 @@ class JettyTests {
             + PORT
             + "/erddap/tabledap/index.xhtml?page=1&amp;itemsPerPage=1000</td>\n"
             + "</tr>\n"
-            + (EDStatic.sosActive
+            + (EDStatic.config.sosActive
                 ? "<tr>\n"
                     + "<td>sos</td>\n"
                     + "<td>http://localhost:"
@@ -6913,7 +6915,7 @@ class JettyTests {
                     + "/erddap/sos/index.xhtml?page=1&amp;itemsPerPage=1000</td>\n"
                     + "</tr>\n"
                 : "")
-            + (EDStatic.wcsActive
+            + (EDStatic.config.wcsActive
                 ? "<tr>\n"
                     + "<td>wcs</td>\n"
                     + "<td>http://localhost:"
@@ -6921,7 +6923,7 @@ class JettyTests {
                     + "/erddap/wcs/index.xhtml?page=1&amp;itemsPerPage=1000</td>\n"
                     + "</tr>\n"
                 : "")
-            + (EDStatic.wmsActive
+            + (EDStatic.config.wmsActive
                 ? "<tr>\n"
                     + "<td>wms</td>\n"
                     + "<td>http://localhost:"
@@ -11075,10 +11077,10 @@ class JettyTests {
     results = SSR.getUrlResponseStringUnchanged(baseUrl + tQuery);
     expected =
         "*GLOBAL*,Conventions,\"COARDS, CF-1.6, ACDD-1.3, NCCSV-1.2\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,_FillValue,1.0E35f\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,_FillValue,1.0E35f\n" : "")
             + "*GLOBAL*,cdm_data_type,TimeSeries\n"
             + "*GLOBAL*,cdm_timeseries_variables,\"array, station, wmo_platform_code, longitude, latitude, depth\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,CREATION_DATE,hh:mm  D-MMM-YYYY\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,CREATION_DATE,hh:mm  D-MMM-YYYY\n" : "")
             + "*GLOBAL*,creator_email,Dai.C.McClurg@noaa.gov\n"
             + "*GLOBAL*,creator_name,GTMBA Project Office/NOAA/PMEL\n"
             + "*GLOBAL*,creator_type,group\n"
@@ -11105,9 +11107,9 @@ class JettyTests {
             + "*GLOBAL*,keywords,\"buoys, centered, daily, depth, Earth Science > Oceans > Ocean Temperature > Sea Surface Temperature, identifier, noaa, ocean, oceans, pirata, pmel, quality, rama, sea, sea_surface_temperature, source, station, surface, tao, temperature, time, triton\"\n"
             + "*GLOBAL*,keywords_vocabulary,GCMD Science Keywords\n"
             + "*GLOBAL*,license,\"Request for Acknowledgement: If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115\\n\\nThe data may be used and redistributed for free but is not intended\\nfor legal use, since it may contain inaccuracies. Neither the data\\nContributor, ERD, NOAA, nor the United States Government, nor any\\nof their employees or contractors, makes any warranty, express or\\nimplied, including warranties of merchantability and fitness for a\\nparticular purpose, or assumes any legal liability for the accuracy,\\ncompleteness, or usefulness, of this information.\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,missing_value,1.0E35f\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,missing_value,1.0E35f\n" : "")
             + "*GLOBAL*,Northernmost_Northing,21.0d\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,platform_code,CODE\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,platform_code,CODE\n" : "")
             + "*GLOBAL*,project,\"TAO/TRITON, RAMA, PIRATA\"\n"
             + "*GLOBAL*,Request_for_acknowledgement,\"If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115\"\n"
             + "*GLOBAL*,sourceUrl,(local files)\n"
@@ -11276,10 +11278,10 @@ class JettyTests {
     results = SSR.getUrlResponseStringUnchanged(baseUrl + tQuery);
     expected =
         "*GLOBAL*,Conventions,\"COARDS, CF-1.6, ACDD-1.3, NCCSV-1.2\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,_FillValue,1.0E35f\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,_FillValue,1.0E35f\n" : "")
             + "*GLOBAL*,cdm_data_type,TimeSeries\n"
             + "*GLOBAL*,cdm_timeseries_variables,\"array, station, wmo_platform_code, longitude, latitude, depth\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,CREATION_DATE,hh:mm  D-MMM-YYYY\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,CREATION_DATE,hh:mm  D-MMM-YYYY\n" : "")
             + "*GLOBAL*,creator_email,Dai.C.McClurg@noaa.gov\n"
             + "*GLOBAL*,creator_name,GTMBA Project Office/NOAA/PMEL\n"
             + "*GLOBAL*,creator_type,group\n"
@@ -11317,9 +11319,9 @@ class JettyTests {
             + "*GLOBAL*,keywords,\"buoys, centered, daily, depth, Earth Science > Oceans > Ocean Temperature > Sea Surface Temperature, identifier, noaa, ocean, oceans, pirata, pmel, quality, rama, sea, sea_surface_temperature, source, station, surface, tao, temperature, time, triton\"\n"
             + "*GLOBAL*,keywords_vocabulary,GCMD Science Keywords\n"
             + "*GLOBAL*,license,\"Request for Acknowledgement: If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115\\n\\nThe data may be used and redistributed for free but is not intended\\nfor legal use, since it may contain inaccuracies. Neither the data\\nContributor, ERD, NOAA, nor the United States Government, nor any\\nof their employees or contractors, makes any warranty, express or\\nimplied, including warranties of merchantability and fitness for a\\nparticular purpose, or assumes any legal liability for the accuracy,\\ncompleteness, or usefulness, of this information.\"\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,missing_value,1.0E35f\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,missing_value,1.0E35f\n" : "")
             + "*GLOBAL*,Northernmost_Northing,21.0d\n"
-            + (EDStatic.useSaxParser ? "*GLOBAL*,platform_code,CODE\n" : "")
+            + (EDStatic.config.useSaxParser ? "*GLOBAL*,platform_code,CODE\n" : "")
             + "*GLOBAL*,project,\"TAO/TRITON, RAMA, PIRATA\"\n"
             + "*GLOBAL*,Request_for_acknowledgement,\"If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115\"\n"
             + "*GLOBAL*,sourceUrl,(local files)\n"
@@ -11522,10 +11524,10 @@ class JettyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "EDDGridLonPM180_testGridWithDepth2",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     po = results.indexOf("depth {");
     Test.ensureTrue(po >= 0, "results=\n" + results);
     expected =
@@ -11535,18 +11537,18 @@ class JettyTests {
             + "    Float64 actual_range 5.01, 5375.0;\n"
             + // 2014-01-17 was 5.0, 5374.0
             "    String axis \"Z\";\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    String grads_dim \"z\";\n" + "    String grads_mapping \"levels\";\n"
                 : "")
             + "    String ioos_category \"Location\";\n"
             + "    String long_name \"Depth\";\n"
-            + (EDStatic.useSaxParser
+            + (EDStatic.config.useSaxParser
                 ? "    Float64 maximum 5375.0;\n"
                     + "    Float64 minimum 5.01;\n"
                     + "    String name \"Depth\";\n"
                 : "")
             + "    String positive \"down\";\n"
-            + (EDStatic.useSaxParser ? "    Float32 resolution 137.69205;\n" : "")
+            + (EDStatic.config.useSaxParser ? "    Float32 resolution 137.69205;\n" : "")
             + "    String standard_name \"depth\";\n"
             + "    String units \"m\";\n"
             + "  }";
@@ -11560,10 +11562,10 @@ class JettyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "EDDGridLonPM180_testGridWithDepth2",
             ".fgdc");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     po = results.indexOf("<vertdef>");
     Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
     expected =
@@ -11586,10 +11588,10 @@ class JettyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "EDDGridLonPM180_testGridWithDepth2",
             ".iso19115");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
 
     po = results.indexOf("codeListValue=\"vertical\">");
     Test.ensureTrue(po >= 0, "po=-1 results=\n" + results);
@@ -11744,10 +11746,10 @@ class JettyTests {
             null,
             null,
             "temp%5B(2008-11-15)%5D%5B(5)%5D%5B(-75):100:(75)%5D%5B(-90):100:(63.6)%5D",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             "EDDGridLonPM180_testGridWithDepthPreWMS",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time,depth,latitude,longitude,temp\n"
             + "UTC,m,degrees_north,degrees_east,degree_C\n"
@@ -11828,7 +11830,7 @@ class JettyTests {
 
     EDDGridFromDap gridDataset = (EDDGridFromDap) EDDTestDataset.gettestActualRange();
     String tName, results, expected;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     // overall kml
     tName =
@@ -12183,7 +12185,7 @@ class JettyTests {
               + //
               "      :axis = \"T\";\n"
               + //
-              (EDStatic.useSaxParser
+              (EDStatic.config.useSaxParser
                   ? "      :grads_dim = \"t\";\n"
                       + //
                       "      :grads_mapping = \"linear\";\n"
@@ -12194,7 +12196,7 @@ class JettyTests {
               + "      :ioos_category = \"Time\";\n"
               + //
               "      :long_name = \"Centered Time\";\n"
-              + (EDStatic.useSaxParser
+              + (EDStatic.config.useSaxParser
                   ? "      :maximum = \"00z15dec2010\";\n"
                       + "      :minimum = \"00z15jan1871\";\n"
                       + "      :resolution = 30.43657f; // float\n"
@@ -12217,18 +12219,18 @@ class JettyTests {
               + //
               "      :axis = \"Z\";\n"
               + //
-              (EDStatic.useSaxParser
+              (EDStatic.config.useSaxParser
                   ? "      :grads_dim = \"z\";\n" + "      :grads_mapping = \"levels\";\n"
                   : "")
               + "      :ioos_category = \"Location\";\n"
               + "      :long_name = \"Depth\";\n"
-              + (EDStatic.useSaxParser
+              + (EDStatic.config.useSaxParser
                   ? "      :maximum = 5375.0; // double\n"
                       + "      :minimum = 5.01; // double\n"
                       + "      :name = \"Depth\";\n"
                   : "")
               + "      :positive = \"down\";\n"
-              + (EDStatic.useSaxParser ? "      :resolution = 137.69205f; // float\n" : "")
+              + (EDStatic.config.useSaxParser ? "      :resolution = 137.69205f; // float\n" : "")
               + "      :standard_name = \"depth\";\n"
               + //
               "      :units = \"m\";\n"
@@ -12243,14 +12245,14 @@ class JettyTests {
               + //
               "      :axis = \"Y\";\n"
               + //
-              (EDStatic.useSaxParser
+              (EDStatic.config.useSaxParser
                   ? "      :grads_dim = \"y\";\n"
                       + "      :grads_mapping = \"linear\";\n"
                       + "      :grads_size = \"330\";\n"
                   : "")
               + "      :ioos_category = \"Location\";\n"
               + "      :long_name = \"Latitude\";\n"
-              + (EDStatic.useSaxParser
+              + (EDStatic.config.useSaxParser
                   ? "      :maximum = 89.25; // double\n"
                       + "      :minimum = -75.25; // double\n"
                       + "      :resolution = 0.5f; // float\n"
@@ -12269,14 +12271,14 @@ class JettyTests {
               + //
               "      :axis = \"X\";\n"
               + //
-              (EDStatic.useSaxParser
+              (EDStatic.config.useSaxParser
                   ? "      :grads_dim = \"x\";\n"
                       + "      :grads_mapping = \"linear\";\n"
                       + "      :grads_size = \"720\";\n"
                   : "")
               + "      :ioos_category = \"Location\";\n"
               + "      :long_name = \"Longitude\";\n"
-              + (EDStatic.useSaxParser
+              + (EDStatic.config.useSaxParser
                   ? "      :maximum = 359.75; // double\n"
                       + "      :minimum = 0.25; // double\n"
                       + "      :resolution = 0.5f; // float\n"
@@ -12610,10 +12612,10 @@ class JettyTests {
             null,
             null,
             griddapUserDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             eddGrid2.className() + "_Itself",
             ".xhtml");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
@@ -12805,10 +12807,10 @@ class JettyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Entire",
             ".das");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Attributes {\n"
@@ -13107,10 +13109,10 @@ class JettyTests {
             null,
             null,
             "",
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Entire",
             ".dds");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -13162,10 +13164,10 @@ class JettyTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".asc");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         "Dataset {\n"
@@ -13211,12 +13213,12 @@ class JettyTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         "time,longitude\n"
             + "UTC,degrees_east\n"
@@ -13242,12 +13244,12 @@ class JettyTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_AxisG.A",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
-    // Test.displayInBrowser("file://" + EDStatic.fullTestCacheDirectory + tName);
+    // Test.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     // expected = "time,longitude\n" +
     // "UTC,degrees_east\n" +
     // "2002-07-08T00:00:00Z,360.0\n" +
@@ -13269,12 +13271,12 @@ class JettyTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".dods");
     results =
         String2.annotatedString(
-            File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName));
+            File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName));
     // String2.log(results);
     expected =
         "Dataset {[10]\n"
@@ -13305,11 +13307,11 @@ class JettyTests {
             null,
             null,
             matlabAxisQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".mat");
-    String2.log(".mat test file is " + EDStatic.fullTestCacheDirectory + tName);
-    results = File2.hexDump(EDStatic.fullTestCacheDirectory + tName, 1000000);
+    String2.log(".mat test file is " + EDStatic.config.fullTestCacheDirectory + tName);
+    results = File2.hexDump(EDStatic.config.fullTestCacheDirectory + tName, 1000000);
     String2.log(results);
     expected =
         "4d 41 54 4c 41 42 20 35   2e 30 20 4d 41 54 2d 66   MATLAB 5.0 MAT-f |\n"
@@ -13363,7 +13365,7 @@ class JettyTests {
     Test.ensureEqual(
         results.substring(0, 71 * 4) + results.substring(71 * 7), // remove the creation dateTime
         expected,
-        "RESULTS(" + EDStatic.fullTestCacheDirectory + tName + ")=\n" + results);
+        "RESULTS(" + EDStatic.config.fullTestCacheDirectory + tName + ")=\n" + results);
 
     // .ncHeader
     String2.log("\n*** EDDGridFromErddap test get .NCHEADER axis data\n");
@@ -13374,10 +13376,10 @@ class JettyTests {
             null,
             null,
             query,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Axis",
             ".ncHeader");
-    results = File2.directReadFromUtf8File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     // String2.log(results);
     expected =
         // "netcdf EDDGridFromErddap_Axis.nc {\n" +
@@ -13461,10 +13463,10 @@ class JettyTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     expected = // missing values are "NaN"
         // pre 2010-10-26 was
         "time,latitude,longitude,chlorophyll\n"
@@ -13522,10 +13524,10 @@ class JettyTests {
             null,
             null,
             "chlorophyll." + userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_DotNotation",
             ".csv");
-    results = File2.directReadFrom88591File(EDStatic.fullTestCacheDirectory + tName);
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
     // expected =
     // // pre 2010-10-26 was
     // // "time, altitude, latitude, longitude, chlorophyll\n" +
@@ -13579,10 +13581,10 @@ class JettyTests {
             null,
             null,
             userDapQuery,
-            EDStatic.fullTestCacheDirectory,
+            EDStatic.config.fullTestCacheDirectory,
             gridDataset.className() + "_Data",
             ".nc");
-    results = NcHelper.ncdump(EDStatic.fullTestCacheDirectory + tName, "");
+    results = NcHelper.ncdump(EDStatic.config.fullTestCacheDirectory + tName, "");
     expected =
         "netcdf EDDGridFromErddap_Data.nc {\n"
             + //
@@ -14442,7 +14444,7 @@ class JettyTests {
     int language = 0;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
 
     EDDGrid eddGrid = (EDDGrid) EDDTestDataset.gettest_erdVHNchlamday_Lon0360();
 
@@ -14602,7 +14604,7 @@ class JettyTests {
     int language = 0;
 
     String tName, results, expected, expected2, expected3, userDapQuery;
-    String tDir = EDStatic.fullTestCacheDirectory;
+    String tDir = EDStatic.config.fullTestCacheDirectory;
     int tPo;
     userDapQuery = "longitude,NO3,time,ship&latitude%3E0&time%3E=2002-08-03";
 
@@ -15387,7 +15389,7 @@ class JettyTests {
     // debugMode = true;
     String tName, userDapQuery, results, expected;
     int po;
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     EDDGrid eddGrid = null;
 
     // test notApplicable (dataset maxLon already <180)
@@ -15400,7 +15402,7 @@ class JettyTests {
                   + "The child longitude axis has no values >180 (max=179.9792)!")
           < 0) throw t;
     }
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       Test.ensureEqual(eddGrid, null, "Dataset should be null from exception during construction.");
     }
 
@@ -15828,7 +15830,7 @@ class JettyTests {
             // lon=180
             "&.vec="; // avoid get cached response
     String baseName = "EDDGridFromNcFilesTestSpeed";
-    String baseOut = EDStatic.fullTestCacheDirectory + baseName;
+    String baseOut = EDStatic.config.fullTestCacheDirectory + baseName;
     String extensions[] =
         new String[] {
           ".asc",
@@ -16357,7 +16359,7 @@ class JettyTests {
   @org.junit.jupiter.api.Test
   @TagJetty
   void testInPortXml() throws Throwable {
-    String dir = EDStatic.fullTestCacheDirectory;
+    String dir = EDStatic.config.fullTestCacheDirectory;
     String gridTable = "grid"; // grid or table
     String tDatasetID = "erdSWchlamday";
     String fileName = "ErddapToInPort_" + tDatasetID + ".xml";
@@ -17261,7 +17263,7 @@ class JettyTests {
     context.setMajorLoad(false);
     context.setErddap(new Erddap());
     context.setLastLuceneUpdate(0);
-    context.setDatasetsRegex(EDStatic.datasetsRegex);
+    context.setDatasetsRegex(EDStatic.config.datasetsRegex);
     context.setReallyVerbose(false);
 
     factory = SAXParserFactory.newInstance();

--- a/src/test/java/testDataset/EDDTestDataset.java
+++ b/src/test/java/testDataset/EDDTestDataset.java
@@ -9,7 +9,7 @@ import java.nio.file.Path;
 
 public class EDDTestDataset {
   public static void generateDatasetsXml() throws URISyntaxException, FileNotFoundException {
-    if (EDStatic.useSaxParser) {
+    if (EDStatic.config.useSaxParser) {
       // This section writes xml files that represent parts of a dataset. These are to show using
       // XInclude
       // to load information into the datasets.xml file.
@@ -55,7 +55,7 @@ public class EDDTestDataset {
     try (PrintWriter datasetsXml = new PrintWriter("development/test/datasets.xml")) {
       datasetsXml.append(
           "<?xml version=\"1.0\" encoding=\"ISO-8859-1\" ?>\n"
-              + (EDStatic.useSaxParser ? "<!DOCTYPE note [<!ENTITY deg '&#176;'>]>\n" : "")
+              + (EDStatic.config.useSaxParser ? "<!DOCTYPE note [<!ENTITY deg '&#176;'>]>\n" : "")
               + "<erddapDatasets xmlns:xi=\"http://www.w3.org/2001/XInclude\">\n"
               // Try to set this so the datasets that need to load in the background have a chance
               // and this runs again before the jetty tests to ensure all the datasets are loaded.
@@ -219,8 +219,8 @@ public class EDDTestDataset {
       datasetsXml.append(xmlFragment_erdMH1chla1day());
       datasetsXml.append(xmlFragment_erdMH1chla8day());
       datasetsXml.append(xmlFragment_erdMH1chlamday());
-      datasetsXml.append(xmlFragment_nceiPH53sstd1day(EDStatic.useSaxParser));
-      datasetsXml.append(xmlFragment_nceiPH53sstn1day(EDStatic.useSaxParser));
+      datasetsXml.append(xmlFragment_nceiPH53sstd1day(EDStatic.config.useSaxParser));
+      datasetsXml.append(xmlFragment_nceiPH53sstn1day(EDStatic.config.useSaxParser));
       datasetsXml.append(xmlFragment_testGridFromErddap());
       datasetsXml.append(xmlFragment_testUnsignedGrid());
       datasetsXml.append(xmlFragment_testGridNThreads());
@@ -236,7 +236,7 @@ public class EDDTestDataset {
       // currently loaded
       // datasetsXml.append(xmlFragment_testGroups());// sourceAxisValues null
       datasetsXml.append(xmlFragment_testIslandShift());
-      datasetsXml.append(xmlFragment_testMinimalReadSource(EDStatic.useSaxParser));
+      datasetsXml.append(xmlFragment_testMinimalReadSource(EDStatic.config.useSaxParser));
       // datasetsXml.append(xmlFragment_nosCoopsWLR6()); //stationTable=null
       // datasetsXml.append(xmlFragment_nosCoopsWLR1()); //stationTable=null
       // datasetsXml.append(xmlFragment_nosCoopsWLV6()); //stationTable=null

--- a/src/test/java/testDataset/Initialization.java
+++ b/src/test/java/testDataset/Initialization.java
@@ -13,6 +13,6 @@ public class Initialization {
     System.setProperty("skipEmailThread", String.valueOf(true));
     EDD.debugMode = true;
     SgtMap.fontFamily = "SansSerif";
-    EDStatic.useSaxParser = true;
+    EDStatic.config.useSaxParser = true;
   }
 }


### PR DESCRIPTION
# Description

This refactors messages and config out of EDStatic, both the fields and the parsing of the relevant files. It also adds @FeatureFlag annotation which is used in the new EDConfig to mark booleans that should be included in Prometheus metrics. This will allow admins and ERDDAP developers an easier time knowing what the config state of a server is.

Note this is based on the changes in #252 so that should be merged first. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - almost entirely a refactor, so no new tests added
- [x] New and existing unit tests pass locally with my changes
