### PR TITLE
Set request in TableWriterHtmlTable EDStatic calls to use request headers for images, css, etc

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/TableWriterHtmlTable.java
@@ -132,7 +132,7 @@ public class TableWriterHtmlTable extends TableWriter {
     encode = tEncode;
     writeUnits = tWriteUnits;
     showFirstNRows = tShowFirstNRows >= 0 ? tShowFirstNRows : Integer.MAX_VALUE;
-    tErddapUrl = EDStatic.erddapUrl(null, loggedInAs, language);
+    tErddapUrl = EDStatic.erddapUrl(tRequest, loggedInAs, language);
     externalLinkHtml = EDStatic.messages.externalLinkHtml(language, tErddapUrl);
     questionMarkImageUrl = tQuestionMarkImageUrl;
   }
@@ -266,7 +266,7 @@ public class TableWriterHtmlTable extends TableWriter {
           writer.write("\n</head>\n");
           writer.write(
               EDStatic.startBodyHtml(
-                  null,
+                  request,
                   language,
                   loggedInAs,
                   edd == null
@@ -524,7 +524,10 @@ public class TableWriterHtmlTable extends TableWriter {
       else
         writer.write(
             EDStatic.endBodyHtml(
-                    request, language, EDStatic.erddapUrl(null, loggedInAs, language), loggedInAs)
+                    request,
+                    language,
+                    EDStatic.erddapUrl(request, loggedInAs, language),
+                    loggedInAs)
                 + "\n</html>\n");
 
     writer.flush(); // essential
@@ -583,7 +586,7 @@ public class TableWriterHtmlTable extends TableWriter {
             encode,
             writeUnits,
             tShowFirstNRows,
-            EDStatic.imageDirUrl(null, loggedInAs, language)
+            EDStatic.imageDirUrl(request, loggedInAs, language)
                 + EDStatic.messages.questionMarkImageFile);
     tw.writeAllAndFinish(table);
     tw.close();


### PR DESCRIPTION
# Description

Small change to pass the HttpServletRequest to EDStatic calls (`EDStatic.erddapUrl`, `EDStatic.messages.externalLinkHtml`, `EDStatic.imageDirUrl`, `EDStatic.startHeadHtml`, etc) so that request headers are used when building URLs for images, CSS, etc on `.htmlTable` pages. Note that before this change the `baseUrl`/`baseHttpsUrl` configurations are fell back on instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes