### PR TITLE
Support useHeadersForUrl feature flag (use Host header when building urls)

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/FileVisitorDNLS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/FileVisitorDNLS.java
@@ -1142,8 +1142,8 @@ public class FileVisitorDNLS extends SimpleFileVisitor<Path> {
    *
    * @param tDir The starting directory, with \\ or /, with or without trailing slash, which will be
    *     removed.
-   * @param startOfUrl usually EDStatic.erddapUrl(loggedInAs, language) + "/files/" + datasetID() +
-   *     "/" which will be prepended.
+   * @param startOfUrl usually EDStatic.erddapUrl(request, loggedInAs, language) + "/files/" +
+   *     datasetID() + "/" which will be prepended.
    * @return a table with columns with DIRECTORY (always "/"), NAME, LASTMODIFIED (long
    *     epochMilliseconds), and SIZE (long) columns.
    */
@@ -1164,8 +1164,8 @@ public class FileVisitorDNLS extends SimpleFileVisitor<Path> {
    *
    * @param tDir The starting directory, with \\ or /, with or without trailing slash, which will be
    *     removed.
-   * @param startOfUrl usually EDStatic.erddapUrl(loggedInAs, language) + "/files/" + datasetID() +
-   *     "/" which will be prepended.
+   * @param startOfUrl usually EDStatic.erddapUrl(request, loggedInAs, language) + "/files/" +
+   *     datasetID() + "/" which will be prepended.
    * @return a table with columns with DIRECTORY (always "/"), NAME, LASTMODIFIED (double
    *     epochSeconds), and SIZE (doubles) columns.
    */

--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/HtmlWidgets.java
@@ -129,7 +129,7 @@ public class HtmlWidgets {
    * FontSize from 8pt to 10pt config. FontSize = '10pt' // E.g. '9pt' or '12px' - unit is mandatory
    *
    * @param dir a public directory from the web page's point of view (e.g.,
-   *     EDStatic.imageDirUrl(loggedInAs, language)) where wz_tooltip.js can be found.
+   *     EDStatic.imageDirUrl(request, loggedInAs, language)) where wz_tooltip.js can be found.
    */
   public static String htmlTooltipScript(String dir) {
     return "<!-- Big HTML tooltips are generated with wz_tooltip from \n"
@@ -149,8 +149,8 @@ public class HtmlWidgets {
   /**
    * HTML head stuff for leaflet.
    *
-   * @param tErddapUrl e.g, from EDStatic.erddapUrl(loggedInAs, language): ending in "erddap",
-   *     without the trailing slash
+   * @param tErddapUrl e.g, from EDStatic.erddapUrl(request, loggedInAs, language): ending in
+   *     "erddap", without the trailing slash
    */
   public static String leafletHead(String tErddapUrl) {
     return
@@ -267,7 +267,7 @@ public class HtmlWidgets {
    *     (less than 60 char on some browsers).
    * @param tImageDirUrl the public URL for the image dir which has the arrow, p... and m... .gif
    *     files for the 'select' buttons (or null or "" if not needed). Usually from
-   *     EDStatic.imageDirUrl(loggedInAs, language)
+   *     EDStatic.imageDirUrl(request, loggedInAs, language)
    */
   public HtmlWidgets(boolean tHtmlTooltips, String tImageDirUrl) {
     htmlTooltips = tHtmlTooltips;
@@ -1587,8 +1587,8 @@ public class HtmlWidgets {
    * This creates the html to draw an image (e.g., question mark) that has a big html tooltip.
    * htmlTooltipScript (see above) must be already in the document. See tip().
    *
-   * @param imageRef the reference for the question mark image (e.g.,
-   *     EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile)
+   * @param imageRef the reference for the question mark image (e.g., EDStatic.imageDirUrl(request,
+   *     loggedInAs, language) + EDStatic.messages.questionMarkImageFile)
    * @param alt the alt text to be displayed, e.g., "?" (not yet encoded)
    * @param html the html tooltip text, e.g., "Hi,<br>
    *     there!". It needs explicit br tags to set window width correctly. For plain text, use

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -494,7 +494,7 @@ public class Erddap extends HttpServlet {
         EDStatic.tally.add("Requester Is Logged In (since last daily report)", tLoggedInAs);
       }
 
-      String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+      String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
       String requestUrl = request.getRequestURI(); // post EDStatic.baseUrl(), pre "?"
       // String2.log("requestURL=" + requestUrl);
 
@@ -1067,7 +1067,7 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = getUrlWithoutLang(request); // post EDD.baseUrl, pre "?"
     // plain file types
     for (String plainFileType : plainFileTypes) {
@@ -1127,6 +1127,7 @@ public class Erddap extends HttpServlet {
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "index.html", // was endOfRequest,
@@ -1187,7 +1188,7 @@ public class Erddap extends HttpServlet {
           "\n<li><h3>"
               + MessageFormat.format(
                   EDStatic.messages.indexSearchWithAr[language],
-                  getAdvancedSearchLink(language, loggedInAs, EDStatic.defaultPIppQuery))
+                  getAdvancedSearchLink(request, language, loggedInAs, EDStatic.defaultPIppQuery))
               + "</h3>\n");
 
       // display protocol links
@@ -1605,7 +1606,7 @@ public class Erddap extends HttpServlet {
 
       // end of home page
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
@@ -1613,7 +1614,7 @@ public class Erddap extends HttpServlet {
 
       // end of home page
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -1633,10 +1634,11 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "images/embed.html", // was endOfRequest,
@@ -1650,7 +1652,7 @@ public class Erddap extends HttpServlet {
       writer.write(EDStatic.htmlForException(language, t));
       throw t;
     } finally {
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     }
   }
 
@@ -1670,10 +1672,11 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "information.html", // was endOfRequest,
@@ -1683,16 +1686,17 @@ public class Erddap extends HttpServlet {
     try {
       writer.write("<div class=\"standard_width\">\n");
       writer.write(
-          EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.informationAr[language]));
-      // writer.write(EDStatic.youAreHere(language, loggedInAs, "Information"));
+          EDStatic.youAreHere(
+              request, language, loggedInAs, EDStatic.messages.informationAr[language]));
+      // writer.write(EDStatic.youAreHere(request, language, loggedInAs, "Information"));
       writer.write(EDStatic.messages.theLongDescriptionHtml(language, tErddapUrl));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -1711,10 +1715,11 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "legal.html", // was endOfRequest,
@@ -1725,20 +1730,20 @@ public class Erddap extends HttpServlet {
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, loggedInAs, EDStatic.messages.legalNoticesTitleAr[language])
+                  request, language, loggedInAs, EDStatic.messages.legalNoticesTitleAr[language])
               + EDStatic.messages.legalNoticesAr[language]
               + "\n"
               + EDStatic.messages.standardGeneralDisclaimerAr[language]
               + "\n\n"
               + EDStatic.legal(language, tErddapUrl));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -1822,7 +1827,7 @@ public class Erddap extends HttpServlet {
       int language, HttpServletRequest request, HttpServletResponse response, String loggedInAs)
       throws Throwable {
 
-    String loginUrl = EDStatic.erddapHttpsUrl(language) + "/login.html";
+    String loginUrl = EDStatic.erddapHttpsUrl(request, language) + "/login.html";
 
     // user is trying to log in
     String idtoken = request.getParameter("idtoken"); // from the POST'd info
@@ -1906,13 +1911,14 @@ public class Erddap extends HttpServlet {
    * verification of orcid login. It doesn't display a web page or redirect to a web page.
    *
    * @param language the index of the selected language
+   * @param request the request
    * @param loggedInAs the name of the logged in user (or null if not logged in)
    */
   public void doLoginOrcid(
       int language, HttpServletRequest request, HttpServletResponse response, String loggedInAs)
       throws Throwable {
 
-    String loginUrl = EDStatic.erddapHttpsUrl(language) + "/login.html";
+    String loginUrl = EDStatic.erddapHttpsUrl(request, language) + "/login.html";
 
     // user is trying to log in
     // documentation: https://members.orcid.org/api/integrate/orcid-sign-in
@@ -1947,7 +1953,8 @@ public class Erddap extends HttpServlet {
                   + EDStatic.config.orcidClientSecret
                   + "&grant_type=authorization_code"
                   + "&redirect_uri="
-                  + SSR.minimalPercentEncode(EDStatic.erddapHttpsUrl(language) + "/loginOrcid.html")
+                  + SSR.minimalPercentEncode(
+                      EDStatic.erddapHttpsUrl(request, language) + "/loginOrcid.html")
                   + "&code="
                   + code);
       // example from their documentation:
@@ -2046,7 +2053,7 @@ public class Erddap extends HttpServlet {
     // Special case: "loggedInAsHttps" is for using https without being logged in
     // so that https is used for erddapUrl substitutions,
     // but &amp;loginInfo; indicates user isn't logged in.
-    String tErddapUrl = EDStatic.erddapHttpsUrl(language);
+    String tErddapUrl = EDStatic.erddapHttpsUrl(request, language);
     String loginUrl = tErddapUrl + "/login.html";
     String message = request.getParameter("message");
     String standoutMessage =
@@ -2145,6 +2152,7 @@ public class Erddap extends HttpServlet {
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "login.html", // was endOfRequest,
@@ -2154,7 +2162,8 @@ public class Erddap extends HttpServlet {
       try {
         writer.write("<div class=\"standard_width\">\n");
         writer.write(
-            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
+            EDStatic.youAreHere(
+                request, language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
@@ -2219,7 +2228,7 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
-                  + EDStatic.erddapUrl(loggedInAs, language)
+                  + EDStatic.erddapUrl(request, loggedInAs, language)
                   + "/logout.html\">"
                   + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
@@ -2230,12 +2239,12 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.loginProblemsAfterAr[language], "&secondPart;", ""));
         }
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -2417,6 +2426,7 @@ public class Erddap extends HttpServlet {
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "login.html", // was endOfRequest,
@@ -2426,7 +2436,8 @@ public class Erddap extends HttpServlet {
       try {
         writer.write("<div class=\"standard_width\">\n");
         writer.write(
-            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
+            EDStatic.youAreHere(
+                request, language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
@@ -2483,7 +2494,7 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
-                  + EDStatic.erddapUrl(loggedInAs, language)
+                  + EDStatic.erddapUrl(request, loggedInAs, language)
                   + "/logout.html\">"
                   + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
@@ -2494,12 +2505,12 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.loginProblemsAfterAr[language], "&secondPart;", ""));
         }
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -2520,6 +2531,7 @@ public class Erddap extends HttpServlet {
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "login.html", // was endOfRequest,
@@ -2533,7 +2545,8 @@ public class Erddap extends HttpServlet {
       try {
         writer.write("<div class=\"standard_width\">\n");
         writer.write(
-            EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language]));
+            EDStatic.youAreHere(
+                request, language, loggedInAs, EDStatic.messages.loginAr[language]));
 
         // show message from EDStatic.redirectToLogin (which redirects to here) or logout.html
         writer.write(standoutMessage);
@@ -2569,7 +2582,7 @@ public class Erddap extends HttpServlet {
                           // loginGoogle.html just handles setting session info.
                           // It isn't a web page and the user isn't redirected there.
                           "    xhr.open('POST', '"
-                          + EDStatic.erddapHttpsUrl(language)
+                          + EDStatic.erddapHttpsUrl(request, language)
                           + "/loginGoogle.html');\n"
                           + "    xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');\n"
                           + "    xhr.onload = function() {\n"
@@ -2618,7 +2631,7 @@ public class Erddap extends HttpServlet {
                           + "&scope=/authenticate"
                           + "&redirect_uri="
                           + SSR.minimalPercentEncode(
-                              EDStatic.erddapHttpsUrl(language) + "/loginOrcid.html")
+                              EDStatic.erddapHttpsUrl(request, language) + "/loginOrcid.html")
                           + "\" \n"
                           + "  ><img style=\"vertical-align:middle;\" src=\"images/orcid_24x24.png\" alt=\"ORCID iD icon\"/>&nbsp;"
                           + EDStatic.messages.loginOrcidSignInAr[language]
@@ -2641,7 +2654,7 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.loginAsAr[language], "<strong>" + loggedInAs + "</strong>")
                   + "</span>\n"
                   + "(<a href=\""
-                  + EDStatic.erddapUrl(loggedInAs, language)
+                  + EDStatic.erddapUrl(request, loggedInAs, language)
                   + "/logout.html\">"
                   + EDStatic.messages.logoutAr[language]
                   + "</a>)\n"
@@ -2656,12 +2669,12 @@ public class Erddap extends HttpServlet {
                           : ""));
         }
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -2673,6 +2686,7 @@ public class Erddap extends HttpServlet {
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "login.html", // was endOfRequest,
@@ -2682,18 +2696,19 @@ public class Erddap extends HttpServlet {
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.loginAr[language])
+              + EDStatic.youAreHere(
+                  request, language, loggedInAs, EDStatic.messages.loginAr[language])
               + standoutMessage
               + "<p><span class=\"highlightColor\">"
               + EDStatic.messages.loginCanNotAr[language]
               + "</span>\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
 
@@ -2722,7 +2737,7 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapHttpsUrl(language);
+    String tErddapUrl = EDStatic.erddapHttpsUrl(request, language);
     String loginUrl = tErddapUrl + "/login.html";
 
     // user wasn't logged in?
@@ -2766,6 +2781,7 @@ public class Erddap extends HttpServlet {
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "logout.html", // was endOfRequest,
@@ -2783,7 +2799,8 @@ public class Erddap extends HttpServlet {
                   EDStatic.config.imageDir);
           writer.write(
               "<div class=\"standard_width\">\n"
-                  + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.LogOutAr[language])
+                  + EDStatic.youAreHere(
+                      request, language, loggedInAs, EDStatic.messages.LogOutAr[language])
                   +
                   // "Logging out and redirecting back to login.html.\n" +
                   // Sequence of events here was very difficult to set up.
@@ -2817,12 +2834,12 @@ public class Erddap extends HttpServlet {
                       EDStatic.messages.LogOutAr[language],
                       "onclick=\"signOut();\""));
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, t));
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw t;
         }
         return;
@@ -2857,10 +2874,11 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             tLoggedInAs,
             "dataProviderForm.html", // was endOfRequest,
@@ -2876,13 +2894,16 @@ public class Erddap extends HttpServlet {
             .replaceAll(
                 "&htmlTooltipImage;",
                 EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dataProviderFormSuccessAr[language]))
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dataProviderFormSuccessAr[language]))
             .replaceAll("&tErddapUrl;", tErddapUrl);
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormAr[language]));
+                  request, language, tLoggedInAs, EDStatic.messages.dataProviderFormAr[language]));
 
       // begin text
       writer.write(dataProviderFormLongDescriptionHTML /*
@@ -2951,12 +2972,12 @@ public class Erddap extends HttpServlet {
 */);
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       throw t;
     }
   }
@@ -2976,7 +2997,7 @@ public class Erddap extends HttpServlet {
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = null;
     Writer writer = null;
 
@@ -3114,6 +3135,7 @@ public class Erddap extends HttpServlet {
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               tLoggedInAs,
               "dataProviderForm1.html", // was endOfRequest,
@@ -3123,14 +3145,17 @@ public class Erddap extends HttpServlet {
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP1Ar[language]));
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dataProviderFormP1Ar[language]));
 
       // begin form
       String formName = "f1";
       HtmlWidgets widgets =
           new HtmlWidgets(
               false, // style, false=not htmlTooltips
-              EDStatic.imageDirUrl(tLoggedInAs, language));
+              EDStatic.imageDirUrl(request, tLoggedInAs, language));
       widgets.enterTextSubmitsForm = false;
       writer.write(
           widgets.beginForm(
@@ -3304,13 +3329,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(widgets.endForm());
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       if (writer != null) {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       }
       throw t;
     }
@@ -3331,7 +3356,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = null;
     Writer writer = null;
 
@@ -3597,6 +3622,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               tLoggedInAs,
               "dataProviderForm2.html", // was endOfRequest,
@@ -3606,14 +3632,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP2Ar[language]));
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dataProviderFormP2Ar[language]));
 
       // begin form
       String formName = "f1";
       HtmlWidgets widgets =
           new HtmlWidgets(
               false, // style, false=not htmlTooltips
-              EDStatic.imageDirUrl(tLoggedInAs, language));
+              EDStatic.imageDirUrl(request, tLoggedInAs, language));
       widgets.enterTextSubmitsForm = false;
       writer.write(
           widgets.beginForm(
@@ -3680,7 +3709,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_titleAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_titleTooltipAr[language])
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_titleTooltipAr[language])
               +
               //      "This is a short (&lt;=80 characters) description of the dataset. For
               // example," +
@@ -3694,7 +3723,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_summaryAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_summaryTooltipAr[language]
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_summaryTooltipAr[language]
                   // "This is a paragraph describing the dataset.  (&lt;=500 characters)" +
                   // "<br>The summary should answer these questions:" +
                   // "<br>&bull; Who created the dataset?" +
@@ -3717,7 +3746,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_creatorNameAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_creatorNameTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_creatorNameTooltipAr[language]
                   // "This is the name of the primary person, group, institution," +
                   // "<br>or position that created the data. For example," +
                   // "<br><kbd>John Smith</kbd>"
@@ -3731,7 +3763,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_creatorTypeAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_creatorTypeTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_creatorTypeTooltipAr[language]
                   // "This identifies the creator_name (above) as a person," +
                   // "<br>group, institution, or position."
                   )
@@ -3744,7 +3779,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_creatorEmailAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_creatorEmailTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_creatorEmailTooltipAr[language]
                   // "This is the best contact email address for the creator of this data." +
                   // "<br>Use your judgment &mdash; the creator_email might be for a" +
                   // "<br>different entity than the creator_name." +
@@ -3759,7 +3797,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_institutionAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_institutionTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_institutionTooltipAr[language]
                   // "This is the short/abbreviated form of the name of the primary" +
                   // "<br>organization that created the data. For example," +
                   // "<br><kbd>NOAA NMFS SWFSC</kbd>"
@@ -3773,7 +3814,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_infoUrlAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_infoUrlTooltipAr[language]
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_infoUrlTooltipAr[language]
                   // "This is a URL with information about this dataset." +
                   // "<br>For example, <kbd>http://spray.ucsd.edu</kbd>" +
                   // "<br>If there is no URL related to the dataset, provide" +
@@ -3788,6 +3829,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_licenseAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   tLoggedInAs,
                   EDStatic.messages.dpf_licenseTooltipAr[language].replace(
@@ -3813,7 +3855,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<tr>\n"
               + "<td>cdm_data_type"
               + "<td>&nbsp;"
-              + EDStatic.htmlTooltipImage(language, tLoggedInAs, cdmDataTypeHelp)
+              + EDStatic.htmlTooltipImage(request, language, tLoggedInAs, cdmDataTypeHelp)
               + "&nbsp;\n"
               + "<td>"
               + widgets.select("cdm_data_type", "", 1, cdmDataTypes, tCdmDataType, "")
@@ -3839,7 +3881,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_acknowledgementAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_acknowledgementTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_acknowledgementTooltipAr[language]
                   // "Optional: This is the place to acknowledge various types of support for" +
                   // "<br>the project that produced this data. (&lt;=350 characters) For example," +
                   // "<br><kbd>This project received additional funding from the NOAA" +
@@ -3858,7 +3903,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_historyAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_historyTooltipAr[language]
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_historyTooltipAr[language]
                   // "Optional: This is a list of the actions (one per line) which led to the
                   // creation of this data." +
                   // "<br>Ideally, each line includes a timestamp and a description of the action.
@@ -3880,7 +3925,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<td>id"
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_idTooltipAr[language]
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_idTooltipAr[language]
                   // "Optional: This is an identifier for the dataset, as provided by" +
                   // "<br>its naming authority. The combination of \"naming authority\"" +
                   // "<br>and the \"id\" should be globally unique, but the id can be" +
@@ -3899,7 +3944,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_namingAuthorityAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_namingAuthorityTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_namingAuthorityTooltipAr[language]
                   // "Optional: This is the organization that provided the id (above) for the
                   // dataset." +
                   // "<br>The naming authority should be uniquely specified by this attribute." +
@@ -3916,7 +3964,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_productVersionAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_productVersionTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_productVersionTooltipAr[language]
                   // "Optional: This is the version identifier of this data. For example, if you" +
                   // "<br>plan to add new data yearly, you might use the year as the version
                   // identifier." +
@@ -3931,7 +3982,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_referencesAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_referencesTooltipAr[language]
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dpf_referencesTooltipAr[language]
                   // "Optional: This is one or more published or web-based references" +
                   // "<br>that describe the data or methods used to produce it. URL's and" +
                   // "<br>DOI's are recommend. (&lt;=500 characters) For example,\n" +
@@ -3953,7 +4007,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.dpf_commentAr[language]
               + "<td>&nbsp;"
               + EDStatic.htmlTooltipImage(
-                  language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
+                  request, language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
                   // "Optional: This is miscellaneous information about the data, not" +
                   // "<br>captured elsewhere. (&lt;=350 characters) For example," +
                   // "<br><kbd>No animals were harmed during the collection of this data.</kbd>"
@@ -3999,14 +4053,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // end form
       writer.write(widgets.endForm());
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       if (writer != null) {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       }
       throw t;
     }
@@ -4029,7 +4083,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = null;
     Writer writer = null;
 
@@ -4241,6 +4295,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               tLoggedInAs,
               "dataProviderForm3.html", // was endOfRequest,
@@ -4250,14 +4305,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP3Ar[language]));
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dataProviderFormP3Ar[language]));
 
       // begin form
       String formName = "f1";
       HtmlWidgets widgets =
           new HtmlWidgets(
               false, // style, false=not htmlTooltips
-              EDStatic.imageDirUrl(tLoggedInAs, language));
+              EDStatic.imageDirUrl(request, tLoggedInAs, language));
       widgets.enterTextSubmitsForm = false;
       writer.write(
           widgets.beginForm(
@@ -4346,7 +4404,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_sourceNameTooltipAr[language]
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dpf_sourceNameTooltipAr[language]
                     // "This is the name of this variable currently used by the data source." +
                     // "<br>For example, <kbd>wt</kbd>" +
                     // "<br>This is case-sensitive."
@@ -4361,7 +4422,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_destinationNameTooltipAr[language])
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dpf_destinationNameTooltipAr[language])
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.textField("destinationName" + var, "", 20, 60, tDestinationName[var], "")
@@ -4372,7 +4436,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_longNameTooltipAr[language]
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dpf_longNameTooltipAr[language]
                     // "This is a longer, written-out version of the destinationName." +
                     // "<br>For example, <kbd>Water Temperature</kbd>" +
                     // "<br>Among other uses, it will be used as an axis title on graphs." +
@@ -4390,7 +4457,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_standardNameTooltipAr[language]
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dpf_standardNameTooltipAr[language]
                     // "Optional: This is the name from the CF Standard Name Table" +
                     // "<br>&nbsp;&nbsp;which is most appropriate for this variable.\n" +
                     // "<br>For example, <kbd>sea_water_temperature</kbd>." +
@@ -4417,7 +4487,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.messages.dpf_dataTypeAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
-                + EDStatic.htmlTooltipImage(language, tLoggedInAs, dataTypeHelp)
+                + EDStatic.htmlTooltipImage(request, language, tLoggedInAs, dataTypeHelp)
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.select("dataType" + var, "", 1, dataTypeOptions, tDataType[var], "")
@@ -4428,7 +4498,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_fillValueTooltipAr[language]
+                    request,
+                    language,
+                    tLoggedInAs,
+                    EDStatic.messages.dpf_fillValueTooltipAr[language]
                     // "For numeric variables, this is the value that is used in the" +
                     // "<br>data file to indicate a missing value for this variable.\n" +
                     // "<br>For example, <kbd>-999</kbd> ." +
@@ -4451,7 +4524,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_unitsTooltipAr[language])
+                    request, language, tLoggedInAs, EDStatic.messages.dpf_unitsTooltipAr[language])
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.textField("units" + var, "", 20, 80, tUnits[var], "")
@@ -4462,7 +4535,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_rangeTooltipAr[language]
+                    request, language, tLoggedInAs, EDStatic.messages.dpf_rangeTooltipAr[language]
                     // "For numeric variables, this specifies the typical range of values." +
                     // "<br>For example, <kbd>minimum=32.0</kbd> and <kbd>maximum=37.0</kbd> ." +
                     // "<br>The range should include about 98% of the values." +
@@ -4482,7 +4555,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.messages.dpf_ioosCategoryAr[language]
                 + "\n"
                 + "  <td>&nbsp;"
