### PR TITLE
Another disk cleanup step

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -53,6 +53,11 @@ jobs:
       packages: write
 
     steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:


### PR DESCRIPTION
Another disk cleanup step from https://stackoverflow.com/questions/75536771/github-runner-out-of-disk-space-after-building-docker-image

Fixes Out of memory error during docker image build

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

