### PR TITLE
Bugfix/allow delete char

### DIFF
--- a/WEB-INF/classes/com/cohort/util/String2.java
+++ b/WEB-INF/classes/com/cohort/util/String2.java
@@ -4974,7 +4974,7 @@ public class String2 {
 
   /**
    * This returns the index of the first non-Unicode character. Currently, valid characters are #32
-   * - #126, #160+.
+   * - #127, #160+.
    *
    * @param s
    * @param alsoOK a string with characters (e.g., \r, \n, \t) which are also valid


### PR DESCRIPTION
# Description

We encountered an issue with some NetCDF files that include the DEL char (code 127) in one of their source attributes. The test for printable characters would reject these NetCDF files and cause the dataset to not load with a confusing error log. Allowing the DEL char does not break any of the ERDDAP functionality for the griddap dataset. 

In my opinion, this was an overly restrictive test. This is the simplest code fix I could find without requiring editing the NetCDF data. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