-                + EDStatic.htmlTooltipImage(language, tLoggedInAs, ioosCategoryHelp)
+                + EDStatic.htmlTooltipImage(request, language, tLoggedInAs, ioosCategoryHelp)
                 + "&nbsp;\n"
                 + "  <td>\n"
                 + widgets.select(
@@ -4494,7 +4567,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
-                    language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
+                    request, language, tLoggedInAs, EDStatic.messages.dpf_commentTooltipAr[language]
                     // "Optional: This is miscellaneous information about this variable, not
                     // captured" +
                     // "<br>elsewhere. For example," +
@@ -4541,13 +4614,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(widgets.endForm());
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       if (writer != null) {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       }
       throw t;
     }
@@ -4568,7 +4641,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = null;
     Writer writer = null;
 
@@ -4655,6 +4728,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               tLoggedInAs,
               "dataProviderForm4.html", // was endOfRequest,
@@ -4664,15 +4738,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormP4Ar[language]));
-      // EDStatic.youAreHere(language, tLoggedInAs, "Data Provider Form - Part 4"));
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dataProviderFormP4Ar[language]));
+      // EDStatic.youAreHere(request, language, tLoggedInAs, "Data Provider Form - Part 4"));
 
       // begin form
       String formName = "f1";
       HtmlWidgets widgets =
           new HtmlWidgets(
               false, // style, false=not htmlTooltips
-              EDStatic.imageDirUrl(tLoggedInAs, language));
+              EDStatic.imageDirUrl(request, tLoggedInAs, language));
       widgets.enterTextSubmitsForm = false;
       writer.write(
           widgets.beginForm(
@@ -4749,13 +4826,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(widgets.endForm());
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       if (writer != null) {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       }
       throw t;
     }
@@ -4775,7 +4852,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(tLoggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, tLoggedInAs, language);
     OutputStream out = null;
     Writer writer = null;
 
@@ -4805,6 +4882,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               tLoggedInAs,
               "dataProviderFormDone.html", // was endOfRequest,
@@ -4814,7 +4892,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, tLoggedInAs, EDStatic.messages.dataProviderFormDoneAr[language]));
+                  request,
+                  language,
+                  tLoggedInAs,
+                  EDStatic.messages.dataProviderFormDoneAr[language]));
       // EDStatic.youAreHere(language, tLoggedInAs, "Data Provider Form - Done"));
 
       // begin text
@@ -4839,13 +4920,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           );
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       if (writer != null) {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, tLoggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, tLoggedInAs, false);
       }
       throw t;
     }
@@ -4866,10 +4947,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "status.html", // was endOfRequest,
@@ -4879,7 +4961,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.statusAr[language])
+              + EDStatic.youAreHere(
+                  request, language, loggedInAs, EDStatic.messages.statusAr[language])
               + "<pre>");
       StringBuilder sb = new StringBuilder();
       EDStatic.addIntroStatistics(sb, EDStatic.config.showLoadErrorsOnStatusPage, this);
@@ -4902,7 +4985,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(XML.encodeAsHTML(sb.toString()));
       writer.write("</pre>\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       // as a convenience to admins, viewing status.html calls String2.flushLog()
       String2.flushLog();
@@ -4910,7 +4993,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       // as a convenience to admins, viewing status.html calls String2.flushLog()
       String2.flushLog();
@@ -4933,10 +5016,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "rest.html", // was endOfRequest,
@@ -5018,9 +5102,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, loggedInAs, EDStatic.messages.indexServicesAr[language])
+                  request, language, loggedInAs, EDStatic.messages.indexServicesAr[language])
               +
-              // EDStatic.youAreHere(language, loggedInAs, "RESTful Web Services") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "RESTful Web Services") +
               "<h2 style=\"text-align:center;\"><a class=\"selfLink\" id=\"WebService\" href=\"#WebService\" rel=\"bookmark\">"
               + EDStatic.messages.accessRESTFULAr[language]
               + "</a></h2>\n"
@@ -5574,13 +5658,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               .replaceAll("&tErddapUrl;", tErddapUrl)
               .replaceAll("&erddapVersion;", EDStatic.erddapVersion.getVersion()));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -5897,8 +5981,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * This is used to generate examples for the plainFileTypes in the method above.
    *
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param relativeUrl without the fileType, e.g., "/griddap/index" (no "?" or "?query" at end)
    * @param query after the "?", already HTML encoded, e.g., "searchfor=temperature" or "".
    * @return a string with a series of html links to information about the plainFileTypes
@@ -5952,7 +6036,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     boolean hasDatasetID = datasetIDStartsAt < requestUrl.length();
     String endOfRequestUrl =
@@ -5966,6 +6050,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               protocol + "/documentation.html", // was endOfRequest,
@@ -5976,18 +6061,22 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "<div class=\"standard_width\">\n"
                 + EDStatic.youAreHere(
-                    language, loggedInAs, protocol, EDStatic.messages.documentationAr[language]));
+                    request,
+                    language,
+                    loggedInAs,
+                    protocol,
+                    EDStatic.messages.documentationAr[language]));
         if (protocol.equals("griddap"))
           EDDGrid.writeGeneralDapHtmlInstructions(language, tErddapUrl, writer, true);
         else if (protocol.equals("tabledap"))
           EDDTable.writeGeneralDapHtmlInstructions(language, tErddapUrl, writer, true);
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -6060,18 +6149,20 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write("\n</head>\n");
       writer.write(
           EDStatic.startBodyHtml(
+              request,
               language,
               loggedInAs,
               protocol + "/help.html", // was endOfRequest,
               queryString));
       writer.write("\n");
-      writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(loggedInAs, language)));
+      writer.write(
+          HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs, language)));
       writer.write("<div class=\"standard_width\">\n");
       try {
         writer.write(
             EDStatic.youAreHere(
-                language, loggedInAs, protocol, EDStatic.messages.helpAr[language]));
-        // writer.write(EDStatic.youAreHere(language, loggedInAs, protocol, "Help"));
+                request, language, loggedInAs, protocol, EDStatic.messages.helpAr[language]));
+        // writer.write(EDStatic.youAreHere(request, language, loggedInAs, protocol, "Help"));
         writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
         if (protocol.equals("griddap"))
           EDDGrid.writeGeneralDapHtmlInstructions(
@@ -6080,7 +6171,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           EDDTable.writeGeneralDapHtmlInstructions(
               language, tErddapUrl, writer, true); // true=complete
         writer.write("</div>\n");
-        writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+        writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
         writer.write("</html>");
         writer.flush(); // essential
         if (out instanceof ZipOutputStream zos) zos.closeEntry();
@@ -6089,7 +6180,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+        writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
         writer.write("</html>");
         writer.flush(); // essential
         if (out instanceof ZipOutputStream zos) zos.closeEntry();
@@ -6444,7 +6535,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String fullRequestUrl = EDStatic.baseUrl(loggedInAs) + requestUrl;
     String roles[] = EDStatic.getRoles(loggedInAs);
@@ -6473,6 +6564,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "files/documentation.html", // was endOfRequest,
@@ -6486,6 +6578,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write("<div class=\"standard_width\">\n");
         writer.write(
             EDStatic.youAreHere(
+                request,
                 language,
                 loggedInAs,
                 "files/",
@@ -6496,7 +6589,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
                 </div>
                 """);
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Exception e) {
         EDStatic.rethrowClientAbortException(e); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, e));
@@ -6504,7 +6597,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
                 </div>
                 """);
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw e;
       }
       return;
@@ -6650,6 +6743,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "files/", // was endOfRequest,
@@ -6660,7 +6754,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
         writer.write(
             "<div class=\"standard_width\">\n"
-                + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.EDDFilesAr[language])
+                + EDStatic.youAreHere(
+                    request, language, loggedInAs, EDStatic.messages.EDDFilesAr[language])
                 + EDStatic.messages.filesDescriptionAr[language]
                 + "\n<br><span class=\"warningColor\">"
                 + EDStatic.messages.warningAr[language]
@@ -6683,19 +6778,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 null,
                 fullRequestUrl,
                 queryString, // may have sort instructions
-                EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/",
-                EDStatic.imageDirUrl(loggedInAs, language)
+                EDStatic.imageDirUrl(request, loggedInAs, language) + "fileIcons/",
+                EDStatic.imageDirUrl(request, loggedInAs, language)
                     + EDStatic.messages.questionMarkImageFile,
                 true,
                 subDirNames,
                 subDirDes)); // addParentDir
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Exception e) {
         EDStatic.rethrowClientAbortException(e); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, e));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw e;
       }
 
@@ -6817,6 +6912,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "files/" + id + "/" + nextPath, // was endOfRequest,
@@ -6828,7 +6924,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             nextPath.length() == 0
                 ? EDStatic.youAreHere(
-                    language, loggedInAs, "files/", EDStatic.messages.EDDFilesAr, id)
+                    request, language, loggedInAs, "files/", EDStatic.messages.EDDFilesAr, id)
                 : "\n<h1>"
                     + EDStatic.erddapHref(language, tErddapUrl)
                     + "\n &gt; <a rel=\"contents\" href=\""
@@ -6838,7 +6934,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     + "</a>"
                     + "\n &gt; <a rel=\"contents\" href=\""
                     + XML.encodeAsHTMLAttribute(
-                        EDStatic.erddapUrl(loggedInAs, language) + "/files/" + id + "/")
+                        EDStatic.erddapUrl(request, loggedInAs, language) + "/files/" + id + "/")
                     + "\">"
                     + id
                     + "</a>"
@@ -6864,7 +6960,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + tErddapUrl
                 + "/files/documentation.html#HowCanIWorkWithTheseFiles\">\"How can I work with these files?\"</a>)\n"
                 + "<br>&nbsp;\n");
-        edd.writeHtmlDatasetInfo(language, loggedInAs, writer, true, true, false, true, "", "");
+        edd.writeHtmlDatasetInfo(
+            request, language, loggedInAs, writer, true, true, false, true, "", "");
         writer.write("<br>"); // causes nice spacing between datasetInfo and file table
         writer.flush();
         writer.write(
@@ -6872,19 +6969,19 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 localDir, // display viewers for local files
                 fullRequestUrl,
                 queryString, // may have sort instructions
-                EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/",
-                EDStatic.imageDirUrl(loggedInAs, language)
+                EDStatic.imageDirUrl(request, loggedInAs, language) + "fileIcons/",
+                EDStatic.imageDirUrl(request, loggedInAs, language)
                     + EDStatic.messages.questionMarkImageFile,
                 true,
                 subDirs,
                 null)); // addParentDir
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Exception e) {
         EDStatic.rethrowClientAbortException(e); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, e));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw e;
       }
       return;
@@ -6996,7 +7093,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.baseUrl(), pre "?"
 
     // ensure valid fileTypeName
@@ -7208,7 +7305,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + error[1]);
 
       // make the plain table with the dataset list
-      table = makePlainDatasetTable(language, loggedInAs, ids, sortByTitle, fileTypeName);
+      table = makePlainDatasetTable(request, language, loggedInAs, ids, sortByTitle, fileTypeName);
       sendPlainTable(
           language,
           requestNumber,
@@ -7224,12 +7321,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // make the html table with the dataset list
-    table = makeHtmlDatasetTable(language, loggedInAs, ids, sortByTitle);
+    table = makeHtmlDatasetTable(request, language, loggedInAs, ids, sortByTitle);
 
     // display start of web page
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             protocol + "/index.html", // was endOfRequest,
@@ -7240,12 +7338,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String refine =
           EDStatic.messages.orRefineSearchWithAr[language]
               + getAdvancedSearchLink(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.passThroughPIppQueryPage1(request) + "&protocol=" + uProtocol);
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, uProtocol)
+              + EDStatic.youAreHere(request, language, loggedInAs, uProtocol)
               + description);
 
       /*getYouAreHereTable(
@@ -7302,12 +7401,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -7361,7 +7460,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     Interesting IOOS DIF info c:/programs/sos/EncodingIOOSv0.6.0Observations.doc
     */
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String endOfRequestUrl =
         datasetIDStartsAt >= requestUrl.length() ? "" : requestUrl.substring(datasetIDStartsAt);
@@ -7452,6 +7551,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "sos/" + tDatasetID + "/index.html", // was endOfRequest,
@@ -7460,14 +7560,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               out);
       try {
         writer.write("<div class=\"standard_width\">\n");
-        eddTable.sosDatasetHtml(language, loggedInAs, writer);
+        eddTable.sosDatasetHtml(request, language, loggedInAs, writer);
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -7546,7 +7646,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   ".xml");
           OutputStream out = outSource.outputStream(File2.UTF_8);
           try (Writer writer = File2.getBufferedWriterUtf8(out)) {
-            eddTable.sosGetCapabilities(language, queryMap, writer, loggedInAs);
+            eddTable.sosGetCapabilities(request, language, queryMap, writer, loggedInAs);
             writer.flush();
             if (out instanceof ZipOutputStream zos) zos.closeEntry();
           }
@@ -7649,7 +7749,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               new OutputStreamFromHttpResponse(request, response, fileName, ".xml", ".xml");
           OutputStream out = outSource.outputStream(File2.UTF_8);
           try (Writer writer = File2.getBufferedWriterUtf8(out)) {
-            eddTable.sosDescribeSensor(language, loggedInAs, shortName, writer);
+            eddTable.sosDescribeSensor(request, language, loggedInAs, shortName, writer);
             writer.flush();
             if (out instanceof ZipOutputStream zos) zos.closeEntry();
           }
@@ -7694,6 +7794,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               new OutputStreamFromHttpResponse(
                   request, response, fileName, fileTypeName, extension);
           eddTable.sosGetObservation(
+              request,
               language,
               endOfRequest,
               queryString,
@@ -7820,10 +7921,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "sos/documentation.html", // was endOfRequest,
@@ -7833,7 +7935,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.SOSAr[language])
+              + EDStatic.youAreHere(
+                  request, language, loggedInAs, EDStatic.messages.SOSAr[language])
               + "\n"
               + EDStatic.messages
                   .sosOverview1Ar[language]
@@ -7869,12 +7972,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -7922,7 +8025,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String endOfRequestUrl =
         datasetIDStartsAt >= requestUrl.length() ? "" : requestUrl.substring(datasetIDStartsAt);
@@ -8012,6 +8115,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "wcs/" + tDatasetID + "/index.html", // was endOfRequest,
@@ -8020,14 +8124,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               out);
       try {
         writer.write("<div class=\"standard_width\">\n");
-        eddGrid.wcsDatasetHtml(language, loggedInAs, writer);
+        eddGrid.wcsDatasetHtml(request, language, loggedInAs, writer);
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -8089,7 +8193,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   ".xml");
           OutputStream out = outSource.outputStream(File2.UTF_8);
           try (Writer writer = File2.getBufferedWriterUtf8(out)) {
-            eddGrid.wcsGetCapabilities(language, loggedInAs, tVersion, writer);
+            eddGrid.wcsGetCapabilities(request, language, loggedInAs, tVersion, writer);
             writer.flush();
             if (out instanceof ZipOutputStream zos) zos.closeEntry();
           }
@@ -8233,10 +8337,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "wcs/documentation.html", // was endOfRequest,
@@ -8246,9 +8351,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.WCSAr[language])
+              + EDStatic.youAreHere(
+                  request, language, loggedInAs, EDStatic.messages.WCSAr[language])
               +
-              // EDStatic.youAreHere(language, loggedInAs, "Web Coverage Service (WCS)") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "Web Coverage Service (WCS)") +
               "\n"
               + EDStatic.messages
                   .wcsOverview1Ar[language]
@@ -8287,12 +8393,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               //     EDStatic.externalLinkHtml(language, tErddapUrl) + "</a>\n" +
               "\n</ul>\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -8334,7 +8440,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String endOfRequestUrl =
         datasetIDStartsAt >= requestUrl.length() ? "" : requestUrl.substring(datasetIDStartsAt);
@@ -8659,7 +8765,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String e0 =
         tErddapUrl + "/wms/" + EDStatic.config.wmsSampleDatasetID + "/" + EDD.WMS_SERVER + "?";
     String ec = "service=WMS&#x26;request=GetCapabilities&#x26;version=";
@@ -8770,6 +8876,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "wms/documentation.html", // was endOfRequest,
@@ -8802,9 +8909,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           // see almost identical documentation at ...
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, loggedInAs, "wms", EDStatic.messages.documentationAr[language])
+                  request, language, loggedInAs, "wms", EDStatic.messages.documentationAr[language])
               +
-              // EDStatic.youAreHere(language, loggedInAs, "wms", "Documentation") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "wms", "Documentation") +
               String2.replaceAll(
                   EDStatic.messages.wmsLongDescriptionHtmlAr[language], "&erddapUrl;", tErddapUrl)
               + "\n"
@@ -9317,12 +9424,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</table>\n"
               + "\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -10108,7 +10215,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // make sure version is unspecified (latest), 1.1.0, 1.1.1, or 1.3.0.
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String tVersion = queryMap.get("version");
     if (tVersion == null) tVersion = "1.3.0";
     if (!tVersion.equals("1.1.0") && !tVersion.equals("1.1.1") && !tVersion.equals("1.3.0"))
@@ -10857,7 +10964,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
     boolean wmsClientActive = EDStatic.config.wmsClientActive;
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     if (!tVersion.equals("1.1.0") && !tVersion.equals("1.1.1") && !tVersion.equals("1.3.0"))
       throw new SimpleException(
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
@@ -11086,16 +11193,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</a>";
       writer.write(
           EDStatic.startBodyHtml(
+                  request,
                   language,
                   loggedInAs,
                   "wms/" + tDatasetID + "/index.html", // was endOfRequest,
                   queryString)
               + "\n"
-              + HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(loggedInAs, language))
+              + HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs, language))
               + "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, "wms", tDatasetID));
+              + EDStatic.youAreHere(request, language, loggedInAs, "wms", tDatasetID));
       eddGrid.writeHtmlDatasetInfo(
-          language, loggedInAs, writer, true, true, true, true, queryString, "");
+          request, language, loggedInAs, writer, true, true, true, true, queryString, "");
       if (!wmsClientActive) {
         writer.write(
             "\n<p><span class=\"warningColor\">"
@@ -11112,7 +11220,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       } else {
         // write all the leaflet stuff
         writer.write(HtmlWidgets.ifJavaScriptDisabled + "\n");
-        HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+        HtmlWidgets widgets =
+            new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
         writer.write(
             "<br>"
                 + String2.replaceAll( // these are actually Leaflet instructions
@@ -11366,12 +11475,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(scripts.toString());
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Exception e) {
       EDStatic.rethrowClientAbortException(e); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, e));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw e;
     }
   }
@@ -11397,10 +11506,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
-    String fileIconsDir = EDStatic.imageDirUrl(loggedInAs, language) + "fileIcons/";
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
+    String fileIconsDir = EDStatic.imageDirUrl(request, loggedInAs, language) + "fileIcons/";
     String questionMarkUrl =
-        EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile;
+        EDStatic.imageDirUrl(request, loggedInAs, language)
+            + EDStatic.messages.questionMarkImageFile;
 
     String urlParts[] =
         String2.split(
@@ -11456,6 +11566,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "metadata/", // was endOfRequest,
@@ -11475,12 +11586,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 dirNames,
                 null));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Exception e) {
         EDStatic.rethrowClientAbortException(e); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, e));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw e;
       }
       return;
@@ -11516,6 +11627,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "metadata/" + part1 + "/", // was endOfRequest,
@@ -11535,12 +11647,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 dirNames,
                 null));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       } catch (Exception e) {
         EDStatic.rethrowClientAbortException(e); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, e));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw e;
       }
       return;
@@ -11593,6 +11705,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String title = "Index of " + tErddapUrl + "/" + endOfRequest;
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "metadata/" + part1 + "/xml/", // was endOfRequest,
@@ -11611,7 +11724,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               dirNames,
               null));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       return;
     }
 
@@ -11781,7 +11894,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String erddapRestServices =
         "/" + EDStatic.config.warName + "/rest/services"; // ESRI uses relative URLs
     String roles[] = EDStatic.getRoles(loggedInAs);
@@ -11914,6 +12027,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "rest/services/", // was endOfRequest,
@@ -11984,11 +12098,11 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   // "&nbsp;&nbsp;<a target=\"_blank\" href=\"" + erddapRestServices +
                   // "?f=geositemap\">Geo Sitemap</a>\n" +
                   "<br/>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         } catch (Exception e) {
           EDStatic.rethrowClientAbortException(e); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, e));
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw e;
         }
 
@@ -12080,6 +12194,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "rest/services/" + tDatasetID + "/", // was endOfRequest,
@@ -12140,6 +12255,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   "<br/>\n");
         } finally {
           endHtmlWriter(
+              request,
               language,
               out,
               writer,
@@ -12391,6 +12507,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "rest/services/" + tDatasetID + "/ImageServer/", // was endOfRequest,
@@ -12576,6 +12693,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + "/identify\">Identify</a>\n"
                   + "<br/>\n");
           endHtmlWriter(
+              request,
               language,
               out,
               writer,
@@ -12586,6 +12704,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           EDStatic.rethrowClientAbortException(e); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, e));
           endHtmlWriter(
+              request,
               language,
               out,
               writer,
@@ -13430,7 +13549,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // Okay. This is going to work!
     // substitute &erddapUrl;
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String s = String2.utf8BytesToString(rssAr);
     s = String2.replaceAll(s, "&erddapUrl;", tErddapUrl);
     rssAr = String2.stringToUtf8Bytes(s);
@@ -13603,7 +13722,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // constants
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     int refreshEveryNMinutes = Math2.roundToInt(EDStatic.config.loadDatasetsMinMillis / 60000.0);
 
     // parse endOfRequest
@@ -13682,6 +13801,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "outOfDateDatasets.html", // was endOfRequest,
@@ -13747,7 +13867,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // write html response
       writer.write("<div class=\"standard_width\">");
-      writer.write(EDStatic.youAreHere(language, loggedInAs, shortTitle));
+      writer.write(EDStatic.youAreHere(request, language, loggedInAs, shortTitle));
       writer.write(XML.encodeAsHTML(EDStatic.messages.advc_outOfDateAr[language]));
       writer.write("\n<p>");
       if (table.nRows() == 0) {
@@ -13820,12 +13940,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</a>.\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -13868,7 +13988,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // and move it to forefront (zlevel=highest).
 
     // constants
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String formName = "f1";
     String dFormName = "document." + formName;
     int border = 20;
@@ -13892,6 +14012,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "slidesorter.html", // was endOfRequest,
@@ -13899,9 +14020,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.messages.slideSorterAr[language],
             out);
     try {
-      writer.write(HtmlWidgets.dragDropScript(EDStatic.imageDirUrl(loggedInAs, language)));
+      writer.write(HtmlWidgets.dragDropScript(EDStatic.imageDirUrl(request, loggedInAs, language)));
       writer.write(
           EDStatic.youAreHereWithHelp(
+              request,
               language,
               loggedInAs,
               EDStatic.messages.slideSorterAr[language],
@@ -13912,7 +14034,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
       // begin form
       HtmlWidgets widgets =
-          new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+          new HtmlWidgets(
+              true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
       widgets.enterTextSubmitsForm = false;
       writer.write(
           widgets.beginForm(
@@ -14109,7 +14232,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           if (dataUrl != null)
             writer.write(
                 "   <td><img src=\""
-                    + EDStatic.imageDirUrl(loggedInAs, language)
+                    + EDStatic.imageDirUrl(request, loggedInAs, language)
                     + "data.gif\" alt=\"data\" \n"
                     + "      title=\"Edit the image or download the data in a new browser window.\" \n"
                     + "      style=\"cursor:default;\" \n"
@@ -14121,7 +14244,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           // resize button
           writer.write(
               "   <td><img src=\""
-                  + EDStatic.imageDirUrl(loggedInAs, language)
+                  + EDStatic.imageDirUrl(request, loggedInAs, language)
                   + "resize.gif\" alt=\"s\" \n"
                   + "      title=\"Change between small/medium/large image sizes.\" \n"
                   + "      style=\"cursor:default;\" \n"
@@ -14158,7 +14281,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         if (oldSlide < nSlides)
           writer.write(
               "    <img src=\""
-                  + EDStatic.imageDirUrl(loggedInAs, language)
+                  + EDStatic.imageDirUrl(request, loggedInAs, language)
                   + "x.gif\" alt=\"x\" \n"
                   + "      title=\"Delete this slide.\" \n"
                   + "      style=\"cursor:default; width:"
@@ -14418,13 +14541,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
       // end of slidesorter
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       // end of slidesorter
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -14453,14 +14576,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String fileTypeName = "";
     String searchFor = "";
     /* retired 2017-10-27 String youAreHereTable =
-    //EDStatic.youAreHere(language, loggedInAs, protocol);
+    //EDStatic.youAreHere(request, language, loggedInAs, protocol);
     getYouAreHereTable(
-        EDStatic.youAreHere(language, loggedInAs, protocol),
+        EDStatic.youAreHere(request, language, loggedInAs, protocol),
         //Or, View All Datasets
         //"<br>Or, <a href=\"" + tErddapUrl + "/info/index.html" +
         //    EDStatic.encodedPassThroughPIppQueryPage1(request) + "\">" +
@@ -14582,6 +14705,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "search/index.html", // was endOfRequest,
@@ -14593,7 +14717,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           writer.write(
               "<div class=\"standard_width\">\n"
                   + EDStatic.youAreHere(
-                      language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
+                      request, language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
           // youAreHereTable);
 
           // display the search form
@@ -14605,7 +14729,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           // display datasets
           if (error == null) {
 
-            Table table = makeHtmlDatasetTable(language, loggedInAs, datasetIDs, sortByTitle);
+            Table table =
+                makeHtmlDatasetTable(request, language, loggedInAs, datasetIDs, sortByTitle);
 
             String nMatchingHtml =
                 EDStatic.nMatchingDatasetsHtml(
@@ -14623,7 +14748,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     + "\n"
                     + "<span class=\"N\">("
                     + EDStatic.messages.orRefineSearchWithAr[language]
-                    + getAdvancedSearchLink(language, loggedInAs, queryString)
+                    + getAdvancedSearchLink(request, language, loggedInAs, queryString)
                     + ")</span>\n"
                     + "<br>&nbsp;\n"); // necessary for the blank line before the table (not <p>)
 
@@ -14666,14 +14791,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
           // end of document
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, t));
           // end of document
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw t;
         }
         return;
@@ -14685,7 +14810,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             EDStatic.messages.resourceNotFoundAr[language] + error[0] + " " + error[1]);
 
       Table table =
-          makePlainDatasetTable(language, loggedInAs, datasetIDs, sortByTitle, fileTypeName);
+          makePlainDatasetTable(
+              request, language, loggedInAs, datasetIDs, sortByTitle, fileTypeName);
       sendPlainTable(
           language,
           requestNumber,
@@ -14716,6 +14842,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "search/index.html", // was endOfRequest,
@@ -14727,7 +14854,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "<div class=\"standard_width\">\n"
                 + EDStatic.youAreHere(
-                    language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
+                    request, language, loggedInAs, EDStatic.messages.searchTitleAr[language]));
         // youAreHereTable);
 
         // write (error and) search form
@@ -14749,13 +14876,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         //    "\n");
 
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       } catch (Throwable t2) {
         EDStatic.rethrowClientAbortException(t2); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t2));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t2;
       }
       return;
@@ -14786,7 +14913,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String descriptionUrl = tErddapUrl + "/" + protocol + "/description.xml";
     String serviceWord = "search";
@@ -14836,6 +14963,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "opensearch1.1/index.html", // was endOfRequest,
@@ -14853,7 +14981,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               .replaceAll("&tErddapUrl;", tErddapUrl);
       writer.write(
           "<div class=\"standard_width\">\n"
-              + EDStatic.youAreHere(language, loggedInAs, niceProtocol)
+              + EDStatic.youAreHere(request, language, loggedInAs, niceProtocol)
               + openSearchDescription
           /*
           "<p><a rel=\"bookmark\" href=\"https://github.com/dewitt/opensearch#what-is-opensearch\">" + niceProtocol + "" + //""?
@@ -14889,7 +15017,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "  <a rel=\"help\" href=\"" + tErddapUrl + "/rest.html\">RESTful services</a>.\n" +
           "</div>\n"
           */ );
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       return;
     }
 
@@ -15339,24 +15467,27 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * This writes the link to Advanced Search page.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs
    * @param paramString the param string (after "?") (starting point for advanced search, already
    *     percent encoded, but not XML/HTML encoded) (or "" or null) but should at least have page=
    *     and itemsPerPage= (PIppQuery).
    */
-  public String getAdvancedSearchLink(int language, String loggedInAs, String paramString)
+  public String getAdvancedSearchLink(
+      HttpServletRequest request, int language, String loggedInAs, String paramString)
       throws Throwable {
 
     return "<span class=\"N\"><a href=\""
         + XML.encodeAsHTMLAttribute(
-            EDStatic.erddapUrl(loggedInAs, language)
+            EDStatic.erddapUrl(request, loggedInAs, language)
                 + "/search/advanced.html"
                 + EDStatic.questionQuery(paramString))
         + "\">"
         + String2.replaceAll(EDStatic.messages.advancedSearchAr[language], " ", "&nbsp;")
         + "</a>&nbsp;"
         + EDStatic.htmlTooltipImage(
+            request,
             language,
             loggedInAs,
             "<div class=\"narrow_max_width\">"
@@ -15388,7 +15519,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String catAtts[] = EDStatic.config.categoryAttributes;
     String catAttsInURLs[] = EDStatic.config.categoryAttributesInURLs;
@@ -15631,6 +15762,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       out = getHtmlOutputStreamUtf8(request, response);
       writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "search/advanced.html", // was endOfRequest,
@@ -15639,7 +15771,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               out);
       try {
         HtmlWidgets widgets =
-            new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+            new HtmlWidgets(
+                true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
         widgets.htmlTooltips = true;
         widgets.enterTextSubmitsForm = true;
 
@@ -15648,11 +15781,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         writer.write(
             "<div class=\"standard_width\">\n"
                 + EDStatic.youAreHere(
+                    request,
                     language,
                     loggedInAs,
                     EDStatic.messages.advancedSearchAr[language]
                         + " "
                         + EDStatic.htmlTooltipImage(
+                            request,
                             language,
                             loggedInAs,
                             "<div class=\"narrow_max_width\">"
@@ -15676,7 +15811,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.messages.searchFullTextHtmlAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language])
+                    request, language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language])
                 + "\n"
                 + "<br>"
                 + widgets.textField(
@@ -15699,6 +15834,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.messages.categoryTitleHtmlAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     "<div class=\"narrow_max_width\">"
@@ -15709,6 +15845,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "<tr>\n"
                 + "  <td class=\"N\" style=\"width:20%;\">protocol \n"
                 + EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     "<div class=\"standard_max_width\">" + protocolTooltip + "</div>")
@@ -15756,6 +15893,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + EDStatic.messages.advancedSearchBoundsAr[language]
                 + "</strong>\n"
                 + EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     "<div class=\"standard_max_width\">"
@@ -15857,7 +15995,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 "<tr>\n"
                 + "  <td colspan=\"2\" class=\"N\">"
                 + twoClickMap[0]
-                + EDStatic.htmlTooltipImage(language, loggedInAs, lonTooltip)
+                + EDStatic.htmlTooltipImage(request, language, loggedInAs, lonTooltip)
                 + twoClickMap[1]
                 + "</td>\n"
                 + "</tr>\n"
@@ -15928,7 +16066,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       } // otherwise there is more to the document below...
     }
@@ -16132,11 +16270,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // make the resultsTable
       boolean sortByTitle = false; // already put in appropriate order above
       if (toHtml)
-        resultsTable = makeHtmlDatasetTable(language, loggedInAs, matchingDatasetIDs, sortByTitle);
+        resultsTable =
+            makeHtmlDatasetTable(request, language, loggedInAs, matchingDatasetIDs, sortByTitle);
       else
         resultsTable =
             makePlainDatasetTable(
-                language, loggedInAs, matchingDatasetIDs, sortByTitle, fileTypeName);
+                request, language, loggedInAs, matchingDatasetIDs, sortByTitle, fileTypeName);
     }
 
     // *** show the .html results
@@ -16213,13 +16352,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
 
         writer.write("</div>\n"); // which controls width
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n"); // which controls width
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -16289,6 +16428,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * This generates a results table in response to a searchFor string.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). This is used to
    *     determine if the user has the right to know if a given dataset exists. (But dataset will be
@@ -16303,6 +16443,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @throws Throwable, notably ClientAbortException
    */
   public Table getSearchTable(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       StringArray tDatasetIDs,
@@ -16315,8 +16456,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     boolean sortByTitle = false; // already sorted by search
     return toHtml
-        ? makeHtmlDatasetTable(language, loggedInAs, tDatasetIDs, sortByTitle)
-        : makePlainDatasetTable(language, loggedInAs, tDatasetIDs, sortByTitle, fileTypeName);
+        ? makeHtmlDatasetTable(request, language, loggedInAs, tDatasetIDs, sortByTitle)
+        : makePlainDatasetTable(
+            request, language, loggedInAs, tDatasetIDs, sortByTitle, fileTypeName);
   }
 
   /**
@@ -16674,7 +16816,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String endOfRequestUrl =
         datasetIDStartsAt >= requestUrl.length() ? "" : requestUrl.substring(datasetIDStartsAt);
@@ -16744,13 +16886,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<span class=\"N\">("
               + EDStatic.messages.orRefineSearchWithAr[language]
               + getAdvancedSearchLink(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.passThroughPIppQueryPage1(request) + "&" + advancedQuery)
               + ")</span>\n";
 
     String youAreHere =
-        EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.categoryTitleHtmlAr[language]);
+        EDStatic.youAreHere(
+            request, language, loggedInAs, EDStatic.messages.categoryTitleHtmlAr[language]);
     // String youAreHereTable =
     //    getYouAreHereTable(youAreHere, refine) +
     //    "\n" + HtmlWidgets.ifJavaScriptDisabled + "\n";
@@ -16801,6 +16945,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "categorize/index.html", // was endOfRequest,
@@ -16822,13 +16967,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           writeCategorizeOptionsHtml1(language, request, loggedInAs, writer, null, false);
 
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, t));
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw t;
         }
       }
@@ -16910,6 +17055,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "categorize/index.html", // was endOfRequest,
@@ -16947,13 +17093,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           //    "</table>\n");
 
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, t));
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw t;
         }
       }
@@ -17016,7 +17162,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     boolean sortByTitle = false;
     if (endsWithPlainFileType(part2, "index")) {
       // show the results as plain file type
-      Table table = makePlainDatasetTable(language, loggedInAs, catDats, sortByTitle, fileTypeName);
+      Table table =
+          makePlainDatasetTable(request, language, loggedInAs, catDats, sortByTitle, fileTypeName);
       sendPlainTable(
           language,
           requestNumber,
@@ -17034,12 +17181,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // respond to categorize/{attributeInURL}/{categoryName}/index.html request
     if (part2.equals("index.html")) {
       // make a table of the datasets
-      Table table = makeHtmlDatasetTable(language, loggedInAs, catDats, sortByTitle);
+      Table table = makeHtmlDatasetTable(request, language, loggedInAs, catDats, sortByTitle);
 
       // display start of web page
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "categorize/"
@@ -17127,13 +17275,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "</a>.\n");
 
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -17168,7 +17316,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String queryString)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String requestUrlNoLang = getUrlWithoutLang(request);
     String endOfRequestUrl =
@@ -17259,12 +17407,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       boolean sortByTitle = false; // already sorted above
       if (fileTypeName.equals(".html")) {
         // make the table with the dataset list
-        Table table = makeHtmlDatasetTable(language, loggedInAs, tIDs, sortByTitle);
+        Table table = makeHtmlDatasetTable(request, language, loggedInAs, tIDs, sortByTitle);
 
         // display start of web page
         OutputStream out = getHtmlOutputStreamUtf8(request, response);
         Writer writer =
             getHtmlWriterUtf8(
+                request,
                 language,
                 loggedInAs,
                 "info/index.html", // was endOfRequest,
@@ -17307,6 +17456,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
                   // getYouAreHereTable(
                   EDStatic.youAreHere(
+                      request,
                       language,
                       loggedInAs,
                       MessageFormat.format(
@@ -17382,13 +17532,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           }
 
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
         } catch (Throwable t) {
           EDStatic.rethrowClientAbortException(t); // first thing in catch{}
           writer.write(EDStatic.htmlForException(language, t));
           writer.write("</div>\n");
-          endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+          endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
           throw t;
         }
       } else {
@@ -17396,7 +17546,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           throw new SimpleException(
               EDStatic.messages.resourceNotFoundAr[language] + error[0] + " " + error[1]);
 
-        Table table = makePlainDatasetTable(language, loggedInAs, tIDs, sortByTitle, fileTypeName);
+        Table table =
+            makePlainDatasetTable(request, language, loggedInAs, tIDs, sortByTitle, fileTypeName);
         sendPlainTable(
             language,
             requestNumber,
@@ -17567,6 +17718,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       OutputStream out = getHtmlOutputStreamUtf8(request, response);
       Writer writer =
           getHtmlWriterUtf8(
+              request,
               language,
               loggedInAs,
               "info/" + tID + "/index.html", // was endOfRequest,
@@ -17576,13 +17728,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               out);
       try {
         writer.write("<div class=\"wide_max_width\">\n"); // not standard_width
-        writer.write(EDStatic.youAreHere(language, loggedInAs, protocol, parts[0]));
+        writer.write(EDStatic.youAreHere(request, language, loggedInAs, protocol, parts[0]));
 
         // display a table with the one dataset
         StringArray sa = new StringArray();
         sa.add(parts[0]);
         boolean sortByTitle = true;
-        Table dsTable = makeHtmlDatasetTable(language, loggedInAs, sa, sortByTitle);
+        Table dsTable = makeHtmlDatasetTable(request, language, loggedInAs, sa, sortByTitle);
         dsTable.saveAsHtmlTable(writer, "commonBGColor", null, 1, false, -1, false, false);
 
         // html format the valueSA values
@@ -17685,13 +17837,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         }
 
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
       } catch (Throwable t) {
         EDStatic.rethrowClientAbortException(t); // first thing in catch{}
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+        endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
         throw t;
       }
       return;
@@ -18111,7 +18263,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     if (endOfRequest.equals("subscriptions") || endOfRequest.equals("subscriptions/")) {
       sendRedirect(response, tErddapUrl + "/" + Subscriptions.INDEX_HTML);
@@ -18192,6 +18344,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "subscriptions/index.html", // was endOfRequest,
@@ -18202,7 +18355,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
-                  language, loggedInAs, EDStatic.messages.subscriptionsTitleAr[language])
+                  request, language, loggedInAs, EDStatic.messages.subscriptionsTitleAr[language])
               + EDStatic.messages.subscription0HtmlAr[language]
               + MessageFormat.format(EDStatic.messages.subscription1HtmlAr[language], tErddapUrl)
               + "\n");
@@ -18241,13 +18394,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "</a>\n"
               + "</ul>\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -18256,8 +18409,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * This html is used at the bottom of many doXxxSubscription web pages.
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param tEmail the user's email address (or "")
    */
   private String requestSubscriptionListHtml(int language, String tErddapUrl, String tEmail) {
@@ -18312,7 +18465,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // parse the queryString
     Map<String, String> queryMap = EDD.userQueryHashMap(queryString, true); // true=lowercase keys
@@ -18444,11 +18597,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // display start of web page
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "subscriptions/add.html", // was endOfRequest,
@@ -18459,8 +18614,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               +
-              // EDStatic.youAreHere(language, loggedInAs, protocol, "add") +
+              // EDStatic.youAreHere(request, language, loggedInAs, protocol, "add") +
               EDStatic.youAreHere(
+                  request,
                   language,
                   loggedInAs,
                   protocol,
@@ -18556,7 +18712,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + widgets.textField("action", urlTT, 53, Subscriptions.ACTION_LENGTH, tAction, "")
               + "\n"
               + "    "
-              + EDStatic.htmlTooltipImage(language, loggedInAs, urlTT)
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, urlTT)
               + "  ("
               + EDStatic.messages.optionalAr[language]
               + ")</td>\n"
@@ -18583,13 +18739,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // link to list of subscriptions
       writer.write(requestSubscriptionListHtml(language, tErddapUrl, tEmail));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -18636,7 +18792,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     Map<String, String> queryMap =
         EDD.userQueryHashMap(queryString, true); // true=names toLowerCase
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // process the query
     String tEmail = queryMap.get("email");
@@ -18673,11 +18829,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // display start of web page
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "subscriptions/list.html", // was endOfRequest,
@@ -18688,6 +18846,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
+                  request,
                   language,
                   loggedInAs,
                   protocol,
@@ -18717,7 +18876,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
             writer.write(EDStatic.messages.subscriptionListSuccessAr[language] + "\n");
             // end of document
             writer.write("</div>\n");
-            endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+            endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
             // tally
             EDStatic.tally.add("Subscriptions (since startup)", "List successful");
@@ -18771,13 +18930,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.subscriptionAbuseAr[language]
               + "\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -18821,7 +18980,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     Map<String, String> queryMap =
         EDD.userQueryHashMap(queryString, true); // true=names toLowerCase
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // process the query
     String tSubscriptionID = queryMap.get("subscriptionid"); // lowercase since case insensitive
@@ -18858,11 +19017,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // display start of web page
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "subscriptions/validate.html", // was endOfRequest,
@@ -18873,6 +19034,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
+                  request,
                   language,
                   loggedInAs,
                   protocol,
@@ -18972,12 +19134,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       // link to list of subscriptions
       writer.write(requestSubscriptionListHtml(language, tErddapUrl, ""));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -19022,7 +19184,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     Map<String, String> queryMap =
         EDD.userQueryHashMap(queryString, true); // true=names toLowerCase
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // process the query
     String tSubscriptionID = queryMap.get("subscriptionid"); // lowercase since case insensitive
@@ -19059,11 +19221,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // display start of web page
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "subscriptions/remove.html", // was endOfRequest,
@@ -19074,6 +19238,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               + EDStatic.youAreHere(
+                  request,
                   language,
                   loggedInAs,
                   protocol,
@@ -19175,12 +19340,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + EDStatic.messages.subscriptionRemove2Ar[language]
               + "\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -19223,7 +19388,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       return;
     }
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
     String endOfRequestUrl =
         datasetIDStartsAt >= requestUrl.length() ? "" : requestUrl.substring(datasetIDStartsAt);
@@ -19463,6 +19628,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/index.html", // was endOfRequest,
@@ -19472,9 +19638,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     try {
       writer.write(
           "<div class=\"standard_width\">"
-              + EDStatic.youAreHere(language, loggedInAs, EDStatic.messages.convertAr[language])
+              + EDStatic.youAreHere(
+                  request, language, loggedInAs, EDStatic.messages.convertAr[language])
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert") +
               EDStatic.messages.convertHtmlAr[language]
               + "\n"
               +
@@ -19544,12 +19711,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n"
               + "</ul>\n");
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -19676,13 +19843,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/fipscounty.html", // was endOfRequest,
@@ -19693,16 +19862,17 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "FIPS County") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "FIPS County") +
               // The content in the parenthese requires sepcial handling, because simply calling
               // youAreHere(language, String, String, String)
               // will create an invalid URL in the page title. Similar for several other tags
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -19824,13 +19994,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -19966,13 +20136,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/oceanicAtmosphericAcronyms.html", // was endOfRequest,
@@ -19984,14 +20156,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<div class=\"standard_width\">"
               +
               // read coments in doConverFipsCounty
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "Oceanic/Atmospheric
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "Oceanic/Atmospheric
               // Acronyms") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -20113,13 +20286,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -20258,13 +20431,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/oceanicAtmosphericVariableNames.html", // was endOfRequest,
@@ -20276,14 +20451,16 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<div class=\"standard_width\">"
               +
               // see comments in doConvertFIPSCounty
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "Oceanic/Atmospheric Variable
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "Oceanic/Atmospheric
+              // Variable
               // Names") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -20418,13 +20595,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -20539,12 +20716,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/keywords.html", // was endOfRequest,
@@ -20555,13 +20734,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "keywords") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "keywords") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -20700,13 +20880,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -20804,13 +20984,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/interpolate.html", // was endOfRequest,
@@ -20842,13 +21024,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "Interpolate") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "Interpolate") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -20872,6 +21055,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<tr><td>"
               + EDStatic.messages.convertInterpolateTLLTableAr[language]
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.messages.convertInterpolateTLLTableHelpAr[language])
@@ -20886,6 +21070,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "<tr><td>"
               + EDStatic.messages.convertInterpolateDatasetIDVariableAr[language]
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   MessageFormat.format(
@@ -21003,13 +21188,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write('\n');
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -22034,13 +22219,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/time.html", // was endOfRequest,
@@ -22051,13 +22238,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "time") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "time") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -22264,13 +22452,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -22365,13 +22553,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/units.html", // was endOfRequest,
@@ -22382,13 +22572,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "units") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "units") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -22544,13 +22735,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               + "\n");
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -22655,22 +22846,24 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // HTML response section
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
-    HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
+    HtmlWidgets widgets =
+        new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
-            language, loggedInAs, "convert/color.html", queryString, "Color Plotter", out);
+            request, language, loggedInAs, "convert/color.html", queryString, "Color Plotter", out);
 
     try {
       writer.write(
           "<div class=\"standard_width\">\n"
               + ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -22754,12 +22947,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       }
 
       writer.write("<br>" + widgets.endForm() + "\n</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t);
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -22832,13 +23025,15 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
 
     // do the .html response
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = getHtmlOutputStreamUtf8(request, response);
     Writer writer =
         getHtmlWriterUtf8(
+            request,
             language,
             loggedInAs,
             "convert/urls.html", // was endOfRequest,
@@ -22849,13 +23044,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write(
           "<div class=\"standard_width\">\n"
               +
-              // EDStatic.youAreHere(language, loggedInAs, "convert", "URLs") +
+              // EDStatic.youAreHere(request, language, loggedInAs, "convert", "URLs") +
               ("\n<h1 class=\"nowrap\">"
-                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(loggedInAs, language))
+                  + EDStatic.erddapHref(language, EDStatic.erddapUrl(request, loggedInAs, language))
                   + "\n &gt; <a rel=\"contents\" "
                   + "href=\""
                   + XML.encodeAsHTMLAttribute(
-                      EDStatic.protocolUrl(EDStatic.erddapUrl(loggedInAs, language), "convert"))
+                      EDStatic.protocolUrl(
+                          EDStatic.erddapUrl(request, loggedInAs, language), "convert"))
                   + "\">"
                   + EDStatic.messages.convertAr[language]
                   + "</a>"
@@ -22903,13 +23099,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       writer.write('\n');
 
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
 
     } catch (Throwable t) {
       EDStatic.rethrowClientAbortException(t); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, t));
       writer.write("</div>\n");
-      endHtmlWriter(language, out, writer, tErddapUrl, loggedInAs, false);
+      endHtmlWriter(request, language, out, writer, tErddapUrl, loggedInAs, false);
       throw t;
     }
   }
@@ -22963,6 +23159,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * Get a writer for an html file and write up to and including the startBodyHtml
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in)
    * @param endOfRequest The part after https://..../erddap/ 2022-11-22 AVOID XSS ERROR: THIS MUST
@@ -22976,6 +23173,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @throws Throwable if trouble
    */
   Writer getHtmlWriterUtf8(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String endOfRequest,
@@ -22983,12 +23181,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String addToTitle,
       OutputStream out)
       throws Throwable {
-    return getHtmlWriterUtf8(language, loggedInAs, endOfRequest, queryString, addToTitle, "", out);
+    return getHtmlWriterUtf8(
+        request, language, loggedInAs, endOfRequest, queryString, addToTitle, "", out);
   }
 
   /**
    * Get a writer for an html file and write up to and including the startBodyHtml
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in)
    * @param endOfRequest The part after https://..../erddap/ 2022-11-22 AVOID XSS ERROR: THIS MUST
@@ -23003,6 +23203,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @throws Throwable if trouble
    */
   Writer getHtmlWriterUtf8(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String endOfRequest,
@@ -23015,13 +23216,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     Writer writer = File2.getBufferedWriterUtf8(out);
 
     // write the information for this protocol (dataset list table and instructions)
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     writer.write(EDStatic.startHeadHtml(language, tErddapUrl, addToTitle));
     if (String2.isSomething(addToHead)) writer.write("\n" + addToHead);
     writer.write("\n</head>\n");
-    writer.write(EDStatic.startBodyHtml(language, loggedInAs, endOfRequest, queryString));
+    writer.write(EDStatic.startBodyHtml(request, language, loggedInAs, endOfRequest, queryString));
     writer.write("\n");
-    writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(loggedInAs, language)));
+    writer.write(
+        HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs, language)));
     writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
     return writer;
   }
