### PR TITLE
Remove caching in push build

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -35,7 +35,6 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
     - name: Build and test with Maven
       run: >
         mvn --batch-mode


### PR DESCRIPTION
# Description

Using cache for production builds is a zizmor error.
The fiile clear change seemed to help, not this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

