### PR TITLE
Move -XX:+UseCompactObjectHeaders from .mvn/jvm.config to Dockerfile

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -8,4 +8,3 @@
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
--XX:+UseCompactObjectHeaders

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN if [ "$BUILD_FROM_GIT" = "1" ] && [ -n "$ERDDAP_GIT_URL" ] && [ -n "$ERDDAP_
 
 ARG SKIP_TESTS=false
 RUN --mount=type=cache,id=m2_repo,target=/root/.m2/repository \
-    mvn --batch-mode -DskipTests=${SKIP_TESTS} -Dgcf.skipInstallHooks=true \
+    MAVEN_OPTS="-XX:+UseCompactObjectHeaders" mvn --batch-mode -DskipTests=${SKIP_TESTS} -Dgcf.skipInstallHooks=true \
     -Ddownload.unpack=true -Ddownload.unpackWhenChanged=false \
     -Dmaven.test.redirectTestOutputToFile=true package \
     && find target -maxdepth 1 -type d -name 'ERDDAP-*' -exec mv {} target/ERDDAP \;


### PR DESCRIPTION
Move -XX:+UseCompactObjectHeaders from .mvn/jvm.config to Dockerfile, because GitHub's automatic dependency submission apparently uses Java older than 25 (the new flag is not recognized, which breaks dependency submission). I couldn't find anywhere to specify a Java version for dependency submission.

Eventually GitHub will probably update the bundled Java for dependency submission and the flag can be moved back to .mvn/jvm.config if desired.