### PR TITLE
Set erddap version to 2.29.0-alpha

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -203,7 +203,7 @@ public class EDStatic {
    * anything following it. A request to http.../erddap/version will return just the number (as
    * text). A request to http.../erddap/version_string will return the full string.
    */
-  public static final Semver erddapVersion = new Semver("2.28.1");
+  public static final Semver erddapVersion = new Semver("2.29.0-alpha");
 
   /** This identifies the dods server/version that this mimics. */
   public static final String dapVersion = "DAP/2.0";

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>gov.noaa.pfel.erddap</groupId>
     <artifactId>ERDDAP</artifactId>
-    <version>2.28.1</version>
+    <version>2.29.0-alpha</version>
     <packaging>war</packaging>
 
     <name>erddap</name>


### PR DESCRIPTION
# Description

Updates the version to 2.29.0-alpha so "nightly" builds will have it set appropriately.