### PR TITLE
Docker: only compile, test, and build war on build platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the ERDDAP war from source
-FROM maven:3.9.9-eclipse-temurin-21-jammy AS build
+FROM --platform=$BUILDPLATFORM maven:3.9.9-eclipse-temurin-21-jammy AS build
 
 # install zip so certain tests can pass
 RUN apt-get update && \


### PR DESCRIPTION
# Description

For multi-platform builds, only run Maven to compile, test, and build exploded WAR on the build platform, and then copy the exploded war to platform/architecture-specific second Tomcat stage.

https://docs.docker.com/build/building/multi-platform/#cross-compilation

This allows multi-platform builds to complete quickly and reliably (arm64 builds were taking 3+ hours or failing when run under emulation).

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes