### PR TITLE
docker-compose: wait for erddap container startup to start logs container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,9 @@ services:
     volumes:
       - data:/erddapData:ro
     mem_limit: 256m
+    depends_on:
+      erddap:
+        condition: service_healthy
     command: tail -F /erddapData/logs/log.txt
 
   nginx-proxy:


### PR DESCRIPTION
# Description

As reported in #271, the `logs` container starts at the same time as the `erddap` container, and during a first time start up complains that the `/erddapData/logs/log.txt` file doesn't exist. Once the `erddap` container starts up the `log.txt` file will be created and due to the `tail -F` retry behavior it will be detected and tailed.

This change makes the `logs` container start up wait for the `erddap` container to be up and healthy before tailing the log file, avoiding the harmless but confusing warning message.

Fixes #271 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes