### PR TITLE
Use a temp directory within the project.

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -8,3 +8,6 @@
 --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+-Djava.io.tmpdir=./target/temp
+-Dtmp=./target/temp
+-Dtemp=./target/temp

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.9.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>properties</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-utils -->
                 <plugin>
@@ -616,7 +623,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <environmentVariables>
+                        <temp>${project.basedir}/target/temp/</temp>
+                        <tmp>${project.basedir}/target/temp/</tmp>
+                        <java.io.tmpdir>${project.basedir}/target/temp/</java.io.tmpdir>
+                    </environmentVariables>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
                     </additionalClasspathElements>
@@ -634,7 +646,12 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <argLine>${failsafe.jacoco.args}</argLine>
+                            <argLine>${failsafe.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                            <environmentVariables>
+                                <temp>${project.basedir}/target/temp/</temp>
+                                <tmp>${project.basedir}/target/temp/</tmp>
+                                <java.io.tmpdir>${project.basedir}/target/temp/</java.io.tmpdir>
+                            </environmentVariables>
                             <additionalClasspathElements>
                                 <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
                             </additionalClasspathElements>
@@ -661,7 +678,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <environmentVariables>
+                        <temp>${project.basedir}/target/temp/</temp>
+                        <tmp>${project.basedir}/target/temp/</tmp>
+                        <java.io.tmpdir>${project.basedir}/target/temp/</java.io.tmpdir>
+                    </environmentVariables>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
                     </additionalClasspathElements>
@@ -680,7 +702,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <environmentVariables>
+                        <temp>${project.basedir}/target/temp/</temp>
+                        <tmp>${project.basedir}/target/temp/</tmp>
+                        <java.io.tmpdir>${project.basedir}/target/temp/</java.io.tmpdir>
+                    </environmentVariables>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.basedir}/test-data</additionalClasspathElement>
                     </additionalClasspathElements>


### PR DESCRIPTION
# Description

The motivating change for this is IT for my main work computer required security changes that block programs in the default temp directory from running. Specifically surefire, failsafe, and mockito generate jars and then run them as part of testing. By using a temp directory in the project, they are allowed to run.

I didn't know if this would be useful for other contributors, but also felt that a project temp directory would be beneficial for things like checking temp files written during tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
