### PR TITLE
Add -XX:+UseCompactObjectHeaders optimization flag

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -8,3 +8,4 @@
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+-XX:+UseCompactObjectHeaders

--- a/docker/tomcat/bin/setenv.sh
+++ b/docker/tomcat/bin/setenv.sh
@@ -13,7 +13,7 @@ if [ -f "${CATALINA_HOME}/bin/config.sh" ]; then
 fi
 
 # JAVA_OPTS
-NORMAL="-server -Djava.awt.headless=true"
+NORMAL="-server -Djava.awt.headless=true -XX:+UseCompactObjectHeaders"
 HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
 
 # Memory


### PR DESCRIPTION
Add -XX:+UseCompactObjectHeaders flag, which requires Java 25 and increases performance using compact object headers.

https://openjdk.org/jeps/519
