### PR TITLE
docker compose: clean up monitoring profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@
 # ERDDAP_DEBUG_PORT - Local port on which to run ERDDAP remote debug server (example 8000)
 # NGINX_PROXY_HTTP_PORT - Port for nginx-proxy HTTP (example 80)
 # NGINX_PROXY_HTTPS_PORT - Port for nginx-proxy HTTPS (example 443)
+# GRAFANA_PUBLIC_HOST - Public hostname for Grafana. Only set if you are running
+#                       both the monitoring and ngnix-proxy profiles, and want
+#                       your grafana server to be publicly accessible (still password protected).
+# PROMETHEUS_LOCAL_HTTP_PORT - Local port on which to run Prometheus (default 9090)
+# GRAFANA_LOCAL_HTTP_PORT - Local port on which to serve Grafana (default 3000)
+#
 #
 # Example .env file:
 #
@@ -74,6 +80,7 @@ services:
       VIRTUAL_PORT: 8080
       LETSENCRYPT_HOST: "${ERDDAP_HOST:-}"
     mem_limit: "${ERDDAP_CONTAINER_MEM_LIMIT:-6g}"
+    restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-fl", "http://localhost:8080/erddap/index.html"]
       interval: 15s
@@ -88,13 +95,12 @@ services:
     depends_on:
       erddap:
         condition: service_healthy
+    restart: unless-stopped
     command: tail -F /erddapData/logs/log.txt
 
   # Monitoring services (part of the monitoring profile)
   prometheus:
     image: prom/prometheus:latest
-    profiles: ["monitoring"]
-    container_name: erddap-prometheus
     volumes:
       - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
@@ -106,27 +112,31 @@ services:
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--web.enable-lifecycle'
     ports:
-      - "9090:9090"
+      - "${PROMETHEUS_LOCAL_HTTP_PORT:-9090}:9090"
     restart: unless-stopped
+    profiles:
+      - monitoring
 
   grafana:
     image: grafana/grafana:latest
-    profiles: ["monitoring"]
-    container_name: erddap-grafana
     volumes:
       - grafana_data:/var/lib/grafana
       - ./docker/prometheus/grafana/provisioning:/etc/grafana/provisioning
       - ./docker/prometheus/grafana/dashboards:/var/lib/grafana/dashboards
     environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:-erddapadmin}
-      - GF_USERS_ALLOW_SIGN_UP=false
-      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-piechart-panel
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GF_SECURITY_ADMIN_PASSWORD:-erddapadmin}"
+      GF_USERS_ALLOW_SIGN_UP: false
+      GF_INSTALL_PLUGINS: grafana-clock-panel,grafana-piechart-panel
+      VIRTUAL_HOST: "${GRAFANA_PUBLIC_HOST:-}"
+      LETSENCRYPT_HOST: "${GRAFANA_PUBLIC_HOST:-}"
     ports:
-      - "3000:3000"
+      - "${GRAFANA_LOCAL_HTTP_PORT:-3000}:3000"
     depends_on:
       - prometheus
     restart: unless-stopped
+    profiles:
+      - monitoring
     
   nginx-proxy:
     image: nginxproxy/nginx-proxy:1.7
@@ -139,8 +149,10 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
     environment:
       DEFAULT_HOST: "${ERDDAP_HOST:-}"
+    restart: unless-stopped
     profiles:
       - nginx-proxy
+
   acme-companion:
     image: nginxproxy/acme-companion:2.5
     volumes_from:
@@ -151,6 +163,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       DEFAULT_EMAIL: shane@axds.co
+    restart: unless-stopped
     profiles:
       - nginx-proxy
 


### PR DESCRIPTION
# Description

Clean up and standardize monitoring containers in Docker compose profile, including:

* adding the ability to customize local ports for prometheus and grafana
* not specifying hardcoded container names for prometheus and grafana
* ability to serve grafana publicly with an SSL cert via nginx-proxy/acme-companion

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
