### PR TITLE
add github as a docker image provider

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           file: ./Dockerfile
           push: true

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -61,6 +61,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: erddap
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get current date for tag
         id: date
         run: echo "::set-output name=now::$(date +'%Y%m%d%H%M%S')"
@@ -74,3 +81,4 @@ jobs:
           tags: |
             erddap/erddap:alpha-latest
             erddap/erddap:${{ steps.date.outputs.now }}
+            ghcr.io/erddap:${{ steps.date.outputs.now }}


### PR DESCRIPTION
# Description

Some people are having trouble with dockerhub today and having an alternative source for the images could help.

Note that this PR is untested and I'm not familiar with the docker image publication here. Please feel free to close it if this is not planned or desired for this repo. 

Fixes # (issue)

## Type of change

Added a new docker image source.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
