### PR TITLE
Add support for string substitution (environment and other) when pars…

### DIFF
--- a/WEB-INF/classes/com/cohort/util/XML.java
+++ b/WEB-INF/classes/com/cohort/util/XML.java
@@ -14,6 +14,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.io.StringSubstitutorReader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -584,9 +586,16 @@ public class XML {
    * @return a DOM Document
    * @throws Exception if trouble
    */
-  public static Document parseXml(String fileName, boolean validating) throws Exception {
+  public static Document parseXml(String fileName, boolean validating, boolean withEnvSubstitutions)
+      throws Exception {
     try (BufferedReader reader = File2.getDecompressedBufferedFileReader(fileName, File2.UTF_8)) {
-      return parseXml(new InputSource(reader), validating);
+      InputSource source;
+      if (withEnvSubstitutions) {
+        source = new InputSource(new StringSubstitutorReader(reader, new StringSubstitutor()));
+      } else {
+        source = new InputSource(reader);
+      }
+      return parseXml(source, validating);
     }
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
@@ -307,7 +307,7 @@ public class EDConfig {
     // read static Strings from setup.xml
     String setupFileName = contentDirectory + "setup" + (developmentMode ? "2" : "") + ".xml";
     errorInMethod = "ERROR while reading " + setupFileName + ": ";
-    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false));
+    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false, true));
     Map<String, String> ev = System.getenv();
 
     // logLevel may be: warning, info(default), all

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDMessages.java
@@ -1042,7 +1042,7 @@ public class EDMessages {
     String setupFileName =
         contentDirectory + "setup" + (EDStatic.config.developmentMode ? "2" : "") + ".xml";
     String errorInMethod;
-    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false));
+    ResourceBundle2 setup = ResourceBundle2.fromXml(XML.parseXml(setupFileName, false, true));
     Map<String, String> ev = System.getenv();
     // **** messages.xml *************************************************************
     // This is read AFTER setup.xml. If that is a problem for something, defer reading it in setup
@@ -1053,7 +1053,7 @@ public class EDMessages {
     if (File2.isFile(messagesFileName)) {
       String2.log("Using custom messages.xml from " + messagesFileName);
       // messagesAr[0] is either the custom messages.xml or the one provided by Erddap
-      messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false));
+      messagesAr[0] = ResourceBundle2.fromXml(XML.parseXml(messagesFileName, false, false));
     } else {
       // use default messages.xml
       String2.log("Custom messages.xml not found at " + messagesFileName);


### PR DESCRIPTION
…ing setup.xml.

# Description

This adds support for string substitution to the setup.xml. The big win for admins is being able to use environment variables or other substitutions for sensitive inputs like usernames and passwords.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - documentation update to be made soon along with the datasets.xml substitution support documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
