### PR TITLE
Don't log the exception while checking for isBufferedImageAccelerated…

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/SgtUtil.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/sgt/SgtUtil.java
@@ -375,8 +375,7 @@ public class SgtUtil {
         isBufferedImageAccelerated =
             "bufferedImage isAccelerated=" + (imCap == null ? "[unknown]" : imCap.isAccelerated());
       } catch (Throwable t) {
-        String2.log(MustBe.throwableToString(t));
-        isBufferedImageAccelerated = "bufferedImage isAccelerated=[unknown]";
+        isBufferedImageAccelerated = "bufferedImage isAccelerated=[" + t.toString() + "]";
       }
     }
     return isBufferedImageAccelerated;


### PR DESCRIPTION
…. Do record the toString of the exception in the status so it is still communicated.

Fixes #220 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