@@ -23029,16 +23231,18 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * Write the end of the standard html doc to writer.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param out
    * @param writer
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param loggedInAs
    * @param forceWriteDiagnostics
    * @throws Throwable if trouble
    */
   void endHtmlWriter(
+      HttpServletRequest request,
       int language,
       OutputStream out,
       Writer writer,
@@ -23049,7 +23253,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     try (writer) {
       // end of document
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("\n</html>\n");
 
       // essential
@@ -23126,9 +23330,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String searchFor)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     StringBuilder sb = new StringBuilder();
     sb.append(widgets.beginForm("search", "GET", tErddapUrl + "/search/index.html", ""));
@@ -23149,7 +23354,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     widgets.htmlTooltips = true;
     sb.append(
         EDStatic.htmlTooltipImage(
-            language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language]));
+            request, language, loggedInAs, EDStatic.messages.searchHintsTooltipAr[language]));
     widgets.htmlTooltips = false;
     sb.append(
         widgets.htmlButton(
@@ -23168,8 +23373,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * This returns a table with categorize options.
    *
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param fileTypeName .html or a plainFileType e.g., .htmlTable
    * @return a table with categorize options.
    * @throws Throwable if trouble
@@ -23218,8 +23423,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * getYouAreHereTable).
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @return the html with the category links
    */
   public String getCategoryLinksHtml(int language, HttpServletRequest request, String tErddapUrl)
@@ -23258,7 +23463,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       boolean homePage)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     if (homePage) {
       Table table = categorizeOptionsTable(request, tErddapUrl, ".html");
       int n = table.nRows();
@@ -23290,11 +23495,12 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
         "<h3>1) "
             + EDStatic.messages.categoryPickAttributeAr[language]
             + "&nbsp;"
-            + EDStatic.htmlTooltipImage(language, loggedInAs, tCategoryHtml)
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, tCategoryHtml)
             + "</h3>\n");
     String attsInURLs[] = EDStatic.config.categoryAttributesInURLs;
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     writer.write(
         widgets.select(
             "cat1",
@@ -23333,20 +23539,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String value)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String values[] = categoryInfo(attribute).toArray();
     writer.write(
         "<h3>2) "
             + MessageFormat.format(EDStatic.messages.categorySearchHtmlAr[language], attributeInURL)
             + ":&nbsp;"
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.messages.categoryClickHtmlAr[language])
+                request, language, loggedInAs, EDStatic.messages.categoryClickHtmlAr[language])
             + "</h3>\n");
     if (values.length == 0) {
       writer.write(MustBe.THERE_IS_NO_DATA);
     } else {
       HtmlWidgets widgets =
-          new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+          new HtmlWidgets(
+              true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
       writer.write(
           widgets.select(
               "cat2",
@@ -23392,7 +23599,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       String fileTypeName)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     StringArray cats = categoryInfo(attribute); // already safe
     int nCats = cats.size();
 
@@ -23435,6 +23642,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * Given a list of datasetIDs, this makes a sorted table of the datasets info.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). This is used to
    *     ensure that the user sees only datasets they have a right to know exist. But this has
@@ -23446,13 +23654,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @return table a table with plain text information about the datasets
    */
   public Table makePlainDatasetTable(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       StringArray datasetIDs,
       boolean sortByTitle,
       String fileTypeName) {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String roles[] = EDStatic.getRoles(loggedInAs);
     boolean isLoggedIn = loggedInAs != null && !loggedInAs.equals(EDStatic.loggedInAsHttps);
     Table table = new Table();
@@ -23586,6 +23795,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
   /**
    * Given a list of datasetIDs, this makes a sorted table of the datasets info.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). This is used to
    *     ensure that the user sees only datasets they have a right to know exist. But this has
@@ -23596,9 +23806,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    * @return table a table with html-formatted information about the datasets
    */
   public Table makeHtmlDatasetTable(
-      int language, String loggedInAs, StringArray datasetIDs, boolean sortByTitle) {
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      StringArray datasetIDs,
+      boolean sortByTitle) {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String roles[] = EDStatic.getRoles(loggedInAs);
     boolean isLoggedIn = loggedInAs != null && !loggedInAs.equals(EDStatic.loggedInAsHttps);
     Table table = new Table();
@@ -23649,13 +23863,14 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     accessTip += "<br>\"graphs\" = " + EDStatic.messages.dtAccessibleGraphsAr[language];
     if (EDStatic.config.authentication.length() > 0)
       table.addColumn(
-          "Acces-<br>sible<br>" + EDStatic.htmlTooltipImage(language, loggedInAs, accessTip),
+          "Acces-<br>sible<br>"
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, accessTip),
           accessCol);
     String loginHref =
         EDStatic.config.authentication.length() == 0
             ? "no"
             : "<a rel=\"bookmark\" href=\""
-                + EDStatic.erddapHttpsUrl(language)
+                + EDStatic.erddapHttpsUrl(request, language)
                 + "/login.html\" "
                 + "title=\""
                 + EDStatic.messages.dtLogInAr[language]
@@ -23801,6 +24016,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
       summaryCol.add(
           "&nbsp;&nbsp;&nbsp;"
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   "<div class=\"standard_max_width\">"
@@ -23872,10 +24088,13 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                   + "\" >background"
                   + (edd.infoUrl().startsWith(EDStatic.config.baseUrl) ? "" : externalLinkHtml)
                   + "</a>");
-      rssCol.add(graphsAccessible && !isAllDatasets ? edd.rssHref(language, loggedInAs) : "&nbsp;");
+      rssCol.add(
+          graphsAccessible && !isAllDatasets
+              ? edd.rssHref(request, language, loggedInAs)
+              : "&nbsp;");
       emailCol.add(
           graphsAccessible && EDStatic.config.subscriptionSystemActive && !isAllDatasets
-              ? edd.emailHref(language, loggedInAs)
+              ? edd.emailHref(request, language, loggedInAs)
               : "&nbsp;");
       String tInstitution = edd.institution();
       if (tInstitution.length() > 20)
@@ -23887,6 +24106,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + "...</td>\n"
                 + "  <td class=\"R\">&nbsp;"
                 + EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     "<div class=\"standard_max_width\">"
@@ -23981,6 +24201,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     switch (fileTypeName) {
       case ".htmlTable" ->
           TableWriterHtmlTable.writeAllAndFinish(
+              request,
               language,
               null,
               null,
@@ -24068,6 +24289,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
               "NaN"); // separator, quoted, writeColumnNames, writeUnits
       case ".xhtml" ->
           TableWriterHtmlTable.writeAllAndFinish(
+              request,
               language,
               null,
               null,

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDD.java
@@ -1905,7 +1905,7 @@ public abstract class EDD {
    *
    * @param language the index of the selected language
    */
-  public String rssHref(int language, String loggedInAs) {
+  public String rssHref(HttpServletRequest request, int language, String loggedInAs) {
     return "<a rel=\"alternate\" type=\"application/rss+xml\" "
         + "  href=\""
         + EDStatic.preferredErddapUrl
@@ -1918,7 +1918,7 @@ public abstract class EDD {
         + EDStatic.messages.subscriptionRSSAr[language]
         + "\" \n"
         + "    src=\""
-        + EDStatic.imageDirUrl(loggedInAs, language)
+        + EDStatic.imageDirUrl(request, loggedInAs, language)
         + "rss.gif\" ></a>"; // no img end tag
   }
 
@@ -1926,9 +1926,11 @@ public abstract class EDD {
    * This returns the a/href tag which advertises the email subscription url for this dataset (or ""
    * if !EDStatic.config.subscriptionSystemActive).
    *
+   * @param request the request
    * @param language the index of the selected language
+   * @param loggedInAs
    */
-  public String emailHref(int language, String loggedInAs) {
+  public String emailHref(HttpServletRequest request, int language, String loggedInAs) {
     if (EDStatic.config.subscriptionSystemActive)
       return "<a rel=\"alternate\" \n"
           + "  href=\""
@@ -1944,7 +1946,7 @@ public abstract class EDD {
           + XML.encodeAsHTMLAttribute(EDStatic.messages.subscriptionEmailAr[language])
           + "\" \n"
           + "    src=\""
-          + EDStatic.imageDirUrl(loggedInAs, language)
+          + EDStatic.imageDirUrl(request, loggedInAs, language)
           + "envelope.gif\" ></a>";
     return "&nbsp;";
   }
@@ -3758,6 +3760,7 @@ public abstract class EDD {
    * This writes the dataset info (id, title, institution, infoUrl, summary) to an html document
    * (e.g., the top of a Data Access Form).
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Normally, this is
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
@@ -3777,6 +3780,7 @@ public abstract class EDD {
    * @throws Throwable if trouble
    */
   public void writeHtmlDatasetInfo(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       Writer writer,
@@ -3792,7 +3796,7 @@ public abstract class EDD {
 
     boolean isAccessible = isAccessibleTo(EDStatic.getRoles(loggedInAs));
     boolean graphsAccessible = isAccessible || graphsAccessibleToPublic();
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String tQuery =
         userDapQuery == null || userDapQuery.length() == 0
             ? ""
@@ -3881,10 +3885,10 @@ public abstract class EDD {
             + "</strong>\n"
             + (graphsAccessible
                 ? "      "
-                    + emailHref(language, loggedInAs)
+                    + emailHref(request, language, loggedInAs)
                     + "\n"
                     + "      "
-                    + rssHref(language, loggedInAs)
+                    + rssHref(request, language, loggedInAs)
                     + "\n"
                 : "")
             + "      </span>\n"
@@ -3910,7 +3914,7 @@ public abstract class EDD {
             + EDStatic.messages.EDDInformationAr[language]
             + ":&nbsp;</td>\n"
             + "    <td>"
-            + getDisplayInfo(language, loggedInAs)
+            + getDisplayInfo(request, language, loggedInAs)
             + (accessibleViaFGDC.length() > 0
                 ? ""
                 : "     | <a rel=\"alternate\" \n"
@@ -3973,7 +3977,7 @@ public abstract class EDD {
    *
    * @return the String to append to Information row
    */
-  private String getDisplayInfo(int language, String loggedInAs) {
+  private String getDisplayInfo(HttpServletRequest request, int language, String loggedInAs) {
     if (EDStatic.displayAttributeAr.length != EDStatic.displayInfoAr.length) {
       String2.log("Incorrect input to the displayAttribute and displayInfo tags");
       return "";
@@ -4002,6 +4006,7 @@ public abstract class EDD {
       }
       value =
           EDStatic.htmlTooltipImage(
+              request,
               language,
               loggedInAs,
               "<div class=\"standard_max_width\">"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGrid.java
@@ -2613,7 +2613,7 @@ public abstract class EDDGrid extends EDD {
       throws Throwable {
 
     try {
-      String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+      String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
       // save data to outputStream
       switch (fileTypeName) {
         case ".graph" -> {
@@ -2645,6 +2645,7 @@ public abstract class EDDGrid extends EDD {
             writer.write("\n</head>\n");
             writer.write(
                 EDStatic.startBodyHtml(
+                    request,
                     language,
                     loggedInAs,
                     "griddap/" + datasetID + ".html", // was endOfRequest,
@@ -2652,15 +2653,18 @@ public abstract class EDDGrid extends EDD {
             writer.write("\n");
             writer.write(
                 HtmlWidgets.htmlTooltipScript(
-                    EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+                    EDStatic.imageDirUrl(
+                        request, loggedInAs, language))); // this is a link to a script
             writer.write(
                 HtmlWidgets.dragDropScript(
-                    EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+                    EDStatic.imageDirUrl(
+                        request, loggedInAs, language))); // this is a link to a script
             writer.flush(); // Steve Souder says: the sooner you can send some html to user, the
             // better
             writer.write("<div class=\"standard_width\">\n");
             writer.write(
                 EDStatic.youAreHereWithHelp(
+                    request,
                     language,
                     loggedInAs,
                     dapProtocol,
@@ -2673,11 +2677,11 @@ public abstract class EDDGrid extends EDD {
                         + EDStatic.messages.dafGridBypassTooltipAr[language]
                         + "</div>"));
             writeHtmlDatasetInfo(
-                language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
+                request, language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
             if (userDapQuery.length() == 0)
               userDapQuery =
                   defaultDataQuery(); // after writeHtmlDatasetInfo and before writeDapHtmlForm
-            writeDapHtmlForm(language, loggedInAs, userDapQuery, writer);
+            writeDapHtmlForm(request, language, loggedInAs, userDapQuery, writer);
 
             // End of page / other info
 
@@ -2703,14 +2707,14 @@ public abstract class EDDGrid extends EDD {
                             """);
             writeGeneralDapHtmlInstructions(language, tErddapUrl, writer, false);
             writer.write("</div>\n");
-            writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+            writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
             writer.write("</html>");
             writer.close();
 
           } catch (Exception e) {
             EDStatic.rethrowClientAbortException(e); // first thing in catch{}
             writer.write(EDStatic.htmlForException(language, e));
-            writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+            writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
             writer.write("</html>");
             writer.close();
             throw e;
@@ -2819,12 +2823,13 @@ public abstract class EDDGrid extends EDD {
       throw new SimpleException(
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaMAG());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String formName = "f1"; // change JavaScript below if this changes
     OutputStream out = outputStreamSource.outputStream(File2.UTF_8);
     Writer writer = File2.getBufferedWriterUtf8(out);
     try {
-      HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+      HtmlWidgets widgets =
+          new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
 
       // write the header
       writer.write(
@@ -2834,6 +2839,7 @@ public abstract class EDDGrid extends EDD {
       writer.write("\n</head>\n");
       writer.write(
           EDStatic.startBodyHtml(
+              request,
               language,
               loggedInAs,
               "griddap/" + datasetID + ".graph", // was endOfRequest,
@@ -2841,14 +2847,15 @@ public abstract class EDDGrid extends EDD {
       writer.write("\n");
       writer.write(
           HtmlWidgets.htmlTooltipScript(
-              EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+              EDStatic.imageDirUrl(request, loggedInAs, language))); // this is a link to a script
       writer.write(
           HtmlWidgets.dragDropScript(
-              EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+              EDStatic.imageDirUrl(request, loggedInAs, language))); // this is a link to a script
       writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
       writer.write("<div class=\"standard_width\">\n");
       writer.write(
           EDStatic.youAreHereWithHelp(
+              request,
               language,
               loggedInAs,
               "griddap",
@@ -2856,7 +2863,8 @@ public abstract class EDDGrid extends EDD {
               "<div class=\"standard_max_width\">"
                   + EDStatic.messages.magGridTooltipAr[language]
                   + "</div>"));
-      writeHtmlDatasetInfo(language, loggedInAs, writer, true, true, true, false, userDapQuery, "");
+      writeHtmlDatasetInfo(
+          request, language, loggedInAs, writer, true, true, true, false, userDapQuery, "");
       if (userDapQuery.length() == 0)
         userDapQuery =
             defaultGraphQuery(); // after writeHtmlDatasetInfo and before Table.getDapQueryParts
@@ -3453,6 +3461,7 @@ public abstract class EDDGrid extends EDD {
           " "
               + // spacer
               EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   "<div class=\"standard_max_width\">"
@@ -3499,6 +3508,7 @@ public abstract class EDDGrid extends EDD {
             " "
                 + // spacer
                 EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     MessageFormat.format(EDStatic.messages.magAxisVarHelpAr[language], varHelp[v])
@@ -3521,6 +3531,7 @@ public abstract class EDDGrid extends EDD {
               + EDStatic.messages.EDDGridDimensionRangesAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.messages.EDDGridDimensionTooltipAr[0]
@@ -3532,6 +3543,7 @@ public abstract class EDDGrid extends EDD {
               + EDStatic.messages.EDDGridStartAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.messages.EDDGridDimensionTooltipAr[language]
@@ -3545,6 +3557,7 @@ public abstract class EDDGrid extends EDD {
               + EDStatic.messages.EDDGridStopAr[0]
               + " "
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   EDStatic.messages.EDDGridDimensionTooltipAr[0]
@@ -3569,7 +3582,7 @@ public abstract class EDDGrid extends EDD {
                 + edvga.destinationName()
                 + " "
                 + tUnits
-                + EDStatic.htmlTooltipImageEDVGA(language, loggedInAs, edvga)
+                + EDStatic.htmlTooltipImageEDVGA(request, language, loggedInAs, edvga)
                 + "</td>\n");
 
         for (int ss = 0; ss < 2; ss++) { // 0=start, 1=stop
@@ -3589,7 +3602,7 @@ public abstract class EDDGrid extends EDD {
               buttons.append(
                   "<td class=\"B\">\n"
                       + HtmlWidgets.htmlTooltipImage(
-                          EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
+                          EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowLL.gif",
                           "|<",
                           EDStatic.messages.magItemFirstAr[language],
                           "class=\"B\" "
@@ -3614,7 +3627,7 @@ public abstract class EDDGrid extends EDD {
               buttons.append(
                   "<td class=\"B\">\n"
                       + HtmlWidgets.htmlTooltipImage(
-                          EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
+                          EDStatic.imageDirUrl(request, loggedInAs, language) + "minus.gif",
                           "-",
                           EDStatic.messages.magItemPreviousAr[language],
                           "class=\"B\" "
@@ -3635,7 +3648,7 @@ public abstract class EDDGrid extends EDD {
               buttons.append(
                   "<td class=\"B\">\n"
                       + HtmlWidgets.htmlTooltipImage(
-                          EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
+                          EDStatic.imageDirUrl(request, loggedInAs, language) + "plus.gif",
                           "+",
                           EDStatic.messages.magItemNextAr[language],
                           "class=\"B\" "
@@ -3653,7 +3666,7 @@ public abstract class EDDGrid extends EDD {
               buttons.append(
                   "<td class=\"B\">\n"
                       + HtmlWidgets.htmlTooltipImage(
-                          EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
+                          EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowRR.gif",
                           ">|",
                           EDStatic.messages.magItemLastAr[language],
                           // the word "last" works for all datasets
@@ -4414,7 +4427,7 @@ public abstract class EDDGrid extends EDD {
               + "title=\"griddap documentation\">"
               + EDStatic.messages.magDocumentationAr[language]
               + "</a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml)
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, genViewHtml)
               + ")\n");
       writer.write("""
               </td></tr>
@@ -4443,7 +4456,10 @@ public abstract class EDDGrid extends EDD {
             EDStatic.messages.magZoomCenterAr[language]
                 + "\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.messages.magZoomCenterTooltipAr[language])
+                    request,
+                    language,
+                    loggedInAs,
+                    EDStatic.messages.magZoomCenterTooltipAr[language])
                 + "<br><strong>"
                 + EDStatic.messages.magZoomAr[language]
                 + ":</strong>\n");
@@ -4466,7 +4482,7 @@ public abstract class EDDGrid extends EDD {
 
         writer.write(
             // HtmlWidgets.htmlTooltipImage(
-            //    EDStatic.imageDirUrl(loggedInAs, language) + "arrowDD.gif",
+            //    EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowDD.gif",
             widgets.button(
                 "button",
                 "",
@@ -4780,7 +4796,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 "&nbsp;"
                     + HtmlWidgets.htmlTooltipImage(
-                        EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
+                        EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowLL.gif",
                         "|<",
                         MessageFormat.format(
                                 EDStatic.messages.magTimeRangeFirstAr[language], timeRangeString)
@@ -4810,7 +4826,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 "&nbsp;"
                     + HtmlWidgets.htmlTooltipImage(
-                        EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
+                        EDStatic.imageDirUrl(request, loggedInAs, language) + "minus.gif",
                         "-",
                         MessageFormat.format(
                                 EDStatic.messages.magTimeRangeBackAr[language], timeRangeString)
@@ -4847,7 +4863,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 "&nbsp;"
                     + HtmlWidgets.htmlTooltipImage(
-                        EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
+                        EDStatic.imageDirUrl(request, loggedInAs, language) + "plus.gif",
                         "+",
                         MessageFormat.format(
                                 EDStatic.messages.magTimeRangeForwardAr[language], timeRangeString)
@@ -4890,7 +4906,7 @@ public abstract class EDDGrid extends EDD {
             writer.write(
                 "&nbsp;"
                     + HtmlWidgets.htmlTooltipImage(
-                        EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
+                        EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowRR.gif",
                         ">|",
                         MessageFormat.format(
                                 EDStatic.messages.magTimeRangeLastAr[language], timeRangeString)
@@ -4998,7 +5014,7 @@ public abstract class EDDGrid extends EDD {
           // all the way left
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowLL.gif",
                       "|<",
                       EDStatic.messages.shiftXAllTheWayLeftAr[language],
                       "class=\"B\" "
@@ -5020,7 +5036,7 @@ public abstract class EDDGrid extends EDD {
           int howMuch = Math.min(tRange2, tStartIndex);
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "minus.gif",
                       "-",
                       EDStatic.messages.shiftXLeftAr[language],
                       "class=\"B\" "
@@ -5046,7 +5062,7 @@ public abstract class EDDGrid extends EDD {
           int howMuch = Math.min(tRange2, tSize1 - tStopIndex);
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "plus.gif",
                       "+",
                       EDStatic.messages.shiftXRightAr[0],
                       "class=\"B\" "
@@ -5067,7 +5083,7 @@ public abstract class EDDGrid extends EDD {
           // all the way right
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                  EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
+                  EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowRR.gif",
                   ">|",
                   EDStatic.messages.shiftXAllTheWayRightAr[language],
                   "class=\"B\" "
@@ -5173,7 +5189,7 @@ public abstract class EDDGrid extends EDD {
               EDV.SLIDER_PIXELS - 1));
 
       writer.write("</div>\n"); // standard_width
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("</html>");
       if (!dimensionValuesInMemory) setDimensionValuesToNull();
 
@@ -5185,7 +5201,7 @@ public abstract class EDDGrid extends EDD {
               + " when writing web page:\n"
               + MustBe.throwableToString(e)); // before writer.write's
       writer.write(EDStatic.htmlForException(language, e));
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("</html>");
       if (!dimensionValuesInMemory) setDimensionValuesToNull();
 
@@ -6236,6 +6252,7 @@ public abstract class EDDGrid extends EDD {
    * This writes an HTML form requesting info from this dataset (like the OPeNDAP Data Access
    * forms).
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Normally, this is
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
@@ -6245,11 +6262,16 @@ public abstract class EDDGrid extends EDD {
    * @param writer
    * @throws Throwable if trouble
    */
-  public void writeDapHtmlForm(int language, String loggedInAs, String userDapQuery, Writer writer)
+  public void writeDapHtmlForm(
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String userDapQuery,
+      Writer writer)
       throws Throwable {
 
     // parse userDapQuery
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     if (userDapQuery == null) userDapQuery = "";
     userDapQuery = userDapQuery.trim();
     StringArray destinationNames = new StringArray();
@@ -6270,7 +6292,8 @@ public abstract class EDDGrid extends EDD {
 
     // beginning of form   ("form1" is used in javascript below")
     writer.write(HtmlWidgets.ifJavaScriptDisabled + "\n");
-    HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+    HtmlWidgets widgets =
+        new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
     String formName = "form1";
     writer.write("&nbsp;\n"); // necessary for the blank line before the form (not <p>)
     writer.write(widgets.beginForm(formName, "GET", "", ""));
@@ -6292,6 +6315,7 @@ public abstract class EDDGrid extends EDD {
             + EDStatic.messages.EDDGridDimensionAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 dimHelp + EDStatic.messages.EDDGridVarHasDimTooltipAr[language])
@@ -6299,17 +6323,17 @@ public abstract class EDDGrid extends EDD {
             + "  <th class=\"L\">"
             + EDStatic.messages.EDDGridStartAr[language]
             + " "
-            + EDStatic.htmlTooltipImage(language, loggedInAs, startTooltip)
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, startTooltip)
             + " </th>\n"
             + "  <th class=\"L\">"
             + EDStatic.messages.EDDGridStrideAr[language]
             + " "
-            + EDStatic.htmlTooltipImage(language, loggedInAs, strideTooltip)
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, strideTooltip)
             + " </th>\n"
             + "  <th class=\"L\">"
             + EDStatic.messages.EDDGridStopAr[language]
             + " "
-            + EDStatic.htmlTooltipImage(language, loggedInAs, stopTooltip)
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, stopTooltip)
             + " </th>\n"
             +
             // "  <th class=\"L\">&nbsp;" + EDStatic.messages.EDDGridFirst + " " +
@@ -6319,13 +6343,14 @@ public abstract class EDDGrid extends EDD {
             + EDStatic.messages.EDDGridNValuesAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.messages.EDDGridNValuesHtmlAr[language])
+                request, language, loggedInAs, EDStatic.messages.EDDGridNValuesHtmlAr[language])
             + "</th>\n"
             + "  <th class=\"L\">"
             + gap
             + EDStatic.messages.EDDGridSpacingAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
@@ -6374,7 +6399,7 @@ public abstract class EDDGrid extends EDD {
               ""));
 
       writer.write(extra + " ");
-      writer.write(EDStatic.htmlTooltipImageEDVGA(language, loggedInAs, edvga));
+      writer.write(EDStatic.htmlTooltipImageEDVGA(request, language, loggedInAs, edvga));
       writer.write("&nbsp;</td>\n");
 
       // set default start, stride, stop
@@ -6521,7 +6546,8 @@ public abstract class EDDGrid extends EDD {
               ""));
 
       writer.write(extra + " ");
-      writer.write(EDStatic.htmlTooltipImageEDVG(language, loggedInAs, edv, allDimString()));
+      writer.write(
+          EDStatic.htmlTooltipImageEDVG(request, language, loggedInAs, edv, allDimString()));
       writer.write("</td>\n");
 
       // end of row
@@ -6651,7 +6677,7 @@ public abstract class EDDGrid extends EDD {
             + tErddapUrl
             + "/griddap/documentation.html\" "
             + "title=\"griddap documentation\">Documentation&nbsp;/&nbsp;Bypass&nbsp;this&nbsp;form</a>)\n"
-            + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml));
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, genViewHtml));
 
     // submit
     writer.write(
@@ -6696,8 +6722,8 @@ public abstract class EDDGrid extends EDD {
    * This writes HTML info on forming OPeNDAP DAP-style requests for this type of dataset.
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param writer to which will be written HTML info on forming OPeNDAP DAP-style requests for this
    *     type of dataset.
    * @param complete if false, this just writes a paragraph and shows a link to
@@ -8401,18 +8427,20 @@ public abstract class EDDGrid extends EDD {
   /**
    * This responds by writing WCS info for this dataset.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Caller should have
    *     already checked that user has access to this dataset.
    */
-  public void wcsInfo(int language, String loggedInAs, Writer writer) throws Throwable {
+  public void wcsInfo(HttpServletRequest request, int language, String loggedInAs, Writer writer)
+      throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String wcsUrl = tErddapUrl + "/wcs/" + datasetID + "/" + EDDGrid.wcsServer;
     String getCapabilities = wcsUrl + "?service=WCS&amp;request=GetCapabilities";
     String wcsExample = wcsUrl + "?NotYetFinished"; // EDStatic.wcsSampleStation;
     writer.write(
-        EDStatic.youAreHere(language, loggedInAs, "Web Coverage Service (WCS)")
+        EDStatic.youAreHere(request, language, loggedInAs, "Web Coverage Service (WCS)")
             + "\n"
             + "<h2>Overview</h2>\n"
             + "In addition to making data available via \n"
@@ -8462,19 +8490,21 @@ public abstract class EDDGrid extends EDD {
    * called if accessibleViaWCS is true and loggedInAs has access to this dataset (so redirected to
    * login, instead of getting an error here).
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in).
    * @param version Currently, only "1.0.0" is supported.
    * @param writer In the end, the writer is flushed, not closed.
    */
-  public void wcsGetCapabilities(int language, String loggedInAs, String version, Writer writer)
+  public void wcsGetCapabilities(
+      HttpServletRequest request, int language, String loggedInAs, String version, Writer writer)
       throws Throwable {
 
     if (accessibleViaWCS().length() > 0)
       throw new SimpleException(
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaWCS());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String wcsUrl = tErddapUrl + "/wcs/" + datasetID + "/" + wcsServer;
     String titleXml = XML.encodeAsXML(title());
     String keywordsSA[] = keywords();
@@ -9579,15 +9609,17 @@ public abstract class EDDGrid extends EDD {
    * Currently, this just works as a WCS 1.0.0 server. <br>
    * The caller should have already checked loggedInAs and accessibleViaWCS().
    *
+   * @param request the servlet request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). This doesn't check
    *     if eddGrid is accessible to loggedInAs. The caller should do that.
    * @param writer afterwards, the writer is flushed, not closed
    * @throws Throwable if trouble (there shouldn't be)
    */
-  public void wcsDatasetHtml(int language, String loggedInAs, Writer writer) throws Throwable {
+  public void wcsDatasetHtml(
+      HttpServletRequest request, int language, String loggedInAs, Writer writer) throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     String wcsUrl = tErddapUrl + "/wcs/" + datasetID + "/" + wcsServer;
     String destName0 = dataVariables[0].destinationName();
@@ -9641,15 +9673,20 @@ public abstract class EDDGrid extends EDD {
     // writer.write(EDStatic.startBodyHtml(language, loggedInAs,
     //    "wcs/" + datasetID + "/index.html", //was endOfRequest,
     //    queryString) + "\n");
-    // writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(loggedInAs, language)));
+    // writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs,
+    // language)));
     // writer.flush(); //Steve Souder says: the sooner you can send some html to user, the better
 
     // *** html body content
     writer.write("<div class=\"standard_width\">\n");
     writer.write(
         EDStatic.youAreHere(
-            language, loggedInAs, "wcs", datasetID)); // wcs must be lowercase for link to work
-    writeHtmlDatasetInfo(language, loggedInAs, writer, true, true, true, true, "", "");
+            request,
+            language,
+            loggedInAs,
+            "wcs",
+            datasetID)); // wcs must be lowercase for link to work
+    writeHtmlDatasetInfo(request, language, loggedInAs, writer, true, true, true, true, "", "");
 
     String datasetListRef =
         "<br>See the\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTable.java
@@ -2889,7 +2889,7 @@ public abstract class EDDTable extends EDD {
               + "\n  fileTypeName="
               + fileTypeName);
     long makeTime = System.currentTimeMillis();
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // special EDDTableFromHttpGet file types
     if (this instanceof EDDTableFromHttpGet etfhg
@@ -2947,6 +2947,7 @@ public abstract class EDDTable extends EDD {
           writer.write("\n</head>\n");
           writer.write(
               EDStatic.startBodyHtml(
+                  request,
                   language,
                   loggedInAs,
                   "tabledap/" + datasetID + ".html", // was endOfRequest,
@@ -2954,15 +2955,18 @@ public abstract class EDDTable extends EDD {
           writer.write("\n");
           writer.write(
               HtmlWidgets.htmlTooltipScript(
-                  EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+                  EDStatic.imageDirUrl(
+                      request, loggedInAs, language))); // this is a link to a script
           writer.write(
               HtmlWidgets.dragDropScript(
-                  EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+                  EDStatic.imageDirUrl(
+                      request, loggedInAs, language))); // this is a link to a script
           writer
               .flush(); // Steve Souder says: the sooner you can send some html to user, the better
           writer.write("<div class=\"standard_width\">\n");
           writer.write(
               EDStatic.youAreHereWithHelp(
+                  request,
                   language,
                   loggedInAs,
                   dapProtocol,
@@ -2975,11 +2979,11 @@ public abstract class EDDTable extends EDD {
                       + EDStatic.messages.dafTableBypassTooltipAr[language]
                       + "</div>"));
           writeHtmlDatasetInfo(
-              language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
+              request, language, loggedInAs, writer, true, false, true, true, userDapQuery, "");
           if (userDapQuery.length() == 0)
             userDapQuery =
                 defaultDataQuery(); // after writeHtmlDatasetInfo and before writeDapHtmlForm
-          writeDapHtmlForm(language, loggedInAs, userDapQuery, writer);
+          writeDapHtmlForm(request, language, loggedInAs, userDapQuery, writer);
 
           // info at end of page
 
@@ -2999,7 +3003,7 @@ public abstract class EDDTable extends EDD {
           writer.write("<hr>\n");
           writeGeneralDapHtmlInstructions(language, tErddapUrl, writer, false);
           writer.write("</div>\n");
-          writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+          writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
           writer.write("\n</html>\n");
           writer.flush(); // essential
           return;
@@ -3011,7 +3015,7 @@ public abstract class EDDTable extends EDD {
                   + " when writing web page:\n"
                   + MustBe.throwableToString(e)); // before writer.write's
           writer.write(EDStatic.htmlForException(language, e));
-          writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+          writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
           writer.write("\n</html>\n");
           writer.flush(); // essential
           throw e;
@@ -4904,6 +4908,7 @@ public abstract class EDDTable extends EDD {
    * This writes an HTML form requesting info from this dataset (like the OPeNDAP Data Access Forms,
    * DAF).
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Normally, this is
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
@@ -4913,13 +4918,19 @@ public abstract class EDDTable extends EDD {
    * @param writer
    * @throws Throwable if trouble
    */
-  public void writeDapHtmlForm(int language, String loggedInAs, String userDapQuery, Writer writer)
+  public void writeDapHtmlForm(
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String userDapQuery,
+      Writer writer)
       throws Throwable, Exception {
 
-    HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+    HtmlWidgets widgets =
+        new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
 
     // parse userDapQuery
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     if (userDapQuery == null) userDapQuery = "";
     userDapQuery = userDapQuery.trim();
     String queryParts[] =
@@ -4969,6 +4980,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.EDDTableVariableAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
@@ -5003,6 +5015,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.EDDTableOptConstraint1HtmlAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
@@ -5013,6 +5026,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.EDDTableOptConstraint2HtmlAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
@@ -5024,7 +5038,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.EDDMinimumAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.messages.EDDTableMinimumTooltipAr[language])
+                request, language, loggedInAs, EDStatic.messages.EDDTableMinimumTooltipAr[language])
             + (distinctOptions == null
                 ? "<br>&nbsp;"
                 : "<br>"
@@ -5033,6 +5047,7 @@ public abstract class EDDTable extends EDD {
                     + " "
                     + // 2014-07-17 was Distinct Values
                     EDStatic.htmlTooltipImage(
+                        request,
                         language,
                         loggedInAs,
                         "<div class=\"narrow_max_width\">"
@@ -5044,7 +5059,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.EDDMaximumAr[language]
             + " "
             + EDStatic.htmlTooltipImage(
-                language, loggedInAs, EDStatic.messages.EDDTableMaximumTooltipAr[language])
+                request, language, loggedInAs, EDStatic.messages.EDDTableMaximumTooltipAr[language])
             + "<br>&nbsp;"
             + "</th>\n"
             + "</tr>\n");
@@ -5087,7 +5102,7 @@ public abstract class EDDTable extends EDD {
               edv.destinationName()
                   + extra
                   + " "
-                  + EDStatic.htmlTooltipImageEDV(language, loggedInAs, edv),
+                  + EDStatic.htmlTooltipImageEDV(request, language, loggedInAs, edv),
               ""));
       writer.write("  &nbsp;</td>\n");
 
@@ -5292,6 +5307,7 @@ public abstract class EDDTable extends EDD {
                 + "  </td>\n"
                 + "  <td>&nbsp;"
                 + EDStatic.htmlTooltipImage(
+                    request,
                     language,
                     loggedInAs,
                     "<div class=\"narrow_max_width\">"
@@ -5419,7 +5435,7 @@ public abstract class EDDTable extends EDD {
                     "")
                 + "\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.messages.addVarWhereAr[language])
+                    request, language, loggedInAs, EDStatic.messages.addVarWhereAr[language])
                 + "</tr>\n");
       }
       writer.write(widgets.endTable());
@@ -5428,7 +5444,7 @@ public abstract class EDDTable extends EDD {
     // functions
     int nOrderByComboBox = 5;
     writeFunctionHtml(
-        language, loggedInAs, queryParts, writer, widgets, formName, nOrderByComboBox);
+        request, language, loggedInAs, queryParts, writer, widgets, formName, nOrderByComboBox);
 
     // fileType
     writer.write(
@@ -5551,7 +5567,7 @@ public abstract class EDDTable extends EDD {
             + tErddapUrl
             + "/tabledap/documentation.html\" "
             + "title=\"tabledap documentation\">Documentation&nbsp;/&nbsp;Bypass&nbsp;this&nbsp;form</a>\n"
-            + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml)
+            + EDStatic.htmlTooltipImage(request, language, loggedInAs, genViewHtml)
             + ")\n");
 
     // submit
@@ -5601,6 +5617,7 @@ public abstract class EDDTable extends EDD {
    * @param nOrderByComboBox The number of variable list comboBoxes must be 4 or 5.
    */
   void writeFunctionHtml(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String[] queryParts,
@@ -5617,6 +5634,7 @@ public abstract class EDDTable extends EDD {
             + EDStatic.messages.functionsAr[language]
             + "</strong> "
             + EDStatic.htmlTooltipImage(
+                request,
                 language,
                 loggedInAs,
                 "<div class=\"narrow_max_width\">"
@@ -5636,6 +5654,7 @@ public abstract class EDDTable extends EDD {
             ""));
     writer.write(
         EDStatic.htmlTooltipImage(
+            request,
             language,
             loggedInAs,
             "<div class=\"narrow_max_width\">"
@@ -5692,7 +5711,7 @@ public abstract class EDDTable extends EDD {
     writer.write(widgets.select("orderBy", "", 1, orderByOptions, whichOb, ""));
     writer.write(
         EDStatic.htmlTooltipImage(
-            language, loggedInAs, EDStatic.messages.functionOrderByTooltipAr[language]));
+            request, language, loggedInAs, EDStatic.messages.functionOrderByTooltipAr[language]));
     writer.write("(\"");
     for (int ob = 0; ob < nOrderByComboBox; ob++) {
       // if (ob > 0) writer.write(",\n");
@@ -5766,8 +5785,8 @@ public abstract class EDDTable extends EDD {
    * This write HTML info on forming OPeNDAP DAP-style requests for this type of dataset.
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param writer to which will be written HTML info on forming OPeNDAP DAP-style requests for this
    *     type of dataset.
    * @param complete if false, this just writes a paragraph and shows a link to
@@ -7786,7 +7805,7 @@ public abstract class EDDTable extends EDD {
       throw new SimpleException(
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaMAG());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     if (userDapQuery == null) userDapQuery = "";
     if (reallyVerbose) String2.log("*** respondToGraphQuery");
     if (debugMode) String2.log("respondToGraphQuery 1");
@@ -7889,7 +7908,8 @@ public abstract class EDDTable extends EDD {
     OutputStream out = outputStreamSource.outputStream(File2.UTF_8);
     Writer writer = File2.getBufferedWriterUtf8(out);
     try {
-      HtmlWidgets widgets = new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language));
+      HtmlWidgets widgets =
+          new HtmlWidgets(true, EDStatic.imageDirUrl(request, loggedInAs, language));
       writer.write(
           EDStatic.startHeadHtml(
               language, tErddapUrl, title() + " - " + EDStatic.messages.magAr[language]));
@@ -7897,6 +7917,7 @@ public abstract class EDDTable extends EDD {
       writer.write("\n</head>\n");
       writer.write(
           EDStatic.startBodyHtml(
+              request,
               language,
               loggedInAs,
               "tabledap/" + datasetID + ".graph", // was endOfRequest,
@@ -7904,11 +7925,12 @@ public abstract class EDDTable extends EDD {
       writer.write("\n");
       writer.write(
           HtmlWidgets.htmlTooltipScript(
-              EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+              EDStatic.imageDirUrl(request, loggedInAs, language))); // this is a link to a script
       writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
       writer.write("<div class=\"standard_width\">\n");
       writer.write(
           EDStatic.youAreHereWithHelp(
+              request,
               language,
               loggedInAs,
               "tabledap",
@@ -7917,7 +7939,7 @@ public abstract class EDDTable extends EDD {
                   + EDStatic.messages.magTableTooltipAr[language]
                   + "</div>"));
       writeHtmlDatasetInfo(
-          language, loggedInAs, writer, true, true, true, false, userDapQuery, otherRows);
+          request, language, loggedInAs, writer, true, true, true, false, userDapQuery, otherRows);
       if (userDapQuery.length() == 0)
         userDapQuery =
             defaultGraphQuery(); // after writeHtmlDatasetInfo and before parseUserDapQuery
@@ -8385,6 +8407,7 @@ public abstract class EDDTable extends EDD {
                   ");'"));
       writer.write(
           EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   "<div class=\"standard_max_width\">"
@@ -8591,12 +8614,13 @@ public abstract class EDDTable extends EDD {
               + EDStatic.messages.EDDTableConstraintsAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
-                  language, loggedInAs, EDStatic.messages.magConstraintHelpAr[language])
+                  request, language, loggedInAs, EDStatic.messages.magConstraintHelpAr[language])
               + "</th>\n"
               + "  <th style=\"text-align:center;\" colspan=\"2\">"
               + EDStatic.messages.EDDTableOptConstraint1HtmlAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   "<div class=\"narrow_max_width\">"
@@ -8607,6 +8631,7 @@ public abstract class EDDTable extends EDD {
               + EDStatic.messages.EDDTableOptConstraint2HtmlAr[language]
               + " "
               + EDStatic.htmlTooltipImage(
+                  request,
                   language,
                   loggedInAs,
                   "<div class=\"narrow_max_width\">"
@@ -9002,7 +9027,7 @@ public abstract class EDDTable extends EDD {
       // *** function options
       int nOrderByComboBox = 4; // to be narrower than Data Access Form
       writeFunctionHtml(
-          language, loggedInAs, queryParts, writer, widgets, formName, nOrderByComboBox);
+          request, language, loggedInAs, queryParts, writer, widgets, formName, nOrderByComboBox);
       if (String2.indexOf(queryParts, "distinct()") >= 0) {
         graphQuery.append("&distinct()");
         graphQueryNoLatLon.append("&distinct()");
@@ -9708,7 +9733,7 @@ public abstract class EDDTable extends EDD {
               + "title=\"tabledap documentation\">"
               + EDStatic.messages.magDocumentationAr[language]
               + "</a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, genViewHtml)
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, genViewHtml)
               + ")\n");
 
       if (debugMode) String2.log("respondToGraphQuery 8");
@@ -9753,7 +9778,10 @@ public abstract class EDDTable extends EDD {
             EDStatic.messages.magZoomCenterAr[language]
                 + "\n"
                 + EDStatic.htmlTooltipImage(
-                    language, loggedInAs, EDStatic.messages.magZoomCenterTooltipAr[language])
+                    request,
+                    language,
+                    loggedInAs,
+                    EDStatic.messages.magZoomCenterTooltipAr[language])
                 + "<br><strong>"
                 + EDStatic.messages.magZoomAr[language]
                 + ":&nbsp;</strong>\n");
@@ -9918,7 +9946,7 @@ public abstract class EDDTable extends EDD {
           // all the way left
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowLL.gif",
                       "|<",
                       EDStatic.messages.shiftXAllTheWayLeftAr[language],
                       "class=\"B\" "
@@ -9942,7 +9970,7 @@ public abstract class EDDTable extends EDD {
         // left
         writer.write(
             HtmlWidgets.htmlTooltipImage(
-                    EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
+                    EDStatic.imageDirUrl(request, loggedInAs, language) + "minus.gif",
                     "-",
                     EDStatic.messages.shiftXLeftAr[language],
                     "class=\"B\" "
@@ -9963,7 +9991,7 @@ public abstract class EDDTable extends EDD {
         // right
         writer.write(
             HtmlWidgets.htmlTooltipImage(
-                    EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
+                    EDStatic.imageDirUrl(request, loggedInAs, language) + "plus.gif",
                     "+",
                     EDStatic.messages.shiftXRightAr[language],
                     "class=\"B\" "
@@ -9985,7 +10013,7 @@ public abstract class EDDTable extends EDD {
           // all the way right
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowRR.gif",
                       ">|",
                       EDStatic.messages.shiftXAllTheWayRightAr[language],
                       "class=\"B\" "
@@ -10157,7 +10185,7 @@ public abstract class EDDTable extends EDD {
           if (timeMin > edvTimeMin || ratio < 0.99 || ratio > 1.01) {
             writer.write(
                 HtmlWidgets.htmlTooltipImage(
-                        EDStatic.imageDirUrl(loggedInAs, language) + "arrowLL.gif",
+                        EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowLL.gif",
                         "|<",
                         MessageFormat.format(
                             EDStatic.messages.magTimeRangeFirstAr[language], timeRangeString),
@@ -10187,7 +10215,7 @@ public abstract class EDDTable extends EDD {
           idMaxGc.add(Calendar2.IDEAL_UNITS_FIELD.get(idealTimeUnits), -idealTimeN);
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "minus.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "minus.gif",
                       "-",
                       MessageFormat.format(
                           EDStatic.messages.magTimeRangeBackAr[language], timeRangeString),
@@ -10221,7 +10249,7 @@ public abstract class EDDTable extends EDD {
                   : "";
           writer.write(
               HtmlWidgets.htmlTooltipImage(
-                      EDStatic.imageDirUrl(loggedInAs, language) + "plus.gif",
+                      EDStatic.imageDirUrl(request, loggedInAs, language) + "plus.gif",
                       "+",
                       MessageFormat.format(
                           EDStatic.messages.magTimeRangeForwardAr[language], timeRangeString),
@@ -10264,7 +10292,7 @@ public abstract class EDDTable extends EDD {
           if (timeMax < edvTimeMax || ratio < 0.99 || ratio > 1.01) {
             writer.write(
                 HtmlWidgets.htmlTooltipImage(
-                    EDStatic.imageDirUrl(loggedInAs, language) + "arrowRR.gif",
+                    EDStatic.imageDirUrl(request, loggedInAs, language) + "arrowRR.gif",
                     ">|",
                     MessageFormat.format(
                         EDStatic.messages.magTimeRangeLastAr[language], timeRangeString),
@@ -10361,7 +10389,7 @@ public abstract class EDDTable extends EDD {
 
       writer.write("</div>\n");
 
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("\n</html>\n");
       writer.flush(); // essential
       // *** end of document
@@ -10370,7 +10398,7 @@ public abstract class EDDTable extends EDD {
       EDStatic.rethrowClientAbortException(e); // first thing in catch{}
       writer.write(EDStatic.htmlForException(language, e));
       writer.write("</div>\n");
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("\n</html>\n");
       writer.flush(); // essential
       throw e;
@@ -10453,7 +10481,7 @@ public abstract class EDDTable extends EDD {
     String ANY = "(ANY)";
     boolean fixedLLRange = false; // true until 2011-02-08
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String subsetUrl = tErddapUrl + "/tabledap/" + datasetID + ".subset";
     userQuery =
         userQuery == null
@@ -10799,7 +10827,8 @@ public abstract class EDDTable extends EDD {
 
     // show the .html response/form
     HtmlWidgets widgets =
-        new HtmlWidgets(true, EDStatic.imageDirUrl(loggedInAs, language)); // true=htmlTooltips
+        new HtmlWidgets(
+            true, EDStatic.imageDirUrl(request, loggedInAs, language)); // true=htmlTooltips
     widgets.enterTextSubmitsForm = true;
     OutputStream out = outputStreamSource.outputStream(File2.UTF_8);
     Writer writer = File2.getBufferedWriterUtf8(out);
@@ -10811,6 +10840,7 @@ public abstract class EDDTable extends EDD {
       writer.write("\n</head>\n");
       writer.write(
           EDStatic.startBodyHtml(
+              request,
               language,
               loggedInAs,
               "tabledap/" + datasetID + ".subset", // was endOfRequest,
@@ -10819,10 +10849,11 @@ public abstract class EDDTable extends EDD {
       writer.write("<div class=\"standard_width\">\n");
       writer.write(
           HtmlWidgets.htmlTooltipScript(
-              EDStatic.imageDirUrl(loggedInAs, language))); // this is a link to a script
+              EDStatic.imageDirUrl(request, loggedInAs, language))); // this is a link to a script
       writer.flush(); // Steve Souder says: the sooner you can send some html to user, the better
       writer.write(
           EDStatic.youAreHereWithHelp(
+              request,
               language,
               loggedInAs,
               dapProtocol,
@@ -10846,7 +10877,7 @@ public abstract class EDDTable extends EDD {
         }
       }
       writeHtmlDatasetInfo(
-          language, loggedInAs, writer, false, true, true, true, diQuery.toString(), "");
+          request, language, loggedInAs, writer, false, true, true, true, diQuery.toString(), "");
       writer.write(HtmlWidgets.ifJavaScriptDisabled);
 
       // if noData/invalid request, tell user and reset all
@@ -10975,7 +11006,7 @@ public abstract class EDDTable extends EDD {
                 + "  <td>&nbsp;&nbsp;&nbsp;&nbsp;"
                 + pName
                 + "\n"
-                + EDStatic.htmlTooltipImageEDV(language, loggedInAs, edv)
+                + EDStatic.htmlTooltipImageEDV(request, language, loggedInAs, edv)
                 + "  </td>\n"
                 + "  <td>\n");
 
@@ -11171,7 +11202,7 @@ public abstract class EDDTable extends EDD {
                       viewTitle[v],
                       "onclick='mySubmit(null);'")
                   + // IE doesn't trigger onchange for checkbox
-                  EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[v])
+                  EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[v])
                   + "</span>");
           if (viewValue[v] == 1) viewQuery.append("&." + viewParam[v] + "=true");
 
@@ -11201,7 +11232,7 @@ public abstract class EDDTable extends EDD {
                       intOptions,
                       String2.indexOf(intOptions, "" + viewValue[v]),
                       "onchange='mySubmit(null);'")
-                  + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[v]));
+                  + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[v]));
           viewQuery.append("&." + viewParam[v] + "=" + viewValue[v]);
         }
       }
@@ -11306,7 +11337,7 @@ public abstract class EDDTable extends EDD {
                 + "<a class=\"selfLink\" id=\"DistinctMap\" href=\"#DistinctMap\" rel=\"bookmark\"><strong>"
                 + viewTitle[current]
                 + "</strong></a>\n"
-                + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current])
+                + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current])
                 + "&nbsp;&nbsp;(<a href=\""
                 + tErddapUrl
                 + "/tabledap/"
@@ -11400,7 +11431,7 @@ public abstract class EDDTable extends EDD {
                 + "<a class=\"selfLink\" id=\"RelatedMap\" href=\"#RelatedMap\" rel=\"bookmark\"><strong>"
                 + viewTitle[current]
                 + "</strong></a>\n"
-                + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current])
+                + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current])
                 + "&nbsp;&nbsp;(<a href=\""
                 + tErddapUrl
                 + "/tabledap/"
@@ -11457,7 +11488,7 @@ public abstract class EDDTable extends EDD {
               + "<p><a class=\"selfLink\" id=\"DistinctDataCounts\" href=\"#DistinctDataCounts\" rel=\"bookmark\"><strong>"
               + viewTitle[current]
               + "</strong></a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current]));
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current]));
       if (viewValue[current] == 1 && lastP >= 0 && lastPPA != null) { // lastPPA shouldn't be null
         writer.write(
             "&nbsp;&nbsp;\n"
@@ -11525,6 +11556,7 @@ public abstract class EDDTable extends EDD {
           writer.flush(); // essential, since creating and using another writer to write the
           // countTable
           TableWriterHtmlTable.writeAllAndFinish(
+              request,
               language,
               this,
               tNewHistory,
@@ -11577,7 +11609,7 @@ public abstract class EDDTable extends EDD {
               + "<p><a class=\"selfLink\" id=\"DistinctData\" href=\"#DistinctData\" rel=\"bookmark\"><strong>"
               + viewTitle[current]
               + "</strong></a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current])
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current])
               + "&nbsp;&nbsp;(<a href=\""
               + tErddapUrl
               + "/tabledap/"
@@ -11604,6 +11636,7 @@ public abstract class EDDTable extends EDD {
         writer
             .flush(); // essential, since creating and using another writer to write the subsetTable
         TableWriterHtmlTable.writeAllAndFinish(
+            request,
             language,
             this,
             tNewHistory,
@@ -11656,7 +11689,7 @@ public abstract class EDDTable extends EDD {
               + "<p><a class=\"selfLink\" id=\"RelatedDataCounts\" href=\"#RelatedDataCounts\" rel=\"bookmark\"><strong>"
               + viewTitle[current]
               + "</strong></a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current]));
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current]));
       if (viewValue[current] == 1 && lastP >= 0) {
         writer.write(
             "&nbsp;&nbsp;\n"
@@ -11739,6 +11772,7 @@ public abstract class EDDTable extends EDD {
           writer.flush(); // essential, since creating and using another writer to write the
           // countTable
           TableWriterHtmlTable.writeAllAndFinish(
+              request,
               language,
               this,
               tNewHistory,
@@ -11797,7 +11831,7 @@ public abstract class EDDTable extends EDD {
               + "<p><a class=\"selfLink\" id=\"RelatedData\" href=\"#RelatedData\" rel=\"bookmark\"><strong>"
               + viewTitle[current]
               + "</strong></a>\n"
-              + EDStatic.htmlTooltipImage(language, loggedInAs, viewTooltip[current])
+              + EDStatic.htmlTooltipImage(request, language, loggedInAs, viewTooltip[current])
               + "&nbsp;&nbsp;(<a href=\""
               + tErddapUrl
               + "/tabledap/"
@@ -11833,6 +11867,7 @@ public abstract class EDDTable extends EDD {
             // this shows only the first viewValue[current] rows of related data
             TableWriterHtmlTable twht =
                 new TableWriterHtmlTable(
+                    request,
                     language,
                     this,
                     tNewHistory,
@@ -11848,7 +11883,7 @@ public abstract class EDDTable extends EDD {
                     true,
                     true,
                     viewValue[current],
-                    EDStatic.imageDirUrl(loggedInAs, language)
+                    EDStatic.imageDirUrl(request, loggedInAs, language)
                         + EDStatic.messages.questionMarkImageFile);
             if (handleViaFixedOrSubsetVariables(
                 language,
@@ -11959,7 +11994,7 @@ public abstract class EDDTable extends EDD {
       }
 
       writer.write("</div>\n");
-      writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+      writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
       writer.write("\n</html>\n");
       writer.flush(); // essential
     } catch (Throwable t) {
@@ -11967,7 +12002,7 @@ public abstract class EDDTable extends EDD {
       try {
         writer.write(EDStatic.htmlForException(language, t));
         writer.write("</div>\n");
-        writer.write(EDStatic.endBodyHtml(language, tErddapUrl, loggedInAs));
+        writer.write(EDStatic.endBodyHtml(request, language, tErddapUrl, loggedInAs));
         writer.write("\n</html>\n");
         writer.flush(); // essential
       } catch (Exception e) {
@@ -13402,7 +13437,11 @@ public abstract class EDDTable extends EDD {
    * @param loggedInAs the name of the logged in user (or null if not logged in).
    */
   public void sosGetCapabilities(
-      int language, Map<String, String> queryMap, Writer writer, String loggedInAs)
+      HttpServletRequest request,
+      int language,
+      Map<String, String> queryMap,
+      Writer writer,
+      String loggedInAs)
       throws Throwable {
 
     if (accessibleViaSOS().length() > 0)
@@ -13444,7 +13483,7 @@ public abstract class EDDTable extends EDD {
     // don't validate the optional acceptVersions=.  Always return 1.0.0.
 
     // gather other information
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String sensorGmlNameStart = getSosGmlNameStart("sensor");
     String sosUrl = tErddapUrl + "/sos/" + datasetID + "/" + sosServer;
     String datasetObservedProperty = datasetID;
@@ -13993,7 +14032,7 @@ public abstract class EDDTable extends EDD {
     // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
-    // String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    // String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     // String dictUrl = tErddapUrl + "/sos/" + datasetID + "/" + sosPhenomenaDictionaryUrl;
 
     String codeSpace = getSosGmlNameStart("phenomena");
@@ -14108,10 +14147,11 @@ public abstract class EDDTable extends EDD {
    *     validity.
    * @param writer In the end, the writer is flushed, not closed.
    */
-  public void sosDescribeSensor(int language, String loggedInAs, String shortName, Writer writer)
+  public void sosDescribeSensor(
+      HttpServletRequest request, int language, String loggedInAs, String shortName, Writer writer)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // get sensor info
     boolean isNetwork = shortName.equals(datasetID);
@@ -14639,6 +14679,7 @@ public abstract class EDDTable extends EDD {
    * https://sensorweb.demo.52north.org/52nSOSv3.2.1/sos and ndbcSosWind
    * https://sdf.ndbc.noaa.gov/sos/ .
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param sosQuery
    * @param ipAddress The user's IP address (for statistics).
@@ -14649,6 +14690,7 @@ public abstract class EDDTable extends EDD {
    * @throws Exception if trouble (e.g., invalid query parameter)
    */
   public void sosGetObservation(
+      HttpServletRequest request,
       int language,
       String endOfRequest,
       String sosQuery,
@@ -14667,7 +14709,7 @@ public abstract class EDDTable extends EDD {
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr) + accessibleViaSOS());
 
     // parse the sosQuery
-    String dapQueryAr[] = sosQueryToDapQuery(language, loggedInAs, sosQuery);
+    String dapQueryAr[] = sosQueryToDapQuery(request, language, loggedInAs, sosQuery);
     String dapQuery = dapQueryAr[0];
     String offeringType = dapQueryAr[1]; // "network" or e.g., "station"),
     String offeringName = dapQueryAr[2]; // datasetID (all) or 41004
@@ -14714,10 +14756,10 @@ public abstract class EDDTable extends EDD {
           Writer writer = File2.getBufferedWriterUtf8(out);
           if (isIoosSosXmlResponseFormat(language, responseFormat))
             sosObservationsXmlInlineIoos(
-                language, offeringType, offeringName, twawm, writer, loggedInAs);
+                request, language, offeringType, offeringName, twawm, writer, loggedInAs);
           else if (isOostethysSosXmlResponseFormat(language, responseFormat))
             sosObservationsXmlInlineOostethys(
-                language, offeringType, offeringName, twawm, writer, loggedInAs);
+                request, language, offeringType, offeringName, twawm, writer, loggedInAs);
         } finally {
           try {
             twawm.releaseResources();
@@ -14759,6 +14801,7 @@ public abstract class EDDTable extends EDD {
    * This converts a SOS GetObservation query into an OPeNDAP user query. See
    * http://www.oostethys.org/best-practices/best-practices-get [GONE]
    *
+   * @param the request
    * @param language the index of the selected language
    * @param loggedInAs
    * @param sosQuery
@@ -14768,10 +14811,11 @@ public abstract class EDDTable extends EDD {
    *     short observedProperties)
    * @throws Exception if trouble (e.g., invalid query parameter)
    */
-  public String[] sosQueryToDapQuery(int language, String loggedInAs, String sosQuery)
+  public String[] sosQueryToDapQuery(
+      HttpServletRequest request, int language, String loggedInAs, String sosQuery)
       throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     Map<String, String> sosQueryMap = userQueryHashMap(sosQuery, true);
 
     // parse the query and build the dapQuery
@@ -14813,15 +14857,15 @@ public abstract class EDDTable extends EDD {
               + "\".");
 
     // request    required
-    String request = sosQueryMap.get("request"); // test name.toLowerCase()
-    if (request == null || !request.equals("GetObservation"))
+    String sosRequest = sosQueryMap.get("request"); // test name.toLowerCase()
+    if (sosRequest == null || !sosRequest.equals("GetObservation"))
       // this format EDStatic.messages.queryErrorAr[language] + "xxx=" is parsed by Erddap section
       // "deal with
       // SOS error"
       throw new SimpleException(
           EDStatic.simpleBilingual(language, EDStatic.messages.queryErrorAr)
               + "request="
-              + request
+              + sosRequest
               + " should have been \"GetObservation\".");
 
     // srsName  SOS required; erddap optional (default=4326, the only one supported)
@@ -15158,6 +15202,7 @@ public abstract class EDDTable extends EDD {
    * This returns a SOS *out-of-band* response. See Observations and Measurements schema OGC
    * 05-087r3 section 7.3.2.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param requestShortOfferingName the short version
    * @param fileTypeName e.g., .csv or .smallPng?
@@ -15165,6 +15210,7 @@ public abstract class EDDTable extends EDD {
    * @param requestedVars csv of short observedProperties, or "" if all
    */
   public void sosObservationsXmlOutOfBand(
+      HttpServletRequest request,
       int language,
       String requestOfferingType,
       String requestShortOfferingName,
@@ -15180,7 +15226,7 @@ public abstract class EDDTable extends EDD {
     // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String stationGmlNameStart = getSosGmlNameStart(sosOfferingType);
     String sensorGmlNameStart = getSosGmlNameStart("sensor");
     String requestedVarAr[] =
@@ -15537,6 +15583,7 @@ public abstract class EDDTable extends EDD {
    *
    * <p>This seeks to mimic IOOS SOS servers like ndbcSosWind. See https://sdf.ndbc.noaa.gov/sos/ .
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param requestOfferingType e.g., network or e.g., station
    * @param requestShortOfferingName e.g., all or 41004 or ...
@@ -15545,6 +15592,7 @@ public abstract class EDDTable extends EDD {
    * @param loggedInAs the name of the logged in user (or null if not logged in).
    */
   public void sosObservationsXmlInlineIoos(
+      HttpServletRequest request,
       int language,
       String requestOfferingType,
       String requestShortOfferingName,
@@ -15558,7 +15606,7 @@ public abstract class EDDTable extends EDD {
     // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String stationGmlNameStart = getSosGmlNameStart(sosOfferingType);
     String sensorGmlNameStart = getSosGmlNameStart("sensor");
     String datasetObservedProperty = datasetID;
@@ -16234,6 +16282,7 @@ public abstract class EDDTable extends EDD {
    * <p>This seeks to mimic Oostethys SOS servers like gomoosBuoy datasource [was
    * http://www.gomoos.org/cgi-bin/sos/oostethys_sos.cgi ].
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param requestOfferingType e.g., network or e.g., station
    * @param requestShortOfferingName e.g., all or 41004 or ...
@@ -16242,6 +16291,7 @@ public abstract class EDDTable extends EDD {
    * @param loggedInAs the name of the logged in user (or null if not logged in).
    */
   public void sosObservationsXmlInlineOostethys(
+      HttpServletRequest request,
       int language,
       String requestOfferingType,
       String requestShortOfferingName,
@@ -16255,7 +16305,7 @@ public abstract class EDDTable extends EDD {
     // EDStatic.messages.queryErrorAr) +
     //        accessibleViaSOS());
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String sensorGmlNameStart = getSosGmlNameStart("sensor");
     String fullPhenomenaDictionaryUrl =
         tErddapUrl + "/sos/" + datasetID + "/" + sosPhenomenaDictionaryUrl;
@@ -16614,6 +16664,7 @@ public abstract class EDDTable extends EDD {
    * Currently, this just works as a SOS 1.0.0 server. <br>
    * The caller should have already checked loggedInAs and accessibleViaSOS().
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). This doesn't check
    *     if eddTable is accessible to loggedInAs. The caller should do that.
@@ -16623,9 +16674,10 @@ public abstract class EDDTable extends EDD {
    *     Afterwards, the writer is flushed, not closed.
    * @throws Throwable if trouble (there shouldn't be)
    */
-  public void sosDatasetHtml(int language, String loggedInAs, Writer writer) throws Throwable {
+  public void sosDatasetHtml(
+      HttpServletRequest request, int language, String loggedInAs, Writer writer) throws Throwable {
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String sosUrl = tErddapUrl + "/sos/" + datasetID + "/" + sosServer;
     String dictionaryUrl = tErddapUrl + "/sos/" + datasetID + "/" + sosPhenomenaDictionaryUrl;
     int whichOffering =
@@ -16933,15 +16985,20 @@ public abstract class EDDTable extends EDD {
     // writer.write(EDStatic.startBodyHtml(language, loggedInAs,
     //    "/sos/" + datasetID + "/index.html", //was endOfRequest,
     //    queryString) + "\n");
-    // writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(loggedInAs, language)));
+    // writer.write(HtmlWidgets.htmlTooltipScript(EDStatic.imageDirUrl(request, loggedInAs,
+    // language)));
     // writer.flush(); //Steve Souder says: the sooner you can send some html to user, the better
 
     // *** html body content
     writer.write("<div class=\"standard_width\">\n");
     writer.write(
         EDStatic.youAreHere(
-            language, loggedInAs, "sos", datasetID)); // sos must be lowercase for link to work
-    writeHtmlDatasetInfo(language, loggedInAs, writer, true, true, true, true, "", "");
+            request,
+            language,
+            loggedInAs,
+            "sos",
+            datasetID)); // sos must be lowercase for link to work
+    writeHtmlDatasetInfo(request, language, loggedInAs, writer, true, true, true, true, "", "");
 
     String datasetListRef =
         "<p>See the\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromAllDatasets.java
@@ -212,7 +212,7 @@ public class EDDTableFromAllDatasets extends EDDTable {
     StringArray datasetIDs = new StringArray(gridDatasetHashMap.keys());
     datasetIDs.append(new StringArray(tableDatasetHashMap.keys()));
 
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(null, loggedInAs, language);
     String roles[] = EDStatic.getRoles(loggedInAs);
     boolean isLoggedIn = loggedInAs != null && !loggedInAs.equals(EDStatic.loggedInAsHttps);
     double nowES = System.currentTimeMillis() / 1000.0;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromFileNames.java
@@ -1131,7 +1131,7 @@ public class EDDTableFromFileNames extends EDDTable {
             fileNameRegex,
             recursive,
             pathRegex,
-            EDStatic.erddapUrl(loggedInAs, language) + "/files/" + datasetID + "/");
+            EDStatic.erddapUrl(null, loggedInAs, language) + "/files/" + datasetID + "/");
     int nRows = table.nRows();
     if (nRows == 0) throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (0 matching files)");
     return table;
@@ -1267,7 +1267,7 @@ public class EDDTableFromFileNames extends EDDTable {
         BitSet keep = new BitSet(tnRows); // initially all false
         StringArray dirSA = (StringArray) table.getColumn(0);
         int ffrdLength = fileDir.length();
-        String tTo = EDStatic.erddapUrl(loggedInAs, language) + "/files/" + datasetID + "/";
+        String tTo = EDStatic.erddapUrl(null, loggedInAs, language) + "/files/" + datasetID + "/";
         for (int row = 0; row < tnRows; row++) {
           String dir = dirSA.get(row);
           if (dir.startsWith(fileDir)) {
@@ -1284,7 +1284,7 @@ public class EDDTableFromFileNames extends EDDTable {
             FileVisitorDNLS.oneStepDoubleWithUrlsNotDirs(
                 FileVisitorDNLS.oneStepDouble(getCachedDNLSTable()),
                 fileDir,
-                EDStatic.erddapUrl(loggedInAs, language) + "/files/" + datasetID + "/");
+                EDStatic.erddapUrl(null, loggedInAs, language) + "/files/" + datasetID + "/");
 
       } else { // from == fromLocalFiles
         table =

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
@@ -19,6 +19,7 @@ import gov.noaa.pfel.coastwatch.pointdata.Table;
 import gov.noaa.pfel.coastwatch.util.HtmlWidgets;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.EDV;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.util.List;
@@ -45,6 +46,7 @@ public class TableWriterHtmlTable extends TableWriter {
   public static int htmlTableMaxMB = 15;
 
   // set by constructor
+  protected final HttpServletRequest request;
   protected final String loggedInAs;
   protected final String endOfRequest;
   protected final String queryString;
@@ -98,6 +100,7 @@ public class TableWriterHtmlTable extends TableWriter {
    *     the remaining rows.
    */
   public TableWriterHtmlTable(
+      HttpServletRequest tRequest,
       int tLanguage,
       EDD tEdd,
       String tNewHistory,
@@ -116,6 +119,7 @@ public class TableWriterHtmlTable extends TableWriter {
       String tQuestionMarkImageUrl) {
 
     super(tLanguage, tEdd, tNewHistory, tOutputStreamSource);
+    request = tRequest;
     loggedInAs = tLoggedInAs;
     endOfRequest = tEndOfRequest;
     queryString = tQueryString;
@@ -127,7 +131,7 @@ public class TableWriterHtmlTable extends TableWriter {
     encode = tEncode;
     writeUnits = tWriteUnits;
     showFirstNRows = tShowFirstNRows >= 0 ? tShowFirstNRows : Integer.MAX_VALUE;
-    tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    tErddapUrl = EDStatic.erddapUrl(null, loggedInAs, language);
     externalLinkHtml = EDStatic.messages.externalLinkHtml(language, tErddapUrl);
     questionMarkImageUrl = tQuestionMarkImageUrl;
   }
@@ -251,7 +255,7 @@ public class TableWriterHtmlTable extends TableWriter {
                   + XML.encodeAsXML(fileNameNoExt)
                   + "</title>\n"
                   + "  <link rel=\"stylesheet\" type=\"text/css\" href=\""
-                  + EDStatic.imageDirUrl(loggedInAs, language)
+                  + EDStatic.imageDirUrl(request, loggedInAs, language)
                   + "erddap2.css\" />\n"
                   + // xhtml has closing /
                   "</head>\n"
@@ -261,6 +265,7 @@ public class TableWriterHtmlTable extends TableWriter {
           writer.write("\n</head>\n");
           writer.write(
               EDStatic.startBodyHtml(
+                  null,
                   language,
                   loggedInAs,
                   edd == null
@@ -517,7 +522,8 @@ public class TableWriterHtmlTable extends TableWriter {
               """);
       else
         writer.write(
-            EDStatic.endBodyHtml(language, EDStatic.erddapUrl(loggedInAs, language), loggedInAs)
+            EDStatic.endBodyHtml(
+                    request, language, EDStatic.erddapUrl(null, loggedInAs, language), loggedInAs)
                 + "\n</html>\n");
 
     writer.flush(); // essential
@@ -544,6 +550,7 @@ public class TableWriterHtmlTable extends TableWriter {
    * @throws Throwable if trouble (no columns is trouble; no rows is not trouble)
    */
   public static void writeAllAndFinish(
+      HttpServletRequest request,
       int language,
       EDD tEdd,
       String tNewHistory,
@@ -564,6 +571,7 @@ public class TableWriterHtmlTable extends TableWriter {
 
     TableWriterHtmlTable tw =
         new TableWriterHtmlTable(
+            request,
             language,
             tEdd,
             tNewHistory,
@@ -579,7 +587,8 @@ public class TableWriterHtmlTable extends TableWriter {
             encode,
             writeUnits,
             tShowFirstNRows,
-            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile);
+            EDStatic.imageDirUrl(null, loggedInAs, language)
+                + EDStatic.messages.questionMarkImageFile);
     tw.writeAllAndFinish(table);
     tw.close();
   }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/HtmlTableFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/HtmlTableFiles.java
@@ -8,6 +8,7 @@ import gov.noaa.pfel.erddap.dataset.OutputStreamSource;
 import gov.noaa.pfel.erddap.dataset.TableWriter;
 import gov.noaa.pfel.erddap.dataset.TableWriterHtmlTable;
 import gov.noaa.pfel.erddap.util.EDStatic;
+import jakarta.servlet.http.HttpServletRequest;
 
 @FileTypeClass(
     fileTypeExtension = ".html",
@@ -19,6 +20,7 @@ public class HtmlTableFiles extends TableWriterFileType {
   @Override
   public TableWriter generateTableWriter(DapRequestInfo requestInfo) {
     return new TableWriterHtmlTable(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.edd(),
         requestInfo.newHistory(),
@@ -34,13 +36,14 @@ public class HtmlTableFiles extends TableWriterFileType {
         true,
         true,
         -1,
-        EDStatic.imageDirUrl(requestInfo.loggedInAs(), requestInfo.language())
+        EDStatic.imageDirUrl(null, requestInfo.loggedInAs(), requestInfo.language())
             + EDStatic.messages.questionMarkImageFile);
   }
 
   @Override
   public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
     saveAsHtmlTable(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.loggedInAs(),
         requestInfo.requestUrl(),
@@ -80,6 +83,7 @@ public class HtmlTableFiles extends TableWriterFileType {
    * @throws Throwable if trouble.
    */
   protected void saveAsHtmlTable(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String requestUrl,
@@ -114,6 +118,7 @@ public class HtmlTableFiles extends TableWriterFileType {
     // write the data to the tableWriter
     TableWriter tw =
         new TableWriterHtmlTable(
+            request,
             language,
             eddGrid,
             eddGrid.getNewHistory(requestUrl, userDapQuery),
@@ -129,7 +134,8 @@ public class HtmlTableFiles extends TableWriterFileType {
             true,
             true,
             -1, // tencodeAsHTML, tWriteUnits
-            EDStatic.imageDirUrl(loggedInAs, language) + EDStatic.messages.questionMarkImageFile);
+            EDStatic.imageDirUrl(request, loggedInAs, language)
+                + EDStatic.messages.questionMarkImageFile);
     if (isAxisDapQuery) {
       eddGrid.saveAsTableWriter(ada, tw);
     } else {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/KmlFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/KmlFiles.java
@@ -24,6 +24,7 @@ import gov.noaa.pfel.erddap.variable.EDVLatGridAxis;
 import gov.noaa.pfel.erddap.variable.EDVLonGridAxis;
 import gov.noaa.pfel.erddap.variable.EDVTime;
 import gov.noaa.pfel.erddap.variable.EDVTimeGridAxis;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.BufferedWriter;
 import java.text.MessageFormat;
 
@@ -40,6 +41,7 @@ public class KmlFiles extends ImageTypes {
       throws Throwable {
 
     return saveAsKml(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.loggedInAs(),
         requestInfo.requestUrl(),
@@ -55,6 +57,7 @@ public class KmlFiles extends ImageTypes {
       throws Throwable {
 
     return saveAsKml(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.loggedInAs(),
         requestInfo.requestUrl(),
@@ -77,6 +80,7 @@ public class KmlFiles extends ImageTypes {
    * This makes a .kml file. The userDapQuery must include the EDV.LON_NAME and EDV.LAT_NAME columns
    * (and preferably also EDV.ALT_NAME and EDV.TIME_NAME column) in the results variables.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Normally, this is
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
@@ -92,6 +96,7 @@ public class KmlFiles extends ImageTypes {
    * @throws Throwable if trouble
    */
   private boolean saveAsKml(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String requestUrl,
@@ -104,7 +109,7 @@ public class KmlFiles extends ImageTypes {
 
     // before any work is done,
     //  ensure LON_NAME and LAT_NAME are among resultsVariables
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     StringArray resultsVariables = new StringArray();
     StringArray constraintVariables = new StringArray();
     StringArray constraintOps = new StringArray();
@@ -559,6 +564,7 @@ public class KmlFiles extends ImageTypes {
    * data was successfully written. For .kml, dataVariable queries can specify multiple longitude,
    * latitude, and time values, but just one value for other dimensions.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Normally, this is
    *     not used to test if this edd is accessibleTo loggedInAs, but it unusual cases
@@ -573,6 +579,7 @@ public class KmlFiles extends ImageTypes {
    * @throws Throwable if trouble.
    */
   private boolean saveAsKml(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       String requestUrl,
@@ -583,7 +590,7 @@ public class KmlFiles extends ImageTypes {
 
     if (EDDGrid.reallyVerbose) String2.log("  EDDGrid.saveAsKml");
     long time = System.currentTimeMillis();
-    String tErddapUrl = EDStatic.erddapUrl(loggedInAs, language);
+    String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
 
     // check that request meets .kml restrictions.
     // .transparentPng does some of these tests, but better to catch problems

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/XhtmlTableFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/XhtmlTableFiles.java
@@ -14,6 +14,7 @@ public class XhtmlTableFiles extends HtmlTableFiles {
   @Override
   public TableWriter generateTableWriter(DapRequestInfo requestInfo) {
     return new TableWriterHtmlTable(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.edd(),
         requestInfo.newHistory(),
@@ -29,13 +30,15 @@ public class XhtmlTableFiles extends HtmlTableFiles {
         true,
         true,
         -1,
-        EDStatic.imageDirUrl(requestInfo.loggedInAs(), requestInfo.language())
+        EDStatic.imageDirUrl(
+                requestInfo.request(), requestInfo.loggedInAs(), requestInfo.language())
             + EDStatic.messages.questionMarkImageFile);
   }
 
   @Override
   public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
     saveAsHtmlTable(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.loggedInAs(),
         requestInfo.requestUrl(),

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
@@ -241,6 +241,7 @@ public class EDConfig {
   @FeatureFlag public boolean useSharedWatchService = true;
   @FeatureFlag public boolean redirectDocumentationToGitHubIo = true;
   @FeatureFlag public boolean useSisISO19115 = false;
+  @FeatureFlag public boolean useHeadersForUrl = false;
 
   public EDConfig(String webInfParentDirectory) throws Exception {
     fullPaletteDirectory = webInfParentDirectory + "WEB-INF/cptfiles/";
@@ -612,6 +613,7 @@ public class EDConfig {
         String2.split(
             String2.toLowerCase(getSetupEVString(setup, ev, "corsAllowOrigin", (String) null)),
             ',');
+    useHeadersForUrl = getSetupEVBoolean(setup, ev, "useHeadersForUrl", false);
     slideSorterActive = getSetupEVBoolean(setup, ev, "slideSorterActive", true);
     variablesMustHaveIoosCategory =
         getSetupEVBoolean(setup, ev, "variablesMustHaveIoosCategory", true);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -951,6 +951,21 @@ public class EDStatic {
   }
 
   /**
+   * Return the ERDDAP URL prefix, including scheme, host (and port if specified), and WAR context
+   * path (/erddap), with no trailing slash.
+   *
+   * @param request the request
+   * @param loggedInAs the logged in user
+   * @return the ERDDAP URL prefix (example: http://erddap.yourdomain.com/erddap)
+   */
+  protected static String getErddapUrlPrefix(HttpServletRequest request, String loggedInAs) {
+    if (EDStatic.config.useHeadersForUrl && request != null && request.getHeader("Host") != null) {
+      return request.getScheme() + "://" + request.getHeader("Host") + "/" + config.warName;
+    }
+    return loggedInAs == null ? erddapUrl : erddapHttpsUrl;
+  }
+
+  /**
    * If loggedInAs is null, this returns erddapUrl, else erddapHttpsUrl (neither has slash at end).
    *
    * @param language the index of the selected language
@@ -958,21 +973,29 @@ public class EDStatic {
    * @return If loggedInAs == null, this returns erddapUrl, else erddapHttpsUrl (neither has slash
    *     at end).
    */
-  public static String erddapUrl(String loggedInAs, int language) {
-    return (loggedInAs == null ? erddapUrl : erddapHttpsUrl)
-        + // works because of loggedInAsHttps
-        (language == 0 ? "" : "/" + TranslateMessages.languageCodeList.get(language));
+  public static String erddapUrl(HttpServletRequest request, String loggedInAs, int language) {
+    return getErddapUrlPrefix(request, loggedInAs)
+        + (language == 0 ? "" : "/" + TranslateMessages.languageCodeList.get(language));
   }
 
   /**
-   * If loggedInAs is null, this returns erddapUrl, else erddapHttpsUrl (neither has slash at end).
+   * Returns https ERDDAP url plus optional /languageCode, without slash at end. If useHeaderForUrl
+   * is enabled, the https url is built from the request Host header, as long as either the request
+   * scheme is https or the host doesn't contain a port (i.e. http requests without a port in the
+   * host will result in https urls with the same host). Otherwise erddapHttpsUrl is used.
    *
    * @param language the index of the selected language
    * @return erddapHttpsUrl plus optional /languageCode. (without slash at end).
    */
-  public static String erddapHttpsUrl(int language) {
-    return erddapHttpsUrl
-        + (language == 0 ? "" : "/" + TranslateMessages.languageCodeList.get(language));
+  public static String erddapHttpsUrl(HttpServletRequest request, int language) {
+    String httpsUrl = erddapHttpsUrl;
+    if (EDStatic.config.useHeadersForUrl
+        && request != null
+        && request.getHeader("Host") != null
+        && (request.getScheme() == "https" || !request.getHeader("Host").contains(":"))) {
+      httpsUrl = "https://" + request.getHeader("Host") + "/" + config.warName;
+    }
+    return httpsUrl + (language == 0 ? "" : "/" + TranslateMessages.languageCodeList.get(language));
   }
 
   /**
@@ -1007,8 +1030,8 @@ public class EDStatic {
    * @param language
    * @return returns the appropriate image directory URL (with slash at end).
    */
-  public static String imageDirUrl(String loggedInAs, int language) {
-    return erddapUrl(loggedInAs, language) + "/" + EDConfig.IMAGES_DIR;
+  public static String imageDirUrl(HttpServletRequest request, String loggedInAs, int language) {
+    return erddapUrl(request, loggedInAs, language) + "/" + EDConfig.IMAGES_DIR;
   }
 
   /**
@@ -1029,9 +1052,10 @@ public class EDStatic {
    * @param protocol e.g., tabledap
    * @return the You Are Here html for this EDD subclass.
    */
-  public static String youAreHere(int language, String loggedInAs, String protocol) {
+  public static String youAreHere(
+      HttpServletRequest request, int language, String loggedInAs, String protocol) {
     return "\n<h1 class=\"nowrap\">"
-        + erddapHref(language, erddapUrl(loggedInAs, language))
+        + erddapHref(language, erddapUrl(request, loggedInAs, language))
         + " &gt; "
         + protocol
         + "</h1>\n";
@@ -1049,8 +1073,13 @@ public class EDStatic {
    * @return the You Are Here html for this EDD subclass.
    */
   public static String youAreHere(
-      int language, String loggedInAs, String protocol, String protocolNameAr[], String current) {
-    String tErddapUrl = erddapUrl(loggedInAs, language);
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String protocol,
+      String protocolNameAr[],
+      String current) {
+    String tErddapUrl = erddapUrl(request, loggedInAs, language);
     return "\n<h1 class=\"nowrap\">"
         + erddapHref(language, tErddapUrl)
         + " &gt; <a rel=\"bookmark\" href=\""
@@ -1095,8 +1124,12 @@ public class EDStatic {
    * @return the You Are Here html for this EDD subclass.
    */
   public static String youAreHere(
-      int language, String loggedInAs, String protocol, String datasetID) {
-    String tErddapUrl = erddapUrl(loggedInAs, language);
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String protocol,
+      String datasetID) {
+    String tErddapUrl = erddapUrl(request, loggedInAs, language);
     return "\n<h1 class=\"nowrap\">"
         + erddapHref(language, tErddapUrl)
         + "\n &gt; <a rel=\"contents\" "
@@ -1121,14 +1154,18 @@ public class EDStatic {
    * @return the You Are Here html for this EDD subclass.
    */
   public static String youAreHereWithHelp(
-      int language, String loggedInAs, String protocol, String htmlHelp) {
-    String tErddapUrl = erddapUrl(loggedInAs, language);
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String protocol,
+      String htmlHelp) {
+    String tErddapUrl = erddapUrl(request, loggedInAs, language);
     return "\n<h1 class=\"nowrap\">"
         + erddapHref(language, tErddapUrl)
         + "\n &gt; "
         + protocol
         + "\n"
-        + htmlTooltipImage(language, loggedInAs, htmlHelp)
+        + htmlTooltipImage(request, language, loggedInAs, htmlHelp)
         + "\n</h1>\n";
   }
 
@@ -1143,9 +1180,14 @@ public class EDStatic {
    * @return the You Are Here html for this EDD subclass.
    */
   public static String youAreHereWithHelp(
-      int language, String loggedInAs, String protocol, String datasetID, String htmlHelp) {
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String protocol,
+      String datasetID,
+      String htmlHelp) {
 
-    String tErddapUrl = erddapUrl(loggedInAs, language);
+    String tErddapUrl = erddapUrl(request, loggedInAs, language);
     return "\n<h1 class=\"nowrap\">"
         + erddapHref(language, tErddapUrl)
         + "\n &gt; <a rel=\"contents\" "
@@ -1157,7 +1199,7 @@ public class EDStatic {
         + "\n &gt; "
         + datasetID
         + "\n"
-        + htmlTooltipImage(language, loggedInAs, htmlHelp)
+        + htmlTooltipImage(request, language, loggedInAs, htmlHelp)
         + "\n</h1>\n";
   }
 
@@ -1175,7 +1217,7 @@ public class EDStatic {
   /*public static String youAreHere(int language, String loggedInAs, String protocol,
       String attribute, String category) {
 
-      String tErddapUrl = erddapUrl(loggedInAs, language);
+      String tErddapUrl = erddapUrl(request, loggedInAs, language);
       String attributeUrl = tErddapUrl + "/" + protocol + "/" + attribute + "/index.html"; //+?defaultPIppQuery
       return
           "\n<h1>" + erddapHref(language, tErddapUrl) +
@@ -1195,9 +1237,10 @@ public class EDStatic {
    *     there!". It needs explicit br tags to set window width correctly. For plain text, generate
    *     html from XML.encodeAsPreHTML(plainText, 82).
    */
-  public static String htmlTooltipImage(int language, String loggedInAs, String html) {
+  public static String htmlTooltipImage(
+      HttpServletRequest request, int language, String loggedInAs, String html) {
     return HtmlWidgets.htmlTooltipImage(
-        imageDirUrl(loggedInAs, language) + messages.questionMarkImageFile, "?", html, "");
+        imageDirUrl(request, loggedInAs, language) + messages.questionMarkImageFile, "?", html, "");
   }
 
   /**
@@ -1207,10 +1250,11 @@ public class EDStatic {
    * @param language the language code number
    * @param edv from an EDDTable
    */
-  public static String htmlTooltipImageEDV(int language, String loggedInAs, EDV edv)
-      throws Throwable {
+  public static String htmlTooltipImageEDV(
+      HttpServletRequest request, int language, String loggedInAs, EDV edv) throws Throwable {
 
     return htmlTooltipImageLowEDV(
+        request,
         language,
         loggedInAs,
         edv.destinationDataPAType(),
@@ -1225,10 +1269,12 @@ public class EDStatic {
    * @param language the language code number
    * @param edvga
    */
-  public static String htmlTooltipImageEDVGA(int language, String loggedInAs, EDVGridAxis edvga)
+  public static String htmlTooltipImageEDVGA(
+      HttpServletRequest request, int language, String loggedInAs, EDVGridAxis edvga)
       throws Throwable {
 
     return htmlTooltipImageLowEDV(
+        request,
         language,
         loggedInAs,
         edvga.destinationDataPAType(),
@@ -1245,9 +1291,11 @@ public class EDStatic {
    * @param allDimString from eddGrid.allDimString()
    */
   public static String htmlTooltipImageEDVG(
-      int language, String loggedInAs, EDV edv, String allDimString) throws Throwable {
+      HttpServletRequest request, int language, String loggedInAs, EDV edv, String allDimString)
+      throws Throwable {
 
     return htmlTooltipImageLowEDV(
+        request,
         language,
         loggedInAs,
         edv.destinationDataPAType(),
@@ -1259,13 +1307,16 @@ public class EDStatic {
    * This returns the html to draw a question mark that has big html tooltip with a variable's name
    * and attributes. htmlTooltipScript (see HtmlWidgets) must be already in the document.
    *
+   * @param request the servlet request
    * @param language the language code number
+   * @param loggedInAs
    * @param destinationDataPAType
    * @param destinationName perhaps with axis information appended (e.g.,
    *     [time][latitude][longitude]
    * @param attributes
    */
   public static String htmlTooltipImageLowEDV(
+      HttpServletRequest request,
       int language,
       String loggedInAs,
       PAType destinationDataPAType,
@@ -1284,6 +1335,7 @@ public class EDStatic {
             false); // htmlEncoding, strictDapMode
     // String2.log("htmlTooltipImage sb=" + sb.toString());
     return htmlTooltipImage(
+        request,
         language,
         loggedInAs,
         "<div class=\"standard_max_width\">" + XML.encodeAsPreHTML(sb.toString()) + "</div>");
@@ -2076,17 +2128,18 @@ public class EDStatic {
    * <p>This is safe to use this after outputStream has been written to -- this won't make a session
    * if the user doesn't have one.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in) Special case:
    *     "loggedInAsHttps" is for using https without being logged in, but &amp;loginInfo; indicates
    *     user isn't logged in.
    */
-  public static String getLoginHtml(int language, String loggedInAs) {
+  public static String getLoginHtml(HttpServletRequest request, int language, String loggedInAs) {
     if (config.authentication.isEmpty()) {
       // user can't log in
       return "";
     } else {
-      String tUrl = erddapHttpsUrl(language);
+      String tUrl = erddapHttpsUrl(request, language);
       return loggedInAs == null || loggedInAsHttps.equals(loggedInAs)
           ? // ie not logged in
           // always use the erddapHttpsUrl for login/logout pages
@@ -2111,6 +2164,7 @@ public class EDStatic {
    * <p>This is safe to use this after outputStream has been written to -- this won't make a session
    * if the user doesn't have one.
    *
+   * @param request the request
    * @param language the index of the selected language
    * @param loggedInAs the name of the logged in user (or null if not logged in). Special case:
    *     "loggedInAsHttps" is for using https without being logged in, but &amp;loginInfo; indicates
@@ -2122,8 +2176,12 @@ public class EDStatic {
    *     valid and not malicious).
    */
   public static String startBodyHtml(
-      int language, String loggedInAs, String endOfRequest, String queryString) {
-    return startBodyHtml(language, loggedInAs, endOfRequest, queryString, "");
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String endOfRequest,
+      String queryString) {
+    return startBodyHtml(request, language, loggedInAs, endOfRequest, queryString, "");
   }
 
   /**
@@ -2150,9 +2208,14 @@ public class EDStatic {
    * @param otherBody other content for the &lt;body&gt; tag, e.g., " onload=\"myFunction()\"".
    */
   public static String startBodyHtml(
-      int language, String loggedInAs, String endOfRequest, String queryString, String otherBody) {
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      String endOfRequest,
+      String queryString,
+      String otherBody) {
 
-    String tErddapUrl = erddapUrl(loggedInAs, language);
+    String tErddapUrl = erddapUrl(request, loggedInAs, language);
     String s =
         messages
             .startBodyHtmlAr[
@@ -2164,7 +2227,7 @@ public class EDStatic {
     s = String2.replaceAll(s, "&BroughtToYouBy;", messages.BroughtToYouByAr[language]);
     if (String2.isSomething(otherBody))
       s = String2.replaceAll(s, "<body>", "<body " + otherBody + ">");
-    s = String2.replaceAll(s, "&loginInfo;", getLoginHtml(language, loggedInAs));
+    s = String2.replaceAll(s, "&loginInfo;", getLoginHtml(request, language, loggedInAs));
     HtmlWidgets widgets = new HtmlWidgets();
     s =
         String2.replaceAll(
@@ -2192,6 +2255,7 @@ public class EDStatic {
                         false,
                         "")
                     + htmlTooltipImage(
+                        request,
                         language,
                         loggedInAs,
                         "<img src=\""
@@ -2203,18 +2267,19 @@ public class EDStatic {
     // place (and this should never happen)
 
     // String2.log(">> EDStatic startBodyHtml=" + s);
-    return String2.replaceAll(s, "&erddapUrl;", erddapUrl(loggedInAs, language));
+    return String2.replaceAll(s, "&erddapUrl;", erddapUrl(request, loggedInAs, language));
   }
 
   /**
    * The endBody HTML.
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    * @param loggedInAs
    */
-  public static String endBodyHtml(int language, String tErddapUrl, String loggedInAs) {
+  public static String endBodyHtml(
+      HttpServletRequest request, int language, String tErddapUrl, String loggedInAs) {
     String s = String2.replaceAll(messages.endBodyHtmlAr[language], "&erddapUrl;", tErddapUrl);
     if (language > 0)
       s =
@@ -2223,7 +2288,7 @@ public class EDStatic {
               "<br><img src=\""
                   + tErddapUrl
                   + "/images/TranslatedByGoogle.png\" alt=\"Translated by Google\">\n"
-                  + htmlTooltipImage(language, loggedInAs, translationDisclaimer)
+                  + htmlTooltipImage(request, language, loggedInAs, translationDisclaimer)
                   + "<hr>");
     return s;
   }
@@ -2232,8 +2297,8 @@ public class EDStatic {
    * The content of the legal web page.
    *
    * @param language the index of the selected language
-   * @param tErddapUrl from EDStatic.erddapUrl(loggedInAs, language) (erddapUrl, or erddapHttpsUrl
-   *     if user is logged in)
+   * @param tErddapUrl from EDStatic.erddapUrl(request, loggedInAs, language) (erddapUrl, or
+   *     erddapHttpsUrl if user is logged in)
    */
   public static String legal(int language, String tErddapUrl) {
     StringBuilder tsb = new StringBuilder(messages.legal);

--- a/development/jetty/config/setup.xml
+++ b/development/jetty/config/setup.xml
@@ -390,5 +390,6 @@ If an attribute is a global attribute, identify it by prefixing it with "global:
 <useSharedWatchService>true</useSharedWatchService>
 <useSaxParser>true</useSaxParser>
 <usePrometheusMetrics>true</usePrometheusMetrics>
+<useHeadersForUrl>true</useHeadersForUrl>
 </erddapSetup>
 

--- a/development/test/setup.xml
+++ b/development/test/setup.xml
@@ -393,5 +393,6 @@ If an attribute is a global attribute, identify it by prefixing it with "global:
 <usePrometheusMetrics>true</usePrometheusMetrics>
 <showLoadErrorsOnStatusPage>true</showLoadErrorsOnStatusPage>
 <useSisISO19115>true</useSisISO19115>
+<useHeadersForUrl>true</useHeadersForUrl>
 </erddapSetup>
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
@@ -1477,10 +1477,12 @@ class EDDGridFromDapTests {
     // TestUtil.displayInBrowser("file://" + EDStatic.config.fullTestCacheDirectory + tName);
     expected =
         EDStatic.startHeadHtml(
-                language, EDStatic.erddapUrl((String) null, language), "EDDGridFromDap_LatAxis")
+                language,
+                EDStatic.erddapUrl(null, (String) null, language),
+                "EDDGridFromDap_LatAxis")
             + "\n"
             + "</head>\n"
-            + EDStatic.startBodyHtml(language, null, "griddap/erdMHchla8day.html", tQuery)
+            + EDStatic.startBodyHtml(null, language, null, "griddap/erdMHchla8day.html", tQuery)
             + // 2022-11-22
             // .html
             // because
@@ -1527,7 +1529,7 @@ class EDDGridFromDapTests {
             + "</tr>\n"
             + "</table>\n"
             + EDStatic.endBodyHtml(
-                language, EDStatic.erddapUrl((String) null, language), (String) null)
+                null, language, EDStatic.erddapUrl(null, (String) null, language), (String) null)
             + "\n"
             + "</html>\n";
     Test.ensureEqual(results, expected, "RESULTS=\n" + results);
@@ -5109,10 +5111,13 @@ class EDDGridFromDapTests {
     String results = File2.directReadFromUtf8File(EDStatic.config.fullTestCacheDirectory + tName);
     String expected =
         EDStatic.startHeadHtml(
-                language, EDStatic.erddapUrl((String) null, language), "EDDGridFromDap_soda224")
+                language,
+                EDStatic.erddapUrl(null, (String) null, language),
+                "EDDGridFromDap_soda224")
             + "\n"
             + "</head>\n"
-            + EDStatic.startBodyHtml(language, null, "griddap/hawaii_d90f_20ee_c4cb.html", query)
+            + EDStatic.startBodyHtml(
+                null, language, null, "griddap/hawaii_d90f_20ee_c4cb.html", query)
             + // 2022-11-22
             // .htmlTable
             // converted
@@ -6363,13 +6368,13 @@ class EDDGridFromDapTests {
     EDDGridFromDap gridDataset = (EDDGridFromDap) EDDTestDataset.geterdMHchla8day();
     String fileName = EDStatic.config.fullTestCacheDirectory + "gridTestSpeedDAF.txt";
     Writer writer = File2.getBufferedFileWriterUtf8(fileName);
-    gridDataset.writeDapHtmlForm(language, null, "", writer);
+    gridDataset.writeDapHtmlForm(null, language, null, "", writer);
 
     // time it DAF
     String2.log("start timing");
     long time = System.currentTimeMillis();
     for (int i = 0; i < 1000; i++) // 1000 so it dominates program run time
-    gridDataset.writeDapHtmlForm(language, null, "", writer);
+    gridDataset.writeDapHtmlForm(null, language, null, "", writer);
     String2.log(
         "EDDGridFromDap.testSpeedDAF time per .html = "
             + ((System.currentTimeMillis() - time) / 1000.0)

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridTests.java
@@ -869,7 +869,7 @@ class EDDGridTests {
     // try to validate with https://xmlvalidation.com/ (just an error in a schema)
     String2.log("\n+++ GetCapabilities 1.0.0");
     writer = new java.io.StringWriter();
-    eddGrid.wcsGetCapabilities(0, loggedInAs, "1.0.0", writer);
+    eddGrid.wcsGetCapabilities(null, 0, loggedInAs, "1.0.0", writer);
     results = writer.toString();
     String2.log(results);
 

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableFromNcFilesTests.java
@@ -16418,13 +16418,13 @@ class EDDTableFromNcFilesTests {
     String dir = TEMP_DIR.toAbsolutePath().toString() + "/";
     String fileName = dir + "tableTestSpeedDAF.txt";
     Writer writer = File2.getBufferedFileWriterUtf8(fileName);
-    tableDataset.writeDapHtmlForm(language, null, "", writer);
+    tableDataset.writeDapHtmlForm(null, language, null, "", writer);
 
     // time it DAF
     String2.log("start timing");
     long time = System.currentTimeMillis();
     int n = 100; // use 1000 so it dominates program run time if profiling
-    for (int i = 0; i < n; i++) tableDataset.writeDapHtmlForm(language, null, "", writer);
+    for (int i = 0; i < n; i++) tableDataset.writeDapHtmlForm(null, language, null, "", writer);
     float results = ((System.currentTimeMillis() - time) / (float) n);
     double expected = 12.4;
     String msg =

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDTableTests.java
@@ -1,5 +1,6 @@
 package gov.noaa.pfel.erddap.dataset;
 
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,6 +69,9 @@ class EDDTableTests {
         fileType);
     verify(request).getHeader("Range");
     verify(request).getHeader("accept-encoding");
+    if (EDStatic.config.useHeadersForUrl) {
+      verify(request, atLeastOnce()).getHeader("Host");
+    }
     verify(outStream, times(1)).close();
     verifyNoMoreInteractions(request);
   }
@@ -98,7 +102,7 @@ class EDDTableTests {
         EDD.userQueryHashMap(
             "seRvIcE=SOS&ReQueSt=GetCapabilities&sEctIons=gibberish,All",
             true); // true=names toLowerCase
-    eddTable.sosGetCapabilities(language, queryMap, writer, null);
+    eddTable.sosGetCapabilities(null, language, queryMap, writer, null);
     results = writer.toString();
     expected =
         "<?xml version=\"1.0\"?>\n"
@@ -455,7 +459,7 @@ class EDDTableTests {
     // stored as /programs/sos/ndbcSosCurrentsDescribeSensor90810.xml
     String2.log("\n+++ DescribeSensor all");
     writer = new java.io.StringWriter();
-    eddTable.sosDescribeSensor(language, null, eddTable.datasetID, writer);
+    eddTable.sosDescribeSensor(null, language, null, eddTable.datasetID, writer);
     results = writer.toString();
     // String2.log(results);
     expected =
@@ -902,7 +906,7 @@ class EDDTableTests {
     // DescribeSensor 41004
     String2.log("\n+++ DescribeSensor 41004");
     writer = new java.io.StringWriter();
-    eddTable.sosDescribeSensor(language, null, "41004", writer);
+    eddTable.sosDescribeSensor(null, language, null, "41004", writer);
     results = writer.toString();
     // String2.log(results);
     expected =
@@ -1365,7 +1369,7 @@ class EDDTableTests {
     // stored as /programs/sos/ndbcSosCurrentsDescribeSensor90810.xml
     String2.log("\n+++ DescribeSensor 41004:wtmp");
     writer = new java.io.StringWriter();
-    eddTable.sosDescribeSensor(language, null, "41004", writer);
+    eddTable.sosDescribeSensor(null, language, null, "41004", writer);
     results = writer.toString();
     String2.log(results);
     expected =
@@ -1518,7 +1522,7 @@ class EDDTableTests {
             "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z";
     String2.log("\n+++ GetObservations for 1 station  CSV\n" + sosQuery1);
-    String dapQuery1[] = eddTable.sosQueryToDapQuery(language, null, sosQuery1);
+    String dapQuery1[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery1);
     String2.log("\nsosQuery1=" + sosQuery1 + "\n\ndapQuery1=" + dapQuery1[0]);
     Test.ensureEqual(
         dapQuery1[0],
@@ -1527,7 +1531,15 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1Csv, "someIPAddress", null, osss, dir, "testSos1Sta");
+        null,
+        language,
+        endOfRequest,
+        sosQuery1Csv,
+        "someIPAddress",
+        null,
+        osss,
+        dir,
+        "testSos1Sta");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -1556,7 +1568,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSos1");
+        null, language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSos1");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -1716,7 +1728,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1b, "someIPAddress", null, osss, dir, "testSos1b");
+        null, language, endOfRequest, sosQuery1b, "someIPAddress", null, osss, dir, "testSos1b");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected = // changes when I update ndbc
@@ -1737,7 +1749,7 @@ class EDDTableTests {
             "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z"
             + "&featureOfInterest=BBOX:-79.10,32.4,-79.08,32.6";
-    String dapQuery2[] = eddTable.sosQueryToDapQuery(language, null, sosQuery2);
+    String dapQuery2[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery2);
     String2.log("\nsosQuery2=" + sosQuery2 + "\n\ndapQuery2=" + dapQuery2[0]);
     Test.ensureEqual(
         dapQuery2[0],
@@ -1749,7 +1761,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery2, "someIPAddress", null, osss, dir, "testSos2");
+        null, language, endOfRequest, sosQuery2, "someIPAddress", null, osss, dir, "testSos2");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -1773,7 +1785,7 @@ class EDDTableTests {
             "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z"
             + "&featureOfInterest=BBOX:-79.10,32.4,-79.08,32.6";
-    String dapQuery2b[] = eddTable.sosQueryToDapQuery(language, null, sosQuery2b);
+    String dapQuery2b[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery2b);
     String2.log("\nsosQuery2b=" + sosQuery2b + "\n\ndapQuery2b=" + dapQuery2b[0]);
     Test.ensureEqual(
         dapQuery2b[0],
@@ -1784,7 +1796,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery2b, "someIPAddress", null, osss, dir, "testSos2b");
+        null, language, endOfRequest, sosQuery2b, "someIPAddress", null, osss, dir, "testSos2b");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -1808,7 +1820,7 @@ class EDDTableTests {
             "&responseFormat=text/xml;schema=%22ioos/0.6.1%22"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z"
             + "&featureOfInterest=BBOX:-79.10,32.4,-79.08,32.6";
-    String dapQuery2c[] = eddTable.sosQueryToDapQuery(language, null, sosQuery2c);
+    String dapQuery2c[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery2c);
     String2.log("\nsosQuery2c=" + sosQuery2c + "\n\ndapQuery2c=" + dapQuery2c[0]);
     Test.ensureEqual(
         dapQuery2c[0],
@@ -1820,7 +1832,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery2c, "someIPAddress", null, osss, dir, "testSos2c");
+        null, language, endOfRequest, sosQuery2c, "someIPAddress", null, osss, dir, "testSos2c");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -2062,7 +2074,7 @@ class EDDTableTests {
             + "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z"
             + "&featureOfInterest=BBOX:-79.9,32.4,-79.0,33.0";
-    String dapQuery3[] = eddTable.sosQueryToDapQuery(language, null, sosQuery3);
+    String dapQuery3[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery3);
     String2.log("\nsosQuery3=" + sosQuery3 + "\n\ndapQuery3=" + dapQuery3[0]);
     Test.ensureEqual(
         dapQuery3[0],
@@ -2075,7 +2087,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery3, "someIPAddress", null, osss, dir, "testSos3");
+        null, language, endOfRequest, sosQuery3, "someIPAddress", null, osss, dir, "testSos3");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -2097,7 +2109,7 @@ class EDDTableTests {
             "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z"
             + "&featureOfInterest=BBOX:-79.9,32.4,-79.0,33.0";
-    String dapQuery4[] = eddTable.sosQueryToDapQuery(language, null, sosQuery4);
+    String dapQuery4[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery4);
     String2.log("\nsosQuery4=" + sosQuery4 + "\n\ndapQuery4=" + dapQuery4[0]);
     Test.ensureEqual(
         dapQuery4[0],
@@ -2108,7 +2120,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery4, "someIPAddress", null, osss, dir, "testSos4");
+        null, language, endOfRequest, sosQuery4, "someIPAddress", null, osss, dir, "testSos4");
     results = baos.toString(File2.UTF_8);
     expected =
         "longitude, latitude, time, station, wd, wspd, gst, wvht, dpd, apd, mwd, bar, atmp, wtmp, dewp, vis, ptdy, tide, wspu, wspv\n"
@@ -2141,7 +2153,7 @@ class EDDTableTests {
             "&responseFormat=image/png"
             + "&eventTime=2008-07-25T00:00:00Z/2008-08-01T00:00:00Z";
 
-    String dapQuery5[] = eddTable.sosQueryToDapQuery(language, null, sosQuery5csv);
+    String dapQuery5[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery5csv);
     String2.log("\nsosQuery5csv=" + sosQuery5csv + "\n\ndapQuery5=" + dapQuery5[0]);
     Test.ensureEqual(
         dapQuery5[0],
@@ -2152,7 +2164,15 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery5csv, "someIPAddress", null, osss, dir, "testSos5csv");
+        null,
+        language,
+        endOfRequest,
+        sosQuery5csv,
+        "someIPAddress",
+        null,
+        osss,
+        dir,
+        "testSos5csv");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -2175,7 +2195,7 @@ class EDDTableTests {
 
     // #5png get png -> time series
     String2.log("\n+++ 5png: GetObservations for 1 station, 1 obsProp\n" + sosQuery5png);
-    dapQuery5 = eddTable.sosQueryToDapQuery(language, null, sosQuery5png);
+    dapQuery5 = eddTable.sosQueryToDapQuery(null, language, null, sosQuery5png);
     String2.log("\nsosQuery5png=" + sosQuery5png + "\n\ndapQuery5=" + dapQuery5[0]);
     Test.ensureEqual(
         dapQuery5[0],
@@ -2183,7 +2203,7 @@ class EDDTableTests {
             + "&time>=2008-07-25T00:00:00Z&time<=2008-08-01T00:00:00Z"
             + "&.draw=linesAndMarkers&.marker=5|4&.color=0xFF9900",
         "");
-    String dapQuery = eddTable.sosQueryToDapQuery(language, null, sosQuery5png)[0];
+    String dapQuery = eddTable.sosQueryToDapQuery(null, language, null, sosQuery5png)[0];
     fileName =
         eddTable.makeNewFileForDapQuery(
             language,
@@ -2203,7 +2223,7 @@ class EDDTableTests {
             "&observedProperty=wtmp"
             + "&responseFormat=text/csv"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z";
-    String dapQuery6[] = eddTable.sosQueryToDapQuery(language, null, sosQuery6csv);
+    String dapQuery6[] = eddTable.sosQueryToDapQuery(null, language, null, sosQuery6csv);
     String2.log("\nsosQuery6csv=" + sosQuery6csv + "\n\ndapQuery6csv=" + dapQuery6[0]);
     Test.ensureEqual(
         dapQuery6[0],
@@ -2212,7 +2232,15 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery6csv, "someIPAddress", null, osss, dir, "testSos6csv");
+        null,
+        language,
+        endOfRequest,
+        sosQuery6csv,
+        "someIPAddress",
+        null,
+        osss,
+        dir,
+        "testSos6csv");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =
@@ -2246,7 +2274,7 @@ class EDDTableTests {
             "&observedProperty=wtmp"
             + "&responseFormat=image/png"
             + "&eventTime=2008-08-01T00:00:00Z/2008-08-01T01:00:00Z";
-    dapQuery6 = eddTable.sosQueryToDapQuery(language, null, sosQuery6png);
+    dapQuery6 = eddTable.sosQueryToDapQuery(null, language, null, sosQuery6png);
     String2.log("\nsosQuery6png=" + sosQuery6png + "\n\ndapQuery6png=" + dapQuery6[0]);
     Test.ensureEqual(
         dapQuery6[0],
@@ -2286,7 +2314,7 @@ class EDDTableTests {
         EDD.userQueryHashMap(
             "seRvIcE=SOS&ReQueSt=GetCapabilities&sEctIons=gibberish,All",
             true); // true=names toLowerCase
-    eddTable.sosGetCapabilities(language, queryMap, writer, null);
+    eddTable.sosGetCapabilities(null, language, queryMap, writer, null);
     results = writer.toString();
     String2.log(results.substring(0, 7000));
     String2.log("\n...\n");
@@ -2308,7 +2336,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSosCurBB");
+        null, language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSosCurBB");
     /*
      * from eddTableSos.testNdbcSosCurrents
      * "&longitude=-87.94&latitude>=29.1&latitude<29.2&time>=2008-06-01T14:00&time<=2008-06-01T14:30",
@@ -2351,7 +2379,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery2, "someIPAddress", null, osss, dir, "testSosCurSta");
+        null, language, endOfRequest, sosQuery2, "someIPAddress", null, osss, dir, "testSosCurSta");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     // expected = same data
@@ -2372,7 +2400,15 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery3, "someIPAddress", null, osss, dir, "testSosCurSta2");
+        null,
+        language,
+        endOfRequest,
+        sosQuery3,
+        "someIPAddress",
+        null,
+        osss,
+        dir,
+        "testSosCurSta2");
     results = baos.toString(File2.UTF_8);
     // String2.log(results);
     expected =
@@ -2524,7 +2560,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testGomoos");
+        null, language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testGomoos");
     results = baos.toString(File2.UTF_8);
     // String2.log(results);
     expected =
@@ -2564,7 +2600,7 @@ class EDDTableTests {
     baos = new ByteArrayOutputStream();
     osss = new OutputStreamSourceSimple(baos);
     eddTable.sosGetObservation(
-        language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSos1Sta");
+        null, language, endOfRequest, sosQuery1, "someIPAddress", null, osss, dir, "testSos1Sta");
     results = baos.toString(File2.UTF_8);
     String2.log(results);
     expected =

--- a/src/test/java/gov/noaa/pfel/erddap/util/EDStaticTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/util/EDStaticTests.java
@@ -1,10 +1,23 @@
 package gov.noaa.pfel.erddap.util;
 
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
 import com.cohort.array.Attributes;
 import com.cohort.util.String2;
 import com.cohort.util.Test;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.mockito.Mockito;
+import testDataset.Initialization;
 
-class EDStaticTests {
+public class EDStaticTests {
+  @org.junit.jupiter.api.BeforeAll
+  static void beforeAll() {
+    Initialization.edStatic();
+  }
+
   @org.junit.jupiter.api.Test
   void testUpdateUrls() throws Exception {
     String2.log("\n***** EDStatic.testUpdateUrls");
@@ -39,5 +52,193 @@ class EDStaticTests {
             + "    nine=9.0d\n"
             + "    sourceUrl=http://coastwatch.pfel.noaa.gov\n"; // unchanged
     Test.ensureEqual(results, expected, "results=\n" + results);
+  }
+
+  /**
+   * Test EDStatic methods returing ERDDAP URL prefixes, which respect the request's scheme and host
+   * header if useHeadersForUrl feature flag is true.
+   *
+   * <p>General expectations: If useHeadersForUrl is false, erddapUrl or erddapHttpsUrl are used
+   * (legacy behavior). If the request is null, erddapUrl or erddapHttpsUrl are used (legacy
+   * behavior). If useHeadersForUrl is true and request is not null, scheme and host header from
+   * request are used. If useHeadersForUrl true, request not null, and request scheme is http,
+   * EDStatic.erddapHttpsUrl() uses https scheme with request host as long as request host does not
+   * contain a port (i.e. http url are upgraded to https with the same host). If host does contain a
+   * port, erddapHttpsUrl is returned instead. * @throws Exception
+   */
+  @org.junit.jupiter.api.Test
+  void testErddapUrls() throws Exception {
+    String2.log("\n***** EDStatic.testErddapUrls");
+
+    // FIXME changing global config state makes tests brittle
+    boolean cachedUseHeadersForUrlConfig = EDStatic.config.useHeadersForUrl;
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with null request and null loggedInAs",
+        EDStatic.erddapUrl,
+        EDStatic.getErddapUrlPrefix(null, null));
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with null request and loggedInAs",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.getErddapUrlPrefix(null, "fakeLoggedInAs"));
+
+    String requestHost = "erddap.requesthost.org";
+    String requestHostHttpUrl = "http://" + requestHost + "/erddap";
+    String requestHostHttpsUrl = "https://" + requestHost + "/erddap";
+
+    HttpServletRequest httpRequest = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpRequest.getScheme()).thenReturn("http");
+    Mockito.when(httpRequest.getHeader("Host")).thenReturn(requestHost);
+
+    HttpServletRequest httpRequestWithPort = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpRequestWithPort.getScheme()).thenReturn("http");
+    Mockito.when(httpRequestWithPort.getHeader("Host")).thenReturn(requestHost + ":8080");
+
+    HttpServletRequest httpsRequest = Mockito.mock(HttpServletRequest.class);
+    Mockito.when(httpsRequest.getScheme()).thenReturn("https");
+    Mockito.when(httpsRequest.getHeader("Host")).thenReturn(requestHost);
+
+    EDStatic.config.useHeadersForUrl = false;
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with http request, null loggedInAs, and useHeadersForUrl = false",
+        EDStatic.erddapUrl,
+        EDStatic.getErddapUrlPrefix(httpRequest, null));
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with http request, loggedInAs, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.getErddapUrlPrefix(httpRequest, "fakeLoggedInAs"));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with null request, null loggedInAs, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapUrl,
+        EDStatic.erddapUrl(null, null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with null request, null loggedInAs, language 1, and useHeadersForUrl = false",
+        EDStatic.erddapUrl + "/" + TranslateMessages.languageCodeList.get(1),
+        EDStatic.erddapUrl(null, null, 1));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with http request, null loggedInAs, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapUrl,
+        EDStatic.erddapUrl(httpRequest, null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with https request, null loggedInAs, language 1, and useHeadersForUrl = false",
+        EDStatic.erddapUrl + "/" + TranslateMessages.languageCodeList.get(1),
+        EDStatic.erddapUrl(httpsRequest, null, 1));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with null request, loggedInAs, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapUrl(null, "fakeLoggedInAs", 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with http request, loggedInAs, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapUrl(httpRequest, "fakeLoggedInAs", 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with null request, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapHttpsUrl(null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with http request, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapHttpsUrl(httpRequest, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with null request, language 0, and useHeadersForUrl = false",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapHttpsUrl(null, 0));
+
+    EDStatic.config.useHeadersForUrl = true;
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with http request, null loggedInAs, and useHeadersForUrl = true",
+        requestHostHttpUrl,
+        EDStatic.getErddapUrlPrefix(httpRequest, null));
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with http request, loggedInAs, and useHeadersForUrl = true",
+        requestHostHttpUrl,
+        EDStatic.getErddapUrlPrefix(httpRequest, "fakeLoggedInAs"));
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with https request, null loggedInAs, and useHeadersForUrl = true",
+        requestHostHttpsUrl,
+        EDStatic.getErddapUrlPrefix(httpsRequest, null));
+
+    checkUrlExpectation(
+        "EDStatic.getErddapUrlPrefix with https request, loggedInAs, and useHeadersForUrl = true",
+        requestHostHttpsUrl,
+        EDStatic.getErddapUrlPrefix(httpsRequest, "fakeLoggedInAs"));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with null request, null loggedInAs, language 0, and useHeadersForUrl = true",
+        EDStatic.erddapUrl,
+        EDStatic.erddapUrl(null, null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with null request, loggedInAs, language 0, and useHeadersForUrl = true",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapUrl(null, "fakeLoggedInAs", 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with http request, null loggedInAs, language 0, and useHeadersForUrl = true",
+        requestHostHttpUrl,
+        EDStatic.erddapUrl(httpRequest, null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with http request, loggedInAs, language 0, and useHeadersForUrl = true",
+        requestHostHttpUrl,
+        EDStatic.erddapUrl(httpRequest, "fakeLoggedInAs", 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapUrl with http request, null loggedInAs, language 1, and useHeadersForUrl = true",
+        requestHostHttpUrl + "/" + TranslateMessages.languageCodeList.get(1),
+        EDStatic.erddapUrl(httpRequest, null, 1));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with null request, language 0, and useHeadersForUrl = true",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapHttpsUrl(null, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with https request, language 0, and useHeadersForUrl = true",
+        requestHostHttpsUrl,
+        EDStatic.erddapHttpsUrl(httpRequest, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with https request, language 1, and useHeadersForUrl = true",
+        requestHostHttpsUrl + "/" + TranslateMessages.languageCodeList.get(1),
+        EDStatic.erddapHttpsUrl(httpRequest, 1));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with http request, language 0, and useHeadersForUrl = true",
+        requestHostHttpsUrl,
+        EDStatic.erddapHttpsUrl(httpsRequest, 0));
+
+    checkUrlExpectation(
+        "EDStatic.erddapHttpsUrl with http request containing port, language 0, and useHeadersForUrl = true",
+        EDStatic.erddapHttpsUrl,
+        EDStatic.erddapHttpsUrl(httpRequestWithPort, 0));
+
+    // set useHeadersForUrl back to original value
+    EDStatic.config.useHeadersForUrl = cachedUseHeadersForUrlConfig;
+
+    for (HttpServletRequest request : List.of(httpRequest, httpRequestWithPort, httpsRequest)) {
+      verify(request, atLeastOnce()).getHeader("Host");
+      verify(request, atLeastOnce()).getScheme();
+      verifyNoMoreInteractions(request);
+    }
+  }
+
+  private void checkUrlExpectation(String message, String expected, String result) {
+    Test.ensureEqual(result, expected, message + ": expected=" + expected + " got=" + result);
   }
 }

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -6316,10 +6316,10 @@ class JettyTests {
         SSR.getUrlResponseStringUnchanged(
             EDStatic.erddapUrl + "/index.htmlTable?" + EDStatic.defaultPIppQuery);
     expected =
-        EDStatic.startHeadHtml(0, EDStatic.erddapUrl((String) null, language), "Resources")
+        EDStatic.startHeadHtml(0, EDStatic.erddapUrl(null, (String) null, language), "Resources")
             + "\n"
             + "</head>\n"
-            + EDStatic.startBodyHtml(0, null, "index.html", EDStatic.defaultPIppQuery)
+            + EDStatic.startBodyHtml(null, 0, null, "index.html", EDStatic.defaultPIppQuery)
             + // 2022-11-22 .htmlTable
             // converted to
             // .html to avoid user
@@ -6379,7 +6379,8 @@ class JettyTests {
             + "/erddap/wms/index.htmlTable?page=1&amp;itemsPerPage=1000</a>\n"
             + "</tr>\n"
             + "</table>\n"
-            + EDStatic.endBodyHtml(0, EDStatic.erddapUrl((String) null, language), (String) null)
+            + EDStatic.endBodyHtml(
+                null, 0, EDStatic.erddapUrl(null, (String) null, language), (String) null)
             + "\n"
             + "</html>\n";
     Test.ensureEqual(results, expected, "results=\n" + results);
@@ -8682,10 +8683,13 @@ class JettyTests {
     // String2.log(results);
     expected =
         EDStatic.startHeadHtml(
-                language, EDStatic.erddapUrl((String) null, language), "EDDTableFromNcFiles_Data")
+                language,
+                EDStatic.erddapUrl(null, (String) null, language),
+                "EDDTableFromNcFiles_Data")
             + "\n"
             + "</head>\n"
-            + EDStatic.startBodyHtml(language, null, "tabledap/testGlobecBottle.html", userDapQuery)
+            + EDStatic.startBodyHtml(
+                null, language, null, "tabledap/testGlobecBottle.html", userDapQuery)
             + // 2022-11-22
             // .htmlTable
             // converted
@@ -8738,7 +8742,7 @@ class JettyTests {
             + "</tr>\n"
             + "</table>\n"
             + EDStatic.endBodyHtml(
-                language, EDStatic.erddapUrl((String) null, language), (String) null)
+                null, language, EDStatic.erddapUrl(null, (String) null, language), (String) null)
             + "\n"
             + "</html>\n";
     tResults = results.substring(results.length() - expected.length());


### PR DESCRIPTION
# Description

Add support for a useHeadersForUrl feature flag, which changes EDStatic methods erddapUrl() and erddapHttpsUrl() to use request `Host` header when building urls if useHeadersForUrl is true and the request is available/not null.

Functionally, when this flag is enabled ERDDAP can accessed on any address which resolves to it. For example an ERDDAP available at https://erddap.officialdomain.org/erddap, http://server.localdomain:8080/erddap, and http://localhost:8080/erddap will generate URLs consistent with the accessed hostname.

This change makes the assumption that most URLs written in response to user interaction (e.g. loading a page in a browser) should respect the Host header in the request, but some URLs (example RSS feeds) should continue to always use the erddapPreferredUrl, which is constructed from baseUrl and baseHttpsUrl uses baseHttpsUrl if available, or baseUrl if not). If the header driven URL constructing approach becomes the default in the future, we could imagine only having to supply a single ERDDAP preferred URL config to use when constructing URLs outside of a request context (generated emails, etc) instead of separate baseUrl and baseHttpsUrl.

One corner case is the behavior when a user accesses a login page over http. When useHeadersForUrl is enabled and EDStatic.erddapHttpsUrl is called with an http request, the resulting URL prefix is upgraded to https with the request provided Host header as long as there is not a port in the request Host (i.e. a request for http://erddap.domain.org would result in a https://erddap.domain.org base URL, but a request for http://erddap.domain.org:8080 would fall back to returning the erddapHttpsUrl instead since https://erddap.domain.org:8080 is nonsensical).

Absolute URLs are constructed from the request Host header instead of path-only ("/erddap/index.html") or relative ("../status.html") URLs. Returning path-only URLs would be technically simple, and I originally included an option in EDStatic.erddapUrl() to generate them, but removed it for simplicity. EDStatic.erddapUrl() is called a vast number of times, and the risk of bug introduction by generation of path-only or relative URLs (non-interactive contexts etc) seemed to justify keeping the URLs absolute, at least for this change. As such, this change doesn't implement relative URLs but does address many of the concerns in #96.

General expectations of behavior:

If useHeadersForUrl is false, erddapUrl or erddapHttpsUrl are used (legacy behavior).

If the request is null, erddapUrl or erddapHttpsUrl are used (legacy behavior).

If useHeadersForUrl is true and request is not null, scheme and host header from request are used.

If useHeadersForUrl true, request not null, and request scheme is http, EDStatic.erddapHttpsUrl() uses https scheme with request host as long as request host does not contain a port (i.e. http url are upgraded to https with the same host). If host does contain a port, erddapHttpsUrl is returned instead.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
