### PR TITLE
2.26

### DIFF
--- a/WEB-INF/classes/com/cohort/util/String2.java
+++ b/WEB-INF/classes/com/cohort/util/String2.java
@@ -1259,10 +1259,11 @@ public class String2 {
   // Starts with a slash (that wasn't matched in previous sections), then
   // 0 or more directories, ending in either a directory or .extension, optional / or \.
   private static Pattern pathPattern =
-      Pattern.compile("^[/\\\\]?([a-zA-Z0-9-_]+[/\\\\])*[^/\\\\:?#,\\s]*[/\\\\]?(?<![.,?!#])");
+      Pattern.compile(
+          "^[/\\\\]?([a-zA-Z0-9-_.~!$&'()*+,;=:@%\\-]+[/\\\\])*[^/\\\\:?#,\\s]*[/\\\\]?(?<![.,?!#])");
   private static Pattern queryPattern =
       Pattern.compile("^\\?(\".*\"|%22.*%22|[^\\s#])*(?<![.,?!#])");
-  private static Pattern fragmentPattern = Pattern.compile("^#[^.,?!#)\\s]*");
+  private static Pattern fragmentPattern = Pattern.compile("^#[^.,!#)\\s]*(?<![.,?!#])");
 
   public static int[] findUrl(String input) {
     return findUrl(input, 0);

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/Grid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/Grid.java
@@ -12,7 +12,7 @@ import com.cohort.util.MustBe;
 import com.cohort.util.String2;
 import com.cohort.util.Test;
 import com.google.common.collect.ImmutableList;
-import java.io.RandomAccessFile;
+import gov.noaa.pfel.coastwatch.util.BufferedReadRandomAccessFile;
 import java.util.Arrays;
 import java.util.List;
 import ucar.ma2.*;
@@ -476,9 +476,10 @@ public class Grid {
       // String2.log("tLat=" + tLat + " closestLat=" + closestLat + " offset=" + offsetLat[i]);
     }
 
-    // open the file  (reading should be thread safe)
-    try (RandomAccessFile raf = new RandomAccessFile(fullFileName, "r")) {
-
+    // open the file  (reading is thread safe)
+    try (BufferedReadRandomAccessFile raf =
+        new BufferedReadRandomAccessFile(
+            fullFileName, nLon >= 2 ? offsetLon[1] - offsetLon[0] : 2, nLon)) {
       // fill data array
       // lat is outer loop because file is lat major
       // and loop is backwards since stored top to bottom
@@ -489,8 +490,10 @@ public class Grid {
       int maxSData = Integer.MIN_VALUE;
       for (int tLat = nLat - 1; tLat >= 0; tLat--) {
         for (int tLon = 0; tLon < nLon; tLon++) {
-          raf.seek(offsetLat[tLat] + offsetLon[tLon]);
-          short ts = Short.reverseBytes(raf.readShort()); // reverseBytes since etopo1 is LSB
+          short ts =
+              Short.reverseBytes(
+                  raf.readShort(
+                      offsetLat[tLat] + offsetLon[tLon])); // reverseBytes since etopo1 is LSB
           setData(tLon, tLat, ts);
           minSData = Math.min(minSData, ts);
           maxSData = Math.max(maxSData, ts);

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/BufferedReadRandomAccessFile.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/BufferedReadRandomAccessFile.java
@@ -1,0 +1,70 @@
+package gov.noaa.pfel.coastwatch.util;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+/**
+ * Wrap the RandomAccessFile with a buffer. For reads with small step sizes this can drastically
+ * speed up reads. If the step size is large, this doesn't use the buffer and has effectively the
+ * same performance as the regular RandomAccessFile.
+ */
+public class BufferedReadRandomAccessFile implements AutoCloseable {
+  private static final int DEFAULT_BUFSIZE = 4096;
+  private static final int MAX_BUFF_SIZE = 8192;
+  private static int MAX_STEP_SIZE = 512;
+  private RandomAccessFile raf;
+  private byte inbuf[];
+  private long startpos = -1;
+  private long endpos = -1;
+  private int bufsize;
+  private int seeks = 0;
+
+  public BufferedReadRandomAccessFile(String name) throws FileNotFoundException {
+    this(name, DEFAULT_BUFSIZE);
+  }
+
+  public BufferedReadRandomAccessFile(String name, int stepSize, int numSteps)
+      throws FileNotFoundException {
+    this(name, stepSize < MAX_STEP_SIZE ? stepSize * numSteps : 2);
+  }
+
+  public BufferedReadRandomAccessFile(String name, int b) throws FileNotFoundException {
+    raf = new RandomAccessFile(name, "r");
+    // Unless we think the buffer is useless (size 2), don't go lower than default size.
+    if (b > 2 && b < DEFAULT_BUFSIZE) {
+      b = DEFAULT_BUFSIZE;
+    }
+    bufsize = Math.min(b, MAX_BUFF_SIZE);
+    inbuf = new byte[bufsize];
+  }
+
+  public short readShort(long pos) {
+    if (pos < startpos || pos > endpos) {
+      long blockstart = (pos / bufsize) * bufsize;
+      int n;
+      try {
+        raf.seek(blockstart);
+        n = raf.read(inbuf);
+      } catch (IOException e) {
+        return -1;
+      }
+      startpos = blockstart;
+      endpos = blockstart + n - 1;
+      seeks++;
+      if (pos < startpos || pos > endpos) return -1;
+    }
+    return (short)
+        ((inbuf[(int) (pos - startpos) + 1] & 0xff)
+            + ((inbuf[(int) (pos - startpos)] & 0xff) << 8));
+  }
+
+  public int getSeeks() {
+    return seeks;
+  }
+
+  @Override
+  public void close() throws IOException {
+    raf.close();
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -6419,7 +6419,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           out.close(); // often already closed; closing again does nothing
         }
       } catch (Exception e2) {
-        String2.log(MustBe.throwableToString(e2));
+        String2.log("Logging error, likely from client problem: " + MustBe.throwableToString(e2));
       } // essential, to end compression  //hard to put in finally {}
     }
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/LoadDatasets.java
@@ -794,7 +794,7 @@ public class LoadDatasets extends Thread {
               // trigger subscription and dataset.onChange actions (after new dataset is in place)
               EDD cooDataset = dataset == null ? oldDataset : dataset; // currentOrOld, may be null
 
-              erddap.tryToDoActions(
+              Erddap.tryToDoActions(
                   tId,
                   cooDataset,
                   startError + xmlReader.lineNumber() + " with Subscriptions",
@@ -1714,7 +1714,7 @@ public class LoadDatasets extends Thread {
     changedDatasetIDs.add(tId);
     if (needToUpdateLucene) erddap.updateLucene(changedDatasetIDs);
     // do dataset actions so subscribers know it is gone
-    erddap.tryToDoActions(
+    Erddap.tryToDoActions(
         tId,
         oldEdd,
         null, // default subject

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -1284,6 +1284,14 @@ public abstract class EDD {
     return snapshot;
   }
 
+  protected boolean mapValueMatches(
+      Map<String, String> snapshotA, Map<String, String> snapshotB, String key) {
+    if (snapshotA.get(key) == null) {
+      return snapshotB.get(key) == null;
+    }
+    return snapshotA.get(key).equals(snapshotB.get(key));
+  }
+
   /**
    * This tests if 'oldSnapshot' is different from this in any way. <br>
    * This test is from the view of a subscriber who wants to know when a dataset has changed in any
@@ -1321,7 +1329,7 @@ public abstract class EDD {
       String typeKey = "dv_" + dv + "_type";
       String attrKey = "dv_" + dv + "_attr";
       String msg2 = "#" + dv + "=" + newSnapshot.get(nameKey);
-      if (!oldSnapshot.get(nameKey).equals(newSnapshot.get(nameKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, nameKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChanged2Different,
@@ -1331,7 +1339,7 @@ public abstract class EDD {
                     newSnapshot.get(nameKey))
                 + "\n");
       }
-      if (!oldSnapshot.get(typeKey).equals(newSnapshot.get(typeKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, typeKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChanged2Different,

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -565,14 +565,26 @@ public abstract class EDD {
           case "EDDGridCopy" -> {
             return EDDGridCopy.fromXml(erddap, xmlReader);
           }
-          case "EDDGridFromAudioFiles",
-              "EDDGridFromNcFilesUnpacked",
-              "EDDGridFromNcFiles",
-              "EDDGridFromMergeIRFiles",
-              "EDDGridLonPM180",
-              "EDDGridLon0360",
-              "EDDGridSideBySide" -> {
+          case "EDDGridFromAudioFiles" -> {
             return EDDGridFromAudioFiles.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridFromNcFilesUnpacked" -> {
+            return EDDGridFromNcFilesUnpacked.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridFromNcFiles" -> {
+            return EDDGridFromNcFiles.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridFromMergeIRFiles" -> {
+            return EDDGridFromMergeIRFiles.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridLonPM180" -> {
+            return EDDGridLonPM180.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridLon0360" -> {
+            return EDDGridLon0360.fromXml(erddap, xmlReader);
+          }
+          case "EDDGridSideBySide" -> {
+            return EDDGridSideBySide.fromXml(erddap, xmlReader);
           }
           case "EDDGridFromDap" -> {
             return EDDGridFromDap.fromXml(erddap, xmlReader);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -6647,9 +6647,14 @@ public abstract class EDDGrid extends EDD {
         }
 
         dos.flush(); // essential
+      } catch (Exception e) {
+        String2.log(e.getMessage());
       } finally {
         if (writer != null) {
-          writer.close();
+          try {
+            writer.close();
+          } catch (Exception e) {
+          }
           writer = null;
         }
       }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -2706,7 +2706,7 @@ public abstract class EDDGrid extends EDD {
       String maxKey = "av_" + av + "_maxValue";
       String attrKey = "av_" + av + "_attr";
       String msg2 = "#" + av + "=" + newSnapshot.get(nameKey);
-      if (!oldSnapshot.get(nameKey).equals(newSnapshot.get(nameKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, nameKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChangedAxes2Different,
@@ -2716,7 +2716,7 @@ public abstract class EDDGrid extends EDD {
                     newSnapshot.get(nameKey))
                 + "\n");
       }
-      if (!oldSnapshot.get(typeKey).equals(newSnapshot.get(typeKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, typeKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChangedAxes2Different,
@@ -2726,7 +2726,7 @@ public abstract class EDDGrid extends EDD {
                     newSnapshot.get(typeKey))
                 + "\n");
       }
-      if (!oldSnapshot.get(sourceSizeKey).equals(newSnapshot.get(sourceSizeKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, sourceSizeKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChangedAxes2Different,
@@ -2736,7 +2736,7 @@ public abstract class EDDGrid extends EDD {
                     newSnapshot.get(sourceSizeKey))
                 + "\n");
       }
-      if (!oldSnapshot.get(minKey).equals(newSnapshot.get(minKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, minKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChangedAxes2Different,
@@ -2746,7 +2746,7 @@ public abstract class EDDGrid extends EDD {
                     newSnapshot.get(minKey))
                 + "\n");
       }
-      if (!oldSnapshot.get(maxKey).equals(newSnapshot.get(maxKey))) {
+      if (!mapValueMatches(oldSnapshot, newSnapshot, maxKey)) {
         diff.append(
             MessageFormat.format(
                     EDStatic.messages.EDDChangedAxes2Different,

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -3433,7 +3433,13 @@ public abstract class EDDGrid extends EDD {
                               EDStatic.messages.queryErrorFileTypeAr[language], fileTypeName)));
             }
           } finally {
-            fos.close();
+            if (fos != null) {
+              try {
+                fos.close();
+              } catch (Exception e) {
+                String2.log("Error closing stream, log and continue: " + e.getMessage());
+              }
+            }
           }
           File2.rename(cacheFullName + random, cacheFullName);
           if (!ok) // make eligible to be removed from cache in 5 minutes
@@ -6091,7 +6097,11 @@ public abstract class EDDGrid extends EDD {
       writer.flush(); // essential
     } finally {
       if (writer != null) {
-        writer.close();
+        try {
+          writer.close();
+        } catch (Exception e) {
+          String2.log("Error closing writer, log and continue: " + e.getMessage());
+        }
       }
     }
 
@@ -10132,7 +10142,13 @@ public abstract class EDDGrid extends EDD {
           fullOutName,
           time);
     } finally {
-      dos.close();
+      if (dos != null) {
+        try {
+          dos.close();
+        } catch (Exception e) {
+          String2.log("Error closing stream, log and continue: " + e.getMessage());
+        }
+      }
     }
     File2.delete(fullDosName);
 
@@ -11291,7 +11307,11 @@ public abstract class EDDGrid extends EDD {
       writer.flush(); // essential
     } finally {
       if (writer != null) {
-        writer.close();
+        try {
+          writer.close();
+        } catch (Exception e) {
+          String2.log("Error closing writer, log and continue: " + e.getMessage());
+        }
       }
     }
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
@@ -14845,13 +14845,12 @@ public abstract class EDDTable extends EDD {
             true,
             -1);
       }
-
       writer.write(
           "<p>"
               + MessageFormat.format(
                   EDStatic.messages.subsetNVariableCombosAr[language], "" + onRows)
               + "\n");
-      if (onRows > viewValue[current])
+      if (onRows > viewValue[current]) {
         writer.write(
             "<br><span class=\"warningColor\">"
                 + MessageFormat.format(
@@ -14859,7 +14858,9 @@ public abstract class EDDTable extends EDD {
                     "" + Math.min(onRows, viewValue[current]),
                     "" + (onRows - viewValue[current]))
                 + "</span>\n");
-      else writer.write(EDStatic.messages.subsetShowingAllRowsAr[language] + "\n");
+      } else {
+        writer.write(EDStatic.messages.subsetShowingAllRowsAr[language] + "\n");
+      }
       writer.write(
           "<br>"
               + MessageFormat.format(
@@ -15185,15 +15186,28 @@ public abstract class EDDTable extends EDD {
       writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
       writer.write("\n</html>\n");
       writer.flush(); // essential
-
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
-      writer.write(EDStatic.htmlForException(language, t));
-      writer.write("</div>\n");
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
-      writer.write("\n</html>\n");
-      writer.flush(); // essential
+      try {
+        writer.write(EDStatic.htmlForException(language, t));
+        writer.write("</div>\n");
+        writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+        writer.write("\n</html>\n");
+        writer.flush(); // essential
+      } catch (Exception e) {
+        String2.log(
+            "Error while cleaning up from exception (error rethrown after): " + e.getMessage());
+      }
       throw t;
+    } finally {
+      if (writer != null) {
+        try {
+          writer.close();
+        } catch (Exception e) {
+          String2.log(
+              "Error while cleaning up from exception (error rethrown after): " + e.getMessage());
+        }
+      }
     }
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/OutputStreamFromHttpResponse.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/OutputStreamFromHttpResponse.java
@@ -99,7 +99,7 @@ public class OutputStreamFromHttpResponse implements OutputStreamSource {
     // or http://www.freeformatter.com/mime-types-list.html#mime-types-list
     String extensionLC = extension.toLowerCase();
     String contentType = null;
-    HashMap headerMap = new HashMap();
+    HashMap<String, String> headerMap = new HashMap<>();
     boolean genericCompressed = false; // true for generic compressed files, e.g., .zip
     boolean otherCompressed =
         false; // true for app specific compressed (but not audio/ image/ video)
@@ -808,16 +808,15 @@ public class OutputStreamFromHttpResponse implements OutputStreamSource {
     // 2020-12-07 this is the section that was inline but now uses the static methods above
     Object fileTypeInfo[] = getFileTypeInfo(request, fileType, extension);
     String contentType = (String) fileTypeInfo[0];
-    HashMap headerMap = (HashMap) fileTypeInfo[1];
+    HashMap<String, String> headerMap = (HashMap<String, String>) fileTypeInfo[1];
     boolean genericCompressed =
         (Boolean) fileTypeInfo[2]; // true for generic compressed files, e.g., .zip
     boolean otherCompressed =
         (Boolean) fileTypeInfo[3]; // true for app specific compressed (but not audio/ image/ video)
 
     response.setContentType(contentType);
-    for (Object o : headerMap.keySet()) {
-      String key = (String) o;
-      response.setHeader(key, (String) headerMap.get(key));
+    for (String key : headerMap.keySet()) {
+      response.setHeader(key, headerMap.get(key));
     }
 
     // set the characterEncoding

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -185,7 +185,7 @@ public class EDStatic {
    * 2.24 released on 2024-06-07 <br>
    * 2.25 first RC on 2024-10-16 released on 2024-10-31 <br>
    * 2.25_1 RC 2024-11-07 <br>
-   * 2.26 RC on 2025-03-06 <br>
+   * 2.26 RC on 2025-03-11 <br>
    *
    * <p>For main branch releases, this will be a floating point number with 2 decimal digits, with
    * no additional text. !!! In general, people other than the main ERDDAP developer (Bob) should

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -184,7 +184,8 @@ public class EDStatic {
    * 2.23 released on 2023-02-27 <br>
    * 2.24 released on 2024-06-07 <br>
    * 2.25 first RC on 2024-10-16 released on 2024-10-31 <br>
-   * 2.25_1 RC 2024-11-07
+   * 2.25_1 RC 2024-11-07 <br>
+   * 2.26 RC on 2025-03-06 <br>
    *
    * <p>For main branch releases, this will be a floating point number with 2 decimal digits, with
    * no additional text. !!! In general, people other than the main ERDDAP developer (Bob) should
@@ -194,7 +195,7 @@ public class EDStatic {
    * anything following it. A request to http.../erddap/version will return just the number (as
    * text). A request to http.../erddap/version_string will return the full string.
    */
-  public static final String erddapVersion = "2.25_1"; // see comment above
+  public static final String erddapVersion = "2.26"; // see comment above
 
   /** This identifies the dods server/version that this mimics. */
   public static final String dapVersion = "DAP/2.0";

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -425,8 +425,8 @@ public class EDStatic {
   // touchThread variables
   // Funnelling all touchThread tasks through one touchThread ensures that
   //  touches that timeout don't slow down other processes.
-  public static final ArrayList<String> touchList =
-      new ArrayList<>(); // keep here in case TouchThread needs to be restarted
+  public static final RequestQueue<String> touchList =
+      new RequestQueue<>(); // keep here in case TouchThread needs to be restarted
   private static TouchThread touchThread;
 
   // no lastAssignedTouch since not needed

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/RequestQueue.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/RequestQueue.java
@@ -1,0 +1,49 @@
+package gov.noaa.pfel.erddap.util;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * This class is designed to be a queue for requests that only need to happen once. If an item is
+ * added that matches an item currently queued it will be ignored. The original request will still
+ * happen when it reaches the front of the queue. This should make sure the requests are handled
+ * while minimizing duplicated work.
+ */
+public class RequestQueue<T> {
+
+  private final Queue<T> queue = new ArrayDeque<T>();
+  private final Set<T> set = new HashSet<T>();
+  private int removed = 0;
+
+  public boolean add(T t) {
+    // Only add element to queue if the set does not contain the specified element.
+    if (set.add(t)) {
+      queue.add(t);
+    }
+    return true;
+  }
+
+  public T getNext() throws NoSuchElementException {
+    T ret = queue.remove();
+    set.remove(ret);
+    removed++;
+    return ret;
+  }
+
+  public boolean hasNext() {
+    return !queue.isEmpty();
+  }
+
+  /**
+   * This is slightly weird behavior but is done to maintain the same size values as the old
+   * approach.
+   *
+   * @return the size of the current set + the number of used (removed) entries.
+   */
+  public int size() {
+    return removed + set.size();
+  }
+}

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/TouchThread.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/TouchThread.java
@@ -59,7 +59,7 @@ public class TouchThread extends Thread {
         return; // only return (stop thread) if interrupted
       }
 
-      while (EDStatic.nextTouch.get() < EDStatic.touchList.size()) {
+      while (EDStatic.touchList.hasNext()) {
         String url = null;
         try {
           // check isInterrupted
@@ -73,7 +73,7 @@ public class TouchThread extends Thread {
           // start to do the touch
           // do these things quickly to keep internal consistency
           EDStatic.nextTouch.incrementAndGet();
-          url = EDStatic.touchList.get(EDStatic.nextTouch.get() - 1);
+          url = EDStatic.touchList.getNext();
           lastStartTime = System.currentTimeMillis();
           String2.log(
               "%%% TouchThread started touch #"
@@ -135,8 +135,6 @@ public class TouchThread extends Thread {
           lastStartTime = -1;
           synchronized (EDStatic.touchList) {
             EDStatic.lastFinishedTouch.set(EDStatic.nextTouch.get() - 1);
-            EDStatic.touchList.set(
-                (EDStatic.nextTouch.get() - 1), null); // throw away the touch info (gc)
           }
         }
       }

--- a/development/test/setup.xml
+++ b/development/test/setup.xml
@@ -392,5 +392,6 @@ If an attribute is a global attribute, identify it by prefixing it with "global:
 <useSaxParser>true</useSaxParser>
 <usePrometheusMetrics>true</usePrometheusMetrics>
 <showLoadErrorsOnStatusPage>true</showLoadErrorsOnStatusPage>
+<useSisISO19115>true</useSisISO19115>
 </erddapSetup>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <error-prone.version>2.27.0</error-prone.version>
         <prometheusVersion>1.3.6</prometheusVersion>
         <parquetVersion>1.15.0</parquetVersion>
-        <awssdkVersion>2.30.34</awssdkVersion>
+        <awssdkVersion>2.30.38</awssdkVersion>
         <download.unpackWhenChanged>true</download.unpackWhenChanged>
     </properties>
 
@@ -650,7 +650,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.11.3</version>
+                <version>5.12.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -660,7 +660,7 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.6</version>
             </dependency>
 
             <!--
@@ -678,13 +678,13 @@
             <dependency>
                 <groupId>dnsjava</groupId>
                 <artifactId>dnsjava</artifactId>
-                <version>3.6.2</version>
+                <version>3.6.3</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk18on</artifactId>
-                <version>1.79</version>
+                <version>1.80</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2 -->
             <dependency>
@@ -696,7 +696,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.47</version>
+                <version>10.0.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -960,9 +960,9 @@
             <version>1.4</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>4.0.5</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>4.0.4</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -1044,7 +1044,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.115.Final</version>
+            <version>4.1.119.Final</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java 
@@ -1102,7 +1102,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.36.1</version>
+            <version>0.36.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http -->

--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
         <erddapreffiles.download.version>1.0.0</erddapreffiles.download.version>
         <netcdfJavaVersion>5.7.0</netcdfJavaVersion>
         <test.resources.version>test1.04</test.resources.version>
-        <jettyVersion>12.0.16</jettyVersion>
+        <jettyVersion>12.0.18</jettyVersion>
         <error-prone.version>2.27.0</error-prone.version>
         <prometheusVersion>1.3.6</prometheusVersion>
-        <parquetVersion>1.15.0</parquetVersion>
-        <awssdkVersion>2.30.38</awssdkVersion>
+        <parquetVersion>1.15.1</parquetVersion>
+        <awssdkVersion>2.31.3</awssdkVersion>
         <download.unpackWhenChanged>true</download.unpackWhenChanged>
     </properties>
 
@@ -91,6 +91,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.18.0</version>
+                <configuration>
+                    <!-- some location that makes sense for your company/project -->
+                    <rulesUri>file:///${project.basedir}/versionrules.xml</rulesUri>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -400,7 +409,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.9.2.0</version>
+                <version>4.9.3.0</version>
                 <configuration>
                     <effort>max</effort>
                     <includeFilterFile>spotbugs-security-include.xml</includeFilterFile>
@@ -650,7 +659,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.12.0</version>
+                <version>5.12.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -747,7 +756,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.16.0</version>
+            <version>5.16.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -962,7 +971,7 @@
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>4.0.4</version>
+            <version>4.0.5</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -1102,7 +1111,7 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.36.2</version>
+            <version>0.36.3</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>gov.noaa.pfel.erddap</groupId>
     <artifactId>ERDDAP</artifactId>
-    <version>2.25_1</version>
+    <version>2.26</version>
     <packaging>war</packaging>
 
     <name>erddap</name>
@@ -47,8 +47,11 @@
         <erddapreffiles.download.version>1.0.0</erddapreffiles.download.version>
         <netcdfJavaVersion>5.7.0</netcdfJavaVersion>
         <test.resources.version>test1.04</test.resources.version>
-        <jettyVersion>12.0.15</jettyVersion>
+        <jettyVersion>12.0.16</jettyVersion>
         <error-prone.version>2.27.0</error-prone.version>
+        <prometheusVersion>1.3.6</prometheusVersion>
+        <parquetVersion>1.15.0</parquetVersion>
+        <awssdkVersion>2.30.34</awssdkVersion>
         <download.unpackWhenChanged>true</download.unpackWhenChanged>
     </properties>
 
@@ -91,7 +94,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <configuration>
                     <filesets>
                         <fileset>
@@ -105,7 +108,7 @@
                 <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-compiler-plugin -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.0</version>
                 <configuration>
                     <failOnError>true</failOnError>
                     <source>21</source>   <!-- java version -->
@@ -260,7 +263,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.11.5</version>
+                <version>1.13.0</version>
                 <executions>
                     <execution>
                         <id>download-content</id>
@@ -397,7 +400,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.8.6.6</version>
+                <version>4.9.2.0</version>
                 <configuration>
                     <effort>max</effort>
                     <includeFilterFile>spotbugs-security-include.xml</includeFilterFile>
@@ -625,7 +628,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -639,7 +642,7 @@
             <dependency>
               <groupId>software.amazon.awssdk</groupId>
               <artifactId>bom</artifactId>
-              <version>2.29.16</version> <!-- and same number several places below -->
+              <version>${awssdkVersion}</version> <!-- and same number several places below -->
               <type>pom</type>
               <scope>import</scope>
             </dependency>
@@ -763,12 +766,11 @@
         </dependency-->
 
         <!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-core 
-             The Lucene search option uses this. 
-             2021-12-16 WARNING: Lucene 9.0.0 is available but requires Java 11(?). -->
+             The Lucene search option uses this. -->
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>10.0.0</version>
+            <version>10.1.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-queryparser 
@@ -776,7 +778,7 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>10.0.0</version>
+            <version>10.1.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.json/json 
@@ -784,7 +786,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20240303</version>
+            <version>20250107</version>
         </dependency>
 
         <!-- I have private copy of source code in with my code.
@@ -989,7 +991,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.4</version>
+            <version>42.7.5</version>
         </dependency>
 
 
@@ -1009,7 +1011,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.3.1-jre</version>
+            <version>33.4.0-jre</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.jpountz.lz4/lz4 
@@ -1025,7 +1027,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.28</version>
+            <version>4.2.30</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.netty/netty-all 
@@ -1065,7 +1067,7 @@
         <dependency>
           <groupId>software.amazon.awssdk</groupId>
           <artifactId>s3</artifactId>
-          <version>2.29.16</version>
+          <version>${awssdkVersion}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/regions 
@@ -1073,7 +1075,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>regions</artifactId>
-            <version>2.29.16</version>
+            <version>${awssdkVersion}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/s3-transfer-manager
@@ -1081,7 +1083,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3-transfer-manager</artifactId>
-            <version>2.29.16</version>
+            <version>${awssdkVersion}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk.crt/aws-crt
@@ -1091,35 +1093,35 @@
         <dependency>
             <groupId>software.amazon.awssdk.crt</groupId>
             <artifactId>aws-crt</artifactId>
-            <version>0.33.1</version>
+            <version>0.36.1</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.auth/google-auth-library-oauth2-http -->
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>1.30.0</version>
+            <version>1.33.1</version>
         </dependency>
 
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-core</artifactId>
-            <version>1.3.5</version>
+            <version>${prometheusVersion}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-model</artifactId>
-            <version>1.3.5</version>
+            <version>${prometheusVersion}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-instrumentation-jvm</artifactId>
-            <version>1.3.5</version>
+            <version>${prometheusVersion}</version>
         </dependency>
         <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>prometheus-metrics-exporter-servlet-jakarta</artifactId>
-            <version>1.3.5</version>
+            <version>${prometheusVersion}</version>
         </dependency>
         <dependency>
             <groupId>io.github.classgraph</groupId>
@@ -1140,17 +1142,17 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-common</artifactId>
-            <version>1.14.4</version>
+            <version>${parquetVersion}</version>
         </dependency>
          <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-encoding</artifactId>
-            <version>1.14.4</version>
+            <version>${parquetVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
-            <version>1.14.4</version>
+            <version>${parquetVersion}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -743,6 +743,15 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.16.0</version>
+            <scope>test</scope>
+        </dependency>
+
+
         <!-- Kyle had this: 
              https://mvnrepository.com/artifact/org.apache.ant/ant 
         <dependency>

--- a/src/test/java/com/cohort/util/String2Tests.java
+++ b/src/test/java/com/cohort/util/String2Tests.java
@@ -39,6 +39,19 @@ public class String2Tests {
     assertEquals(0, results[0]);
     assertEquals(17, results[1]);
 
+    // check for . within a path
+    results = String2.findUrl("https://tds.hycom.org/thredds/dodsC/GLBu0.08/expt_90.9.html");
+    assertEquals(0, results[0]);
+    assertEquals(59, results[1]);
+    results = String2.findUrl("https://doi.org/10.25921/RE9P-PT57");
+    assertEquals(0, results[0]);
+    assertEquals(34, results[1]);
+
+    // check for ? within a fragment
+    results = String2.findUrl("https://data.cencoos.org/#search?type_group=all&query=hab&page=1");
+    assertEquals(0, results[0]);
+    assertEquals(64, results[1]);
+
     // check a complex url (including spaces inside quotes of query)
     results =
         String2.findUrl(
@@ -115,7 +128,7 @@ public class String2Tests {
   @Test
   void testFindUrl_complex() {
     // two urls, find the first
-    int[] results = String2.findUrl("http://cencoos.org/,https://www.axiomdatascience.com");
+    int[] results = String2.findUrl("http://cencoos.org/, https://www.axiomdatascience.com");
     assertEquals(0, results[0]);
     assertEquals(19, results[1]);
 

--- a/src/test/java/gov/noaa/pfel/erddap/ErddapTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/ErddapTests.java
@@ -1,9 +1,17 @@
 package gov.noaa.pfel.erddap;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.cohort.util.String2;
 import com.cohort.util.Test;
 import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.erddap.dataset.EDDGrid;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.BeforeAll;
 import tags.TagIncompleteTest;
@@ -14,6 +22,17 @@ class ErddapTests {
   @BeforeAll
   static void init() {
     Initialization.edStatic();
+  }
+
+  @org.junit.jupiter.api.Test
+  void testSitemap() throws Throwable {
+    Erddap erddap = new Erddap();
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ServletOutputStream outStream = mock(ServletOutputStream.class);
+    when(response.getOutputStream()).thenReturn(outStream);
+    erddap.doSitemap(request, response);
+    verify(response, times(1)).getOutputStream();
   }
 
   /** Test Convert Nearest Data. */

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
@@ -60,6 +60,52 @@ class EDDGridTests {
     verifyNoMoreInteractions(request);
   }
 
+  @org.junit.jupiter.api.Test
+  void testSaveAsAsc() throws Throwable {
+    EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getetopo180();
+    String mapDapQuery = "altitude%5B(-90.0):(-88.0)%5D%5B(-180.0):(-178.0)%5D";
+    String requestUrl = "/erddap/griddap/etopo180.dods";
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ServletOutputStream outStream = mock(ServletOutputStream.class);
+    when(request.getHeader("Range")).thenReturn(null);
+    when(response.getOutputStream()).thenReturn(outStream);
+    when(request.getHeader("accept-encoding")).thenReturn("gzip");
+    doThrow(new RuntimeException()).when(outStream).close();
+
+    OutputStreamFromHttpResponse outputStreamSource =
+        new OutputStreamFromHttpResponse(request, response, "temp", ".dods", ".dods");
+    eddGrid.saveAsAsc(0, requestUrl, mapDapQuery, outputStreamSource);
+
+    verify(request).getHeader("Range");
+    verify(request).getHeader("accept-encoding");
+    verify(outStream, times(1)).close();
+    verifyNoMoreInteractions(request);
+  }
+
+  @org.junit.jupiter.api.Test
+  void testSaveAsNcoJson() throws Throwable {
+    EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getetopo180();
+    String mapDapQuery = "altitude%5B(-90.0):(-88.0)%5D%5B(-180.0):(-178.0)%5D";
+    String requestUrl = "/erddap/griddap/etopo180.dods";
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ServletOutputStream outStream = mock(ServletOutputStream.class);
+    when(request.getHeader("Range")).thenReturn(null);
+    when(response.getOutputStream()).thenReturn(outStream);
+    when(request.getHeader("accept-encoding")).thenReturn("gzip");
+    doThrow(new RuntimeException()).when(outStream).close();
+
+    OutputStreamFromHttpResponse outputStreamSource =
+        new OutputStreamFromHttpResponse(request, response, "temp", ".dods", ".dods");
+    eddGrid.saveAsNcoJson(0, requestUrl, mapDapQuery, outputStreamSource);
+
+    verify(request).getHeader("Range");
+    verify(request).getHeader("accept-encoding");
+    verify(outStream, times(1)).close();
+    verifyNoMoreInteractions(request);
+  }
+
   /**
    * Test saveAsImage, specifically to make sure a transparent png that's partially outside of the
    * range of the dataset still returns the image for the part that is within range.

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
@@ -1,5 +1,12 @@
 package gov.noaa.pfel.erddap.dataset;
 
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.cohort.util.File2;
 import com.cohort.util.Image2Tests;
 import com.cohort.util.Math2;
@@ -8,6 +15,9 @@ import com.cohort.util.Test;
 import gov.noaa.pfel.coastwatch.griddata.NcHelper;
 import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.erddap.util.EDStatic;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
@@ -25,6 +35,29 @@ class EDDGridTests {
   @BeforeAll
   static void init() {
     Initialization.edStatic();
+  }
+
+  @org.junit.jupiter.api.Test
+  void testSaveAsDODS() throws Throwable {
+    EDDGrid eddGrid = (EDDGrid) EDDTestDataset.getetopo180();
+    String mapDapQuery = "altitude%5B(-90.0):(-88.0)%5D%5B(-180.0):(-178.0)%5D";
+    String requestUrl = "/erddap/griddap/etopo180.dods";
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ServletOutputStream outStream = mock(ServletOutputStream.class);
+    when(request.getHeader("Range")).thenReturn(null);
+    when(response.getOutputStream()).thenReturn(outStream);
+    when(request.getHeader("accept-encoding")).thenReturn("gzip");
+    doThrow(new RuntimeException()).when(outStream).close();
+
+    OutputStreamFromHttpResponse outputStreamSource =
+        new OutputStreamFromHttpResponse(request, response, "temp", ".dods", ".dods");
+    eddGrid.saveAsDODS(0, requestUrl, mapDapQuery, outputStreamSource);
+
+    verify(request).getHeader("Range");
+    verify(request).getHeader("accept-encoding");
+    verify(outStream, times(1)).close();
+    verifyNoMoreInteractions(request);
   }
 
   /**

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
@@ -6956,16 +6956,17 @@ class EDDTableFromNcFilesTests {
     }
     results =
         results.replaceAll(
-            "<gml:beginPosition>....-..-..T12:00:00Z", "<gml:beginPosition>YYYY-MM-DDT12:00:00Z");
-    results =
-        results.replaceAll(
             "<gml:beginPosition>....-..-..T..:..:..Z", "<gml:beginPosition>YYYY-MM-DDT12:00:00Z");
     results =
         results.replaceAll(
-            "<gml:endPosition>....-..-..T12:00:00Z", "<gml:endPosition>YYYY-MM-DDT12:00:00Z");
+            "<gml:beginPosition>....-..-..T..:..:..-..:..",
+            "<gml:beginPosition>YYYY-MM-DDT12:00:00Z");
     results =
         results.replaceAll(
             "<gml:endPosition>....-..-..T..:..:..Z", "<gml:endPosition>YYYY-MM-DDT12:00:00Z");
+    results =
+        results.replaceAll(
+            "<gml:endPosition>....-..-..T..:..:..-..:..", "<gml:endPosition>YYYY-MM-DDT12:00:00Z");
     results =
         results.replaceAll(
             "<gmd:maximumValue><gco:Real>[0-9]+.[0-9]+</gco:Real></gmd:maximumValue>",

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
@@ -6894,8 +6894,8 @@ class EDDTableFromNcFilesTests {
               + "            <gex:EX_TemporalExtent>\n"
               + "              <gex:extent>\n"
               + "                <gml:TimePeriod>\n"
-              + "                  <gml:beginPosition>1977-11-06T07:00:00-05:00</gml:beginPosition>\n"
-              + "                  <gml:endPosition>2022-01-02T07:00:00-05:00</gml:endPosition>\n"
+              + "                  <gml:beginPosition>YYYY-MM-DDT12:00:00Z</gml:beginPosition>\n"
+              + "                  <gml:endPosition>YYYY-MM-DDT12:00:00Z</gml:endPosition>\n"
               + "                </gml:TimePeriod>\n"
               + "              </gex:extent>\n"
               + "            </gex:EX_TemporalExtent>\n"
@@ -6957,6 +6957,15 @@ class EDDTableFromNcFilesTests {
     results =
         results.replaceAll(
             "<gml:beginPosition>....-..-..T12:00:00Z", "<gml:beginPosition>YYYY-MM-DDT12:00:00Z");
+    results =
+        results.replaceAll(
+            "<gml:beginPosition>....-..-..T..:..:..Z", "<gml:beginPosition>YYYY-MM-DDT12:00:00Z");
+    results =
+        results.replaceAll(
+            "<gml:endPosition>....-..-..T12:00:00Z", "<gml:endPosition>YYYY-MM-DDT12:00:00Z");
+    results =
+        results.replaceAll(
+            "<gml:endPosition>....-..-..T..:..:..Z", "<gml:endPosition>YYYY-MM-DDT12:00:00Z");
     results =
         results.replaceAll(
             "<gmd:maximumValue><gco:Real>[0-9]+.[0-9]+</gco:Real></gmd:maximumValue>",

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
@@ -7388,7 +7388,9 @@ class EDDTableFromNcFilesTests {
             + "    String cdm_data_type \"TimeSeries\";\n"
             + "    String cdm_timeseries_variables \"array, station, wmo_platform_code, longitude, latitude, depth\";\n"
             + "    String Conventions \"COARDS, CF-1.6, ACDD-1.3\";\n"
-            + "    String CREATION_DATE \"HH:MM  D-MMM-YYYY\";\n"
+            + (results.indexOf("String CREATION_DATE") > -1
+                ? "    String CREATION_DATE \"HH:MM  D-MMM-YYYY\";\n"
+                : "")
             + "    String creator_email \"Dai.C.McClurg@noaa.gov\";\n"
             + "    String creator_name \"GTMBA Project Office/NOAA/PMEL\";\n"
             + "    String creator_type \"group\";\n"
@@ -7436,9 +7438,15 @@ class EDDTableFromNcFilesTests {
             + "implied, including warranties of merchantability and fitness for a\n"
             + "particular purpose, or assumes any legal liability for the accuracy,\n"
             + "completeness, or usefulness, of this information.\";\n"
-            + "    Float32 missing_value 1.0e+35;\n"
+            + (results.indexOf(
+                        "Float32 missing_value", results.indexOf("tabledap/pmelTaoDyAirt.das"))
+                    > -1
+                ? "    Float32 missing_value 1.0e+35;\n"
+                : "")
             + "    Float64 Northernmost_Northing 21.0;\n"
-            + "    String platform_code \"CODE\";\n"
+            + (results.indexOf("String platform_code") > -1
+                ? "    String platform_code \"CODE\";\n"
+                : "")
             + "    String project \"TAO/TRITON, RAMA, PIRATA\";\n"
             + "    String Request_for_acknowledgement \"If you use these data in publications "
             + "or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. "

--- a/src/test/java/gov/noaa/pfel/erddap/util/RequestQueueTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/util/RequestQueueTests.java
@@ -1,0 +1,54 @@
+package gov.noaa.pfel.erddap.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class RequestQueueTests {
+
+  @Test
+  void basicTests() {
+    RequestQueue<String> queue = new RequestQueue<>();
+    assertFalse(queue.hasNext());
+
+    queue.add("first");
+    assertTrue(queue.hasNext());
+    assertEquals(1, queue.size());
+
+    queue.add("first");
+    assertTrue(queue.hasNext());
+    assertEquals(1, queue.size());
+
+    queue.add("second");
+    assertEquals(2, queue.size());
+
+    queue.add("third");
+    queue.add("first");
+    queue.add("second");
+    queue.add("third");
+    assertEquals(3, queue.size());
+    String value = queue.getNext();
+    assertEquals("first", value);
+    value = queue.getNext();
+    assertEquals("second", value);
+    value = queue.getNext();
+    assertEquals("third", value);
+    assertFalse(queue.hasNext());
+    assertEquals(3, queue.size());
+    queue.add("first");
+    queue.add("second");
+    queue.add("third");
+    assertEquals(6, queue.size());
+    value = queue.getNext();
+    assertEquals("first", value);
+    queue.add("first");
+    queue.add("second");
+    queue.add("third");
+    assertEquals(7, queue.size());
+    value = queue.getNext();
+    assertEquals("second", value);
+    assertEquals(7, queue.size());
+  }
+}

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -4975,7 +4975,7 @@ class JettyTests {
     results = results.substring(0, po + 7);
     expected =
         "HTTP/1.1 200 OK\n"
-            + "Server: Jetty(12.0.15)\n"
+            + "Server: Jetty(12.0.16)\n"
             + "Date: Today\n"
             + "Content-Type: application/javascript;charset=utf-8\n"
             + "Content-Encoding: identity\n"
@@ -16026,7 +16026,7 @@ class JettyTests {
             + //
             "</table>\n"
             + //
-            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.15</a><hr/>\n"
+            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.16</a><hr/>\n"
             + //
             "\n"
             + //
@@ -16072,7 +16072,7 @@ class JettyTests {
             + //
             "</table>\n"
             + //
-            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.15</a><hr/>\n"
+            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.16</a><hr/>\n"
             + //
             "\n"
             + //
@@ -17108,6 +17108,10 @@ class JettyTests {
   @TagJetty
   void parserAllDatasetsTest() throws Throwable {
 
+    if (!EDStatic.config.useSaxParser) {
+      // This test requires SAX parser.
+      return;
+    }
     TopLevelHandler topLevelHandler;
     SAXParserFactory factory;
     SAXParser saxParser;

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -539,8 +539,8 @@ class JettyTests {
               + "            <gex:EX_TemporalExtent>\n"
               + "              <gex:extent>\n"
               + "                <gml:TimePeriod>\n"
-              + "                  <gml:beginPosition>2003-01-01T07:00:00-05:00</gml:beginPosition>\n"
-              + "                  <gml:endPosition>2016-10-17T08:00:00-04:00</gml:endPosition>\n"
+              + "                  <gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>\n"
+              + "                  <gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>\n"
               + "                </gml:TimePeriod>\n"
               + "              </gex:extent>\n"
               + "            </gex:EX_TemporalExtent>\n"
@@ -878,8 +878,8 @@ class JettyTests {
               + "            <gex:EX_TemporalExtent>\n"
               + "              <gex:extent>\n"
               + "                <gml:TimePeriod>\n"
-              + "                  <gml:beginPosition>2003-01-01T07:00:00-05:00</gml:beginPosition>\n"
-              + "                  <gml:endPosition>2016-10-17T08:00:00-04:00</gml:endPosition>\n"
+              + "                  <gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>\n"
+              + "                  <gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>\n"
               + "                </gml:TimePeriod>\n"
               + "              </gex:extent>\n"
               + "            </gex:EX_TemporalExtent>\n"
@@ -1052,8 +1052,8 @@ class JettyTests {
               + "                    <gex:EX_TemporalExtent>\n"
               + "                      <gex:extent>\n"
               + "                        <gml:TimePeriod>\n"
-              + "                          <gml:beginPosition>2003-01-01T07:00:00-05:00</gml:beginPosition>\n"
-              + "                          <gml:endPosition>2016-10-17T08:00:00-04:00</gml:endPosition>\n"
+              + "                          <gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>\n"
+              + "                          <gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>\n"
               + "                        </gml:TimePeriod>\n"
               + "                      </gex:extent>\n"
               + "                    </gex:EX_TemporalExtent>\n"
@@ -1345,8 +1345,20 @@ class JettyTests {
               "<gco:Measure uom=\"s\">VALUE</gco:Measure>");
       results =
           results.replaceAll(
-              "<gml:endPosition>....-..-..T..:00:00Z</gml:endPosition>",
+              "<gml:endPosition>....-..-..T..:..:......-..:..</gml:endPosition>",
               "<gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>");
+      results =
+          results.replaceAll(
+              "<gml:endPosition>....-..-..T..:..:..Z</gml:endPosition>",
+              "<gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>");
+      results =
+          results.replaceAll(
+              "<gml:beginPosition>....-..-..T..:..:......-..:..</gml:beginPosition>",
+              "<gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>");
+      results =
+          results.replaceAll(
+              "<gml:beginPosition>....-..-..T..:..:..Z</gml:beginPosition>",
+              "<gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>");
       results =
           results.replaceAll(
               "<gco:Integer>[0-9]+</gco:Integer>", "<gco:Integer>NUMBER</gco:Integer>");
@@ -1883,7 +1895,7 @@ class JettyTests {
               + "              <gmd:extent>\n"
               + "                <gml:TimePeriod gml:id=\"DI_gmdExtent_timePeriod_id\">\n"
               + "                  <gml:description>seconds</gml:description>\n"
-              + "                  <gml:beginPosition>2003-01-01T12:00:00Z</gml:beginPosition>\n"
+              + "                  <gml:beginPosition>YYYY-MM-DDThh:00:00Z</gml:beginPosition>\n"
               + "                  <gml:endPosition>YYYY-MM-DDThh:00:00Z</gml:endPosition>\n"
               + "                </gml:TimePeriod>\n"
               + "              </gmd:extent>\n"

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -4975,7 +4975,7 @@ class JettyTests {
     results = results.substring(0, po + 7);
     expected =
         "HTTP/1.1 200 OK\n"
-            + "Server: Jetty(12.0.16)\n"
+            + "Server: Jetty(12.0.18)\n"
             + "Date: Today\n"
             + "Content-Type: application/javascript;charset=utf-8\n"
             + "Content-Encoding: identity\n"
@@ -6625,6 +6625,8 @@ class JettyTests {
           // (temporary?) early 2025
           // pcreview site down early 2025
           "https://www.pcreview.co.uk/threads/datetime-accounts-for-leap-seconds.1357623/",
+          // site returns 403 in test, but works in browser
+          "https://www.cnmoc.usff.navy.mil/Our-Commands/United-States-Naval-Observatory/Precise-Time-Department/The-USNO-Master-Clock/Definitions-of-Systems-of-Time/",
         };
     // https://unitsofmeasure.org/ucum.html fails in tests because of certificate,
     // but succeeds in my browser. Others are like this, too.
@@ -16026,7 +16028,7 @@ class JettyTests {
             + //
             "</table>\n"
             + //
-            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.16</a><hr/>\n"
+            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.18</a><hr/>\n"
             + //
             "\n"
             + //
@@ -16072,7 +16074,7 @@ class JettyTests {
             + //
             "</table>\n"
             + //
-            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.16</a><hr/>\n"
+            "<hr/><a href=\"https://jetty.org/\">Powered by Jetty:// 12.0.18</a><hr/>\n"
             + //
             "\n"
             + //

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -1333,6 +1333,10 @@ class JettyTests {
               "<gco:DateTime>YYYY-MM-DDThh:mm:ss.mmm-tz:tz</gco:DateTime>");
       results =
           results.replaceAll(
+              "<gco:DateTime>....-..-..T..:..:......Z</gco:DateTime>",
+              "<gco:DateTime>YYYY-MM-DDThh:mm:ss.mmm-tz:tz</gco:DateTime>");
+      results =
+          results.replaceAll(
               "<gco:Measure uom=\\\"s\\\">[0-9]+.[0-9]+</gco:Measure>",
               "<gco:Measure uom=\"s\">VALUE</gco:Measure>");
       results =

--- a/src/test/java/testDataset/EDDTestDataset.java
+++ b/src/test/java/testDataset/EDDTestDataset.java
@@ -60,9 +60,13 @@ public class EDDTestDataset {
               // Try to set this so the datasets that need to load in the background have a chance
               // and this runs again before the jetty tests to ensure all the datasets are loaded.
               + "<loadDatasetsMinMinutes>4</loadDatasetsMinMinutes>\n"
-              + "<loadDatasetsMaxMinutes>8</loadDatasetsMaxMinutes>\n"
-              + "<displayInfo>display1,display2</displayInfo>\n"
-              + "<displayAttribute>att1,att2</displayAttribute>\n");
+              + "<loadDatasetsMaxMinutes>8</loadDatasetsMaxMinutes>\n");
+
+      if (EDStatic.config.useSaxParser) {
+        datasetsXml.append(
+            "<displayInfo>display1,display2</displayInfo>\n"
+                + "<displayAttribute>att1,att2</displayAttribute>\n");
+      }
 
       datasetsXml.append(xmlFragment_test_chars());
       datasetsXml.append(xmlFragment_testZarr_compressedData());

--- a/versionrules.xml
+++ b/versionrules.xml
@@ -1,0 +1,12 @@
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" 
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+     xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 
+     http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <rules>
+    <rule groupId="*" artifactId="*">
+      <ignoreVersions>
+        <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA)[-_\.]?[0-9]*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
+</ruleset>


### PR DESCRIPTION
# Description

Changes made in preparation for the 2.26 build including making sure version numbers are updated and updating dependencies. There's also some additional exception handling related to the migration to using try-with-resources in this build and a null pointer prevention in the new snapshot diff logic.

Additional changes made during testing:

- New RequestQueue used by the TouchThread which will prevent queueing duplicate reqeusts. This is particularly useful if a frequently updated dataset has a large number of subscribers. It will prevent it from overloading the pending request queue.
- Large optimization for some requests using RandomAccessFile. This is specifically used for Etopo requests (etopo datasets and background info for map requests) and similar file reads. There's a check for if the new approach will be helpful or not, so in requests where the new code path is used it is often anywhere from a 2 to 1000 times speed increase. For requests that are not using it we don't expect a speed increase, so use the old code.

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ x ] This change requires a documentation update

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
