### PR TITLE
Use host header in EDStatic.baseUrl (e.g. redirects) if useHeadersForUrl flag is set

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -6689,7 +6689,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     String tErddapUrl = EDStatic.erddapUrl(request, loggedInAs, language);
     String requestUrl = request.getRequestURI(); // post EDStatic.config.baseUrl, pre "?"
-    String fullRequestUrl = EDStatic.baseUrl(loggedInAs) + requestUrl;
+    String fullRequestUrl = EDStatic.baseUrl(request, loggedInAs) + requestUrl;
     String roles[] = EDStatic.getRoles(loggedInAs);
     // String2.log(">>fullRequestUrl=" + fullRequestUrl);
 
@@ -7278,7 +7278,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (!Arrays.equals(EDStatic.getRawRequestedPIpp(request), EDStatic.getRequestedPIpp(request))) {
       sendRedirect(
           response,
-          EDStatic.baseUrl(loggedInAs)
+          EDStatic.baseUrl(request, loggedInAs)
               + requestUrl
               + "?"
               + EDStatic.passThroughJsonpQuery(language, request)
@@ -7533,7 +7533,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 page,
                 lastPage,
                 false, // =alphabetical
-                EDStatic.baseUrl(loggedInAs)
+                EDStatic.baseUrl(request, loggedInAs)
                     + requestUrl
                     + EDStatic.questionQuery(request.getQueryString()));
 
@@ -14840,7 +14840,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           EDStatic.getRawRequestedPIpp(request), EDStatic.getRequestedPIpp(request))) {
         sendRedirect(
             response,
-            EDStatic.baseUrl(loggedInAs)
+            EDStatic.baseUrl(request, loggedInAs)
                 + request.getRequestURI()
                 + "?"
                 + EDStatic.passThroughJsonpQuery(language, request)
@@ -14962,7 +14962,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     page,
                     lastPage,
                     true, // =most relevant first
-                    EDStatic.baseUrl(loggedInAs)
+                    EDStatic.baseUrl(request, loggedInAs)
                         + requestUrl
                         + EDStatic.questionQuery(request.getQueryString()));
 
@@ -15792,7 +15792,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 + (queryString.length() == 0 ? "" : "&" + queryString);
       queryString = "page=1&" + queryString;
       sendRedirect(
-          response, EDStatic.baseUrl(loggedInAs) + request.getRequestURI() + "?" + queryString);
+          response,
+          EDStatic.baseUrl(request, loggedInAs) + request.getRequestURI() + "?" + queryString);
       return;
     }
     int pipp[] = EDStatic.getRequestedPIpp(request);
@@ -16557,7 +16558,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                     page,
                     lastPage,
                     searchFor.length() > 0 && !searchFor.equals("all"), // true=most relevant first
-                    EDStatic.baseUrl(loggedInAs)
+                    EDStatic.baseUrl(request, loggedInAs)
                         + requestUrl
                         + EDStatic.questionQuery(request.getQueryString()));
 
@@ -17082,7 +17083,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     if (!Arrays.equals(EDStatic.getRawRequestedPIpp(request), EDStatic.getRequestedPIpp(request))) {
       sendRedirect(
           response,
-          EDStatic.baseUrl(loggedInAs)
+          EDStatic.baseUrl(request, loggedInAs)
               + requestUrl
               + "?"
               + EDStatic.passThroughJsonpQuery(language, request)
@@ -17490,7 +17491,9 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                 page,
                 lastPage,
                 false, // =alphabetical
-                EDStatic.baseUrl(loggedInAs) + requestUrl + EDStatic.questionQuery(queryString));
+                EDStatic.baseUrl(request, loggedInAs)
+                    + requestUrl
+                    + EDStatic.questionQuery(queryString));
 
         // display datasets
         writer.write(
@@ -17627,7 +17630,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           EDStatic.getRawRequestedPIpp(request), EDStatic.getRequestedPIpp(request))) {
         sendRedirect(
             response,
-            EDStatic.baseUrl(loggedInAs)
+            EDStatic.baseUrl(request, loggedInAs)
                 + request.getRequestURI()
                 + "?"
                 + EDStatic.passThroughJsonpQuery(language, request)
@@ -17710,7 +17713,7 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
                           page,
                           lastPage,
                           false, // =alphabetical
-                          EDStatic.baseUrl(loggedInAs)
+                          EDStatic.baseUrl(request, loggedInAs)
                               + requestUrl
                               + EDStatic.questionQuery(request.getQueryString()))
                       + "<br>&nbsp;\n";

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcmlFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcmlFiles.java
@@ -15,6 +15,7 @@ import gov.noaa.pfel.erddap.util.EDMessages.Message;
 import gov.noaa.pfel.erddap.util.EDStatic;
 import gov.noaa.pfel.erddap.variable.EDV;
 import gov.noaa.pfel.erddap.variable.EDVGridAxis;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.Writer;
 
@@ -35,6 +36,7 @@ public class NcmlFiles extends FileTypeInterface {
   @Override
   public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
     saveAsNCML(
+        requestInfo.request(),
         requestInfo.language(),
         requestInfo.loggedInAs(),
         requestInfo.outputStream(),
@@ -90,7 +92,11 @@ public class NcmlFiles extends FileTypeInterface {
    * @throws Throwable if trouble.
    */
   private void saveAsNCML(
-      int language, String loggedInAs, OutputStreamSource outputStreamSource, EDDGrid grid)
+      HttpServletRequest request,
+      int language,
+      String loggedInAs,
+      OutputStreamSource outputStreamSource,
+      EDDGrid grid)
       throws Throwable {
     if (EDDGrid.reallyVerbose) String2.log("  EDDGrid.saveAsNCML " + grid.datasetID());
     long time = System.currentTimeMillis();
@@ -98,7 +104,8 @@ public class NcmlFiles extends FileTypeInterface {
     // get the writer
     try (Writer writer =
         File2.getBufferedWriterUtf8(outputStreamSource.outputStream(File2.UTF_8))) {
-      String opendapBaseUrl = EDStatic.baseUrl(loggedInAs) + "/griddap/" + grid.datasetID();
+      String opendapBaseUrl =
+          EDStatic.baseUrl(request, loggedInAs) + "/griddap/" + grid.datasetID();
       writer.write( // NCML
           "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
               + "<netcdf xmlns=\"https://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2\" "

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -950,10 +950,11 @@ public class EDStatic {
    * @return If loggedInAs == null, this returns baseUrl, else baseHttpsUrl (neither has slash at
    *     end).
    */
-  public static String baseUrl(String loggedInAs) {
-    return loggedInAs == null
-        ? config.baseUrl
-        : config.baseHttpsUrl; // works because of loggedInAsHttps
+  public static String baseUrl(HttpServletRequest request, String loggedInAs) {
+    if (EDStatic.config.useHeadersForUrl && request != null && request.getHeader("Host") != null) {
+      return request.getScheme() + "://" + request.getHeader("Host");
+    }
+    return loggedInAs == null ? config.baseUrl : config.baseHttpsUrl;
   }
 
   /**
@@ -966,7 +967,7 @@ public class EDStatic {
    */
   protected static String getErddapUrlPrefix(HttpServletRequest request, String loggedInAs) {
     if (EDStatic.config.useHeadersForUrl && request != null && request.getHeader("Host") != null) {
-      return request.getScheme() + "://" + request.getHeader("Host") + "/" + config.warName;
+      return baseUrl(request, loggedInAs) + "/" + config.warName;
     }
     return loggedInAs == null ? erddapUrl : erddapHttpsUrl;
   }
@@ -2228,7 +2229,7 @@ public class EDStatic {
                         TranslateMessages.languageCodeList,
                         language,
                         "onchange=\"window.location.href='"
-                            + baseUrl(loggedInAs)
+                            + baseUrl(request, loggedInAs)
                             + "/"
                             + config.warName
                             + "/' + "


### PR DESCRIPTION
# Description

Changes `EDStatic.baseUrl` to use the request's host header if `useHeadersForUrl` flag is true. This fixes some issues where internal ERDDAP redirects weren't respecting the host header.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes