### PR TITLE
Support for making ncheader files without generating and saving the entire nc file first.

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/AxisDataAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/AxisDataAccessor.java
@@ -51,6 +51,7 @@ public class AxisDataAccessor {
   // things the constructor generates
   protected EDVGridAxis[] rAxisVariables;
   protected final IntArray constraints;
+  StringArray destinationNames;
   protected Attributes globalAttributes;
   protected Attributes rAxisAttributes[];
   protected PrimitiveArray rAxisValues[];
@@ -79,7 +80,7 @@ public class AxisDataAccessor {
               + userDapQuery);
 
     // parse the query    -- always for just 1 axis variable
-    StringArray destinationNames = new StringArray();
+    destinationNames = new StringArray();
     constraints = new IntArray();
     eddGrid.parseAxisDapQuery(language, userDapQuery, destinationNames, constraints, false);
     if (reallyVerbose) {
@@ -283,5 +284,9 @@ public class AxisDataAccessor {
    */
   public Attributes globalAttributes() {
     return globalAttributes;
+  }
+
+  public StringArray destinationNames() {
+    return destinationNames;
   }
 }

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/metadata/LocalizedAttributes.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/metadata/LocalizedAttributes.java
@@ -64,6 +64,27 @@ public class LocalizedAttributes {
     }
   }
 
+  public Map<String, PrimitiveArray> toMap(int language) {
+    Map<String, PrimitiveArray> attr = new HashMap<>();
+    Set<Entry<String, PrimitiveArray>> entries = map.entrySet();
+    for (Entry<String, PrimitiveArray> entry : entries) {
+      if (entry.getValue() != null) {
+        attr.put(entry.getKey(), entry.getValue());
+      }
+    }
+    Map<String, PrimitiveArray> langMap = safeGetLangMap(language);
+    if (langMap != null) {
+      Set<Entry<String, PrimitiveArray>> langEntries = langMap.entrySet();
+      for (Entry<String, PrimitiveArray> entry : langEntries) {
+        if (entry.getValue() != null) {
+          attr.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+
+    return attr;
+  }
+
   public Attributes toAttributes(int language) {
     Attributes attr = new Attributes();
     Set<Entry<String, PrimitiveArray>> entries = map.entrySet();

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcHeaderFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcHeaderFiles.java
@@ -1,7 +1,44 @@
 package gov.noaa.pfel.erddap.filetypes;
 
+import com.cohort.array.Attributes;
+import com.cohort.array.ByteArray;
+import com.cohort.array.FloatArray;
+import com.cohort.array.IntArray;
+import com.cohort.array.PAOne;
+import com.cohort.array.PAType;
+import com.cohort.array.PrimitiveArray;
+import com.cohort.array.ShortArray;
+import com.cohort.array.StringArray;
+import com.cohort.array.UByteArray;
+import com.cohort.array.UIntArray;
+import com.cohort.array.UShortArray;
+import com.cohort.util.File2;
+import com.cohort.util.SimpleException;
+import gov.noaa.pfel.coastwatch.griddata.NcHelper;
+import gov.noaa.pfel.coastwatch.pointdata.Table;
+import gov.noaa.pfel.erddap.dataset.AxisDataAccessor;
+import gov.noaa.pfel.erddap.dataset.EDDGrid;
+import gov.noaa.pfel.erddap.dataset.EDDTable;
+import gov.noaa.pfel.erddap.dataset.GridDataAccessor;
+import gov.noaa.pfel.erddap.dataset.TableWriter;
+import gov.noaa.pfel.erddap.dataset.TableWriterAllWithMetadata;
+import gov.noaa.pfel.erddap.util.EDMessages;
 import gov.noaa.pfel.erddap.util.EDMessages.Message;
 import gov.noaa.pfel.erddap.util.EDStatic;
+import gov.noaa.pfel.erddap.variable.EDV;
+import gov.noaa.pfel.erddap.variable.EDVGridAxis;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.Group;
+import ucar.nc2.Variable;
+import ucar.nc2.write.NetcdfFileFormat;
+import ucar.nc2.write.NetcdfFormatWriter;
 
 @FileTypeClass(
     fileTypeExtension = ".txt",
@@ -10,9 +47,519 @@ import gov.noaa.pfel.erddap.util.EDStatic;
     versionAdded = "1.0.0",
     contentType = "text/plain",
     addContentDispositionHeader = false)
-public class NcHeaderFiles extends NcFiles {
-  public NcHeaderFiles() {
-    super(true);
+public class NcHeaderFiles extends FileTypeInterface {
+
+  private Attribute.Builder attributeBuilder(String name, PrimitiveArray value) {
+    Attribute.Builder attBuild = Attribute.builder(name);
+    PAType attributeType = value.elementType();
+    attBuild.setDataType(NcHelper.getNc3DataType(attributeType));
+    if (value.size() == 1) {
+      switch (attributeType) {
+        case BOOLEAN:
+          attBuild.setNumericValue(value.getInt(0), false);
+          break;
+        case BYTE:
+          attBuild.setNumericValue(value.getInt(0), false);
+          break;
+        case CHAR:
+          attBuild.setStringValue(value.getString(0));
+          break;
+        case DOUBLE:
+          attBuild.setNumericValue(value.getDouble(0), false);
+          break;
+        case FLOAT:
+          attBuild.setNumericValue(value.getFloat(0), false);
+          break;
+        case INT:
+          attBuild.setNumericValue(value.getInt(0), false);
+          break;
+        case LONG:
+          // For nc3, long is a double.
+          attBuild.setNumericValue(value.getDouble(0), false);
+          break;
+        case SHORT:
+          attBuild.setNumericValue((short) value.getInt(0), false);
+          break;
+        case STRING:
+          attBuild.setStringValue(value.getString(0));
+          break;
+        case UBYTE:
+          attBuild.setNumericValue(value.getInt(0), true);
+          break;
+        case UINT:
+          attBuild.setNumericValue(value.getInt(0), true);
+          break;
+        case ULONG:
+          // For nc3, ulong is a double.
+          attBuild.setNumericValue(value.getDouble(0), true);
+          break;
+        case USHORT:
+          attBuild.setNumericValue((short) value.getInt(0), true);
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "NCHeader does not support type: " + attributeType.toString());
+      }
+    } else {
+      List<Object> values = new ArrayList<>();
+      switch (attributeType) {
+        case BOOLEAN:
+          byte[] boolArray = ((ByteArray) value).array;
+          for (int i = 0; i < boolArray.length; i++) {
+            values.add(boolArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case BYTE:
+          byte[] byteArray = ((ByteArray) value).array;
+          for (int i = 0; i < byteArray.length; i++) {
+            values.add(byteArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case CHAR:
+          String[] charArray = value.toStringArray();
+          for (int i = 0; i < charArray.length; i++) {
+            values.add(charArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case DOUBLE:
+          // For nc3, long is a double.
+          double[] doubleArray = value.toDoubleArray();
+          for (int i = 0; i < doubleArray.length; i++) {
+            values.add(doubleArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case FLOAT:
+          float[] floatArray = ((FloatArray) value).array;
+          for (int i = 0; i < floatArray.length; i++) {
+            values.add(floatArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case INT:
+          int[] intArray = ((IntArray) value).array;
+          for (int i = 0; i < intArray.length; i++) {
+            values.add(intArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case LONG:
+          // For nc3, long is a double.
+          double[] longArray = value.toDoubleArray();
+          for (int i = 0; i < longArray.length; i++) {
+            values.add(longArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case SHORT:
+          short[] shortArray = ((ShortArray) value).array;
+          for (int i = 0; i < shortArray.length; i++) {
+            values.add(shortArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case STRING:
+          String[] stringArray = value.toStringArray();
+          for (int i = 0; i < stringArray.length; i++) {
+            values.add(stringArray[i]);
+          }
+          attBuild.setValues(values, false);
+          break;
+        case UBYTE:
+          byte[] uByteArray = ((UByteArray) value).array;
+          for (int i = 0; i < uByteArray.length; i++) {
+            values.add(uByteArray[i]);
+          }
+          attBuild.setValues(values, true);
+          break;
+        case UINT:
+          int[] uIntArray = ((UIntArray) value).array;
+          for (int i = 0; i < uIntArray.length; i++) {
+            values.add(uIntArray[i]);
+          }
+          attBuild.setValues(values, true);
+          break;
+        case ULONG:
+          // For nc3, ulong is a double.
+          double[] uLongArray = value.toDoubleArray();
+          for (int i = 0; i < uLongArray.length; i++) {
+            values.add(uLongArray[i]);
+          }
+          attBuild.setValues(values, true);
+          break;
+        case USHORT:
+          short[] ushortArray = ((UShortArray) value).array;
+          for (int i = 0; i < ushortArray.length; i++) {
+            values.add(ushortArray[i]);
+          }
+          attBuild.setValues(values, true);
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "NCHeader does not support type: " + attributeType.toString());
+      }
+    }
+
+    return attBuild;
+  }
+
+  private void buildAttributesFromMap(Variable.Builder<?> varBuilder, Attributes attributes) {
+    String[] names = attributes.getNames();
+    Arrays.sort(names);
+    for (String name : names) {
+      Attribute.Builder attBuild = attributeBuilder(name, attributes.get(name));
+      varBuilder.addAttribute(attBuild.build());
+    }
+  }
+
+  private void buildAttributesFromMap(
+      Group.Builder rootGroup, Attributes attributes, Map<String, PrimitiveArray> eddAtts) {
+    String[] names = attributes.getNames();
+
+    List<String> attributeNameList = new ArrayList<>(eddAtts.keySet());
+    attributeNameList.addAll(Arrays.asList(names));
+    attributeNameList.sort(
+        new Comparator<String>() {
+          @Override
+          public int compare(String o1, String o2) {
+            return o1.compareToIgnoreCase(o2);
+          }
+        });
+
+    for (String name : attributeNameList) {
+      PrimitiveArray value = attributes.get(name);
+      if (value != null) {
+        Attribute.Builder attBuild = attributeBuilder(name, value);
+        rootGroup.addAttribute(attBuild.build());
+      } else {
+        Attribute.Builder attBuild = attributeBuilder(name, eddAtts.get(name));
+        rootGroup.addAttribute(attBuild.build());
+      }
+    }
+  }
+
+  private void buildAttributesFromMap(
+      Variable.Builder<?> writerBuilder, Map<String, PrimitiveArray> attributes) {
+    List<Map.Entry<String, PrimitiveArray>> attributeList = new ArrayList<>(attributes.entrySet());
+    attributeList.sort(
+        new Comparator<Map.Entry<String, PrimitiveArray>>() {
+          @Override
+          public int compare(
+              Map.Entry<String, PrimitiveArray> o1, Map.Entry<String, PrimitiveArray> o2) {
+            return o1.getKey().compareToIgnoreCase(o2.getKey());
+          }
+        });
+    for (Map.Entry<String, PrimitiveArray> entry : attributeList) {
+      Attribute.Builder attBuild = attributeBuilder(entry.getKey(), entry.getValue());
+      writerBuilder.addAttribute(attBuild.build());
+    }
+  }
+
+  @Override
+  public void writeTableToStream(DapRequestInfo requestInfo) throws Throwable {
+    if (EDStatic.config.ncHeaderMakeFile) {
+      FileTypeInterface ncFiles = new NcFiles(true);
+      ncFiles.writeTableToStream(requestInfo);
+      return;
+    }
+
+    String cdlOutput = "";
+    NetcdfFormatWriter.Builder writerBuilder =
+        NetcdfFormatWriter.builder()
+            .setFormat(NetcdfFileFormat.NETCDF3) // Set format
+            .setLocation(requestInfo.dir() + requestInfo.fileName() + ".nc");
+
+    Group.Builder rootGroup = Group.builder();
+
+    EDDTable eddTable = requestInfo.getEDDTable();
+    if (eddTable == null) {
+      throw new SimpleException(
+          EDStatic.bilingual(
+              requestInfo.language(),
+              EDStatic.messages.get(Message.QUERY_ERROR, 0)
+                  + EDStatic.messages.get(Message.ERROR_INTERNAL, 0),
+              EDStatic.messages.get(Message.QUERY_ERROR, requestInfo.language())
+                  + EDStatic.messages.get(Message.ERROR_INTERNAL, requestInfo.language())));
+    }
+    try (TableWriterAllWithMetadata tableWriter =
+        new TableWriterAllWithMetadata(
+            requestInfo.language(),
+            eddTable,
+            requestInfo.newHistory(),
+            requestInfo.dir(),
+            requestInfo.fileName() + "_temp")) {
+      if (tableWriter != null) {
+        TableWriter tTableWriter =
+            eddTable.encloseTableWriter(
+                requestInfo.language(),
+                true, // alwaysDoAll
+                requestInfo.dir(),
+                requestInfo.fileName(),
+                tableWriter,
+                requestInfo.requestUrl(),
+                requestInfo.userDapQuery());
+        if (eddTable.handleViaFixedOrSubsetVariables(
+            requestInfo.language(),
+            requestInfo.loggedInAs(),
+            requestInfo.requestUrl(),
+            requestInfo.userDapQuery(),
+            tTableWriter)) {
+        } else {
+          if (tTableWriter != tableWriter)
+            tTableWriter =
+                eddTable.encloseTableWriter(
+                    requestInfo.language(),
+                    false, // alwaysDoAll
+                    requestInfo.dir(),
+                    requestInfo.fileName(),
+                    tableWriter,
+                    requestInfo.requestUrl(),
+                    requestInfo.userDapQuery());
+          eddTable.getDataForDapQuery(
+              requestInfo.language(),
+              requestInfo.loggedInAs(),
+              requestInfo.requestUrl(),
+              requestInfo.userDapQuery(),
+              tTableWriter);
+        }
+        Table table = tableWriter.cumulativeTable();
+        tTableWriter.close();
+        tableWriter.close();
+
+        buildAttributesFromMap(
+            rootGroup,
+            table.globalAttributes(),
+            requestInfo.edd().combinedGlobalAttributes().toMap(EDMessages.DEFAULT_LANGUAGE));
+
+        Dimension obsDim = Dimension.builder("row", table.nRows()).build();
+        rootGroup.addDimension(obsDim);
+
+        for (int i = 0; i < table.nColumns(); i++) {
+
+          Variable.Builder<?> varBuilder;
+          PAType columnType = table.getColumn(i).elementType();
+
+          Attributes varAtts = table.columnAttributes(i);
+
+          // Special handling for NetCDF-3 strings (CHAR arrays)
+          if (columnType == PAType.STRING) {
+            Dimension strDim =
+                Dimension.builder(
+                        table.getColumnName(i) + "_strlen",
+                        ((StringArray) table.getColumn(i)).maxStringLength())
+                    .build();
+
+            // Add this dimension to the rootGroup builder
+            rootGroup.addDimension(strDim);
+
+            varBuilder =
+                Variable.builder()
+                    .setName(table.getColumnName(i))
+                    .setDataType(NcHelper.getNc3DataType(PAType.CHAR))
+                    .setDimensions(List.of(obsDim, strDim));
+
+            varAtts.add("_Encoding", PAOne.fromString("ISO-8859-1").pa());
+
+          } else {
+            // Standard numeric case
+            varBuilder =
+                Variable.builder()
+                    .setName(table.getColumnName(i))
+                    .setDataType(NcHelper.getNc3DataType(columnType))
+                    .setDimensions(List.of(obsDim));
+          }
+
+          // Add all attributes to the *variable* builder
+          buildAttributesFromMap(varBuilder, varAtts);
+
+          // Add the fully-built variable to the rootGroup builder
+          rootGroup.addVariable(varBuilder);
+        }
+        writerBuilder.setRootGroup(rootGroup);
+
+        // Build the writer and extract the header
+        // writerBuilder.build() creates the in-memory object.
+        try (NetcdfFormatWriter writer = writerBuilder.build()) {
+
+          // Get the NetcdfFile object from the writer
+          // and call toString() to get the CDL header.
+          cdlOutput = writer.getOutputFile().toString();
+
+          try (Writer outputWriter =
+              File2.getBufferedWriter88591(
+                  requestInfo.outputStream().outputStream(File2.ISO_8859_1))) {
+            outputWriter.append(cdlOutput);
+            outputWriter.flush();
+          }
+        }
+      }
+    }
+  }
+
+  private void writeGridAxis(
+      EDVGridAxis axis,
+      PrimitiveArray pa,
+      List<Dimension> builtDimensions,
+      Group.Builder rootGroup,
+      NetcdfFormatWriter.Builder writerBuilder) {
+    String dimName = axis.destinationName();
+    Dimension newDim = Dimension.builder(dimName, pa.size()).build();
+    writerBuilder.addDimension(newDim);
+    builtDimensions.add(newDim); // Save for later
+    rootGroup.addDimension(newDim);
+
+    String[] minMax = pa.getNMinMax();
+    Map<String, PrimitiveArray> varAtts =
+        axis.combinedAttributes().toMap(EDMessages.DEFAULT_LANGUAGE);
+    PrimitiveArray minMaxPA = PrimitiveArray.factory(pa.elementType(), 0, minMax[1]);
+    minMaxPA.addString(minMax[1]);
+    minMaxPA.addString(minMax[2]);
+    varAtts.put("actual_range", minMaxPA);
+
+    Variable.Builder<?> varBuilder =
+        Variable.builder()
+            .setName(axis.destinationName())
+            .setDataType(NcHelper.getNc3DataType(axis.destinationDataPAType()))
+            .setDimensions(List.of(newDim));
+    buildAttributesFromMap(varBuilder, varAtts);
+    rootGroup.addVariable(varBuilder);
+  }
+
+  private void writeGridDataVarialbe(
+      EDV variable,
+      List<Dimension> builtDimensions,
+      Group.Builder rootGroup,
+      NetcdfFormatWriter.Builder writerBuilder) {
+    // Create a builder for *this variable*
+    Variable.Builder<?> varBuilder;
+    Map<String, PrimitiveArray> varAtts =
+        variable.combinedAttributes().toMap(EDMessages.DEFAULT_LANGUAGE);
+
+    // Special handling for NetCDF-3 strings (CHAR arrays)
+    if (variable.destinationDataPAType() == PAType.CHAR
+        || variable.destinationDataPAType() == PAType.STRING) {
+      Dimension strDim =
+          Dimension.builder(
+                  variable.destinationName() + "_strlen",
+                  10 // Does this matter? Using 10 as a placeholder.
+                  )
+              .build();
+
+      // Add this dimension to the *file* builder
+      writerBuilder.addDimension(strDim);
+
+      varBuilder =
+          Variable.builder()
+              .setName(variable.destinationName())
+              .setDataType(NcHelper.getNc3DataType(PAType.CHAR))
+              .setDimensions(builtDimensions);
+
+      varAtts.put("_Encoding", PAOne.fromString("ISO-8859-1").pa());
+
+    } else {
+      // Standard numeric case
+      varBuilder =
+          Variable.builder()
+              .setName(variable.destinationName())
+              .setDataType(NcHelper.getNc3DataType(variable.destinationDataPAType()))
+              .setDimensions(builtDimensions);
+    }
+
+    // Add all attributes to the *variable* builder
+    buildAttributesFromMap(varBuilder, varAtts);
+
+    // Add the fully-built variable to the *file* builder
+    rootGroup.addVariable(varBuilder);
+  }
+
+  @Override
+  public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
+    if (EDStatic.config.ncHeaderMakeFile) {
+      FileTypeInterface ncFiles = new NcFiles(true);
+      ncFiles.writeGridToStream(requestInfo);
+      return;
+    }
+
+    String cdlOutput = "";
+    NetcdfFormatWriter.Builder writerBuilder =
+        NetcdfFormatWriter.builder()
+            .setFormat(NetcdfFileFormat.NETCDF3)
+            .setLocation(requestInfo.dir() + requestInfo.fileName() + ".nc");
+
+    Group.Builder rootGroup = Group.builder();
+
+    // This list is crucial: it holds the dimensions
+    List<Dimension> builtDimensions = new ArrayList<>();
+
+    EDDGrid eddGrid = requestInfo.getEDDGrid();
+
+    long rows = 1;
+    // handle axisDapQuery
+    if (eddGrid.isAxisDapQuery(requestInfo.userDapQuery())) {
+      AxisDataAccessor ada =
+          new AxisDataAccessor(
+              requestInfo.language(),
+              eddGrid,
+              requestInfo.requestUrl(),
+              requestInfo.userDapQuery());
+      buildAttributesFromMap(
+          rootGroup,
+          ada.globalAttributes(),
+          requestInfo.edd().combinedGlobalAttributes().toMap(EDMessages.DEFAULT_LANGUAGE));
+      int nRAV = ada.nRequestedAxisVariables();
+      for (int av = 0; av < nRAV; av++) {
+        int dimSize = ada.axisValues(av).size();
+        rows = rows * dimSize;
+        EDVGridAxis axis = ada.axisVariables(av);
+        writeGridAxis(axis, ada.axisValues(av), builtDimensions, rootGroup, writerBuilder);
+      }
+
+      for (EDV variable : requestInfo.edd().dataVariables()) {
+        if (ada.destinationNames().indexOf(variable.destinationName()) != -1) {
+          writeGridDataVarialbe(variable, builtDimensions, rootGroup, writerBuilder);
+        }
+      }
+    } else {
+      // handle gridDapQuery
+      try (GridDataAccessor mainGda =
+          new GridDataAccessor(
+              requestInfo.language(),
+              eddGrid,
+              requestInfo.requestUrl(),
+              requestInfo.userDapQuery(),
+              false,
+              true)) {
+        buildAttributesFromMap(
+            rootGroup,
+            mainGda.globalAttributes(),
+            requestInfo.edd().combinedGlobalAttributes().toMap(EDMessages.DEFAULT_LANGUAGE));
+        int nRAV = eddGrid.axisVariables().length;
+        for (int av = 0; av < nRAV; av++) {
+          int dimSize = mainGda.axisValues(av).size();
+          rows = rows * dimSize;
+          EDVGridAxis axis = eddGrid.axisVariables()[av];
+          writeGridAxis(axis, mainGda.axisValues(av), builtDimensions, rootGroup, writerBuilder);
+        }
+
+        for (EDV variable : mainGda.dataVariables()) {
+          writeGridDataVarialbe(variable, builtDimensions, rootGroup, writerBuilder);
+        }
+      }
+    }
+    writerBuilder.setRootGroup(rootGroup);
+
+    try (NetcdfFormatWriter writer = writerBuilder.build()) {
+      cdlOutput = writer.getOutputFile().toString();
+    }
+
+    try (Writer outputWriter =
+        File2.getBufferedWriter88591(requestInfo.outputStream().outputStream(File2.ISO_8859_1))) {
+      outputWriter.append(cdlOutput);
+      outputWriter.flush();
+    }
   }
 
   @Override

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
@@ -273,6 +273,7 @@ public class EDConfig {
   @FeatureFlag public final boolean useEddReflection;
   @FeatureFlag public boolean enableCors;
   @FeatureFlag public boolean includeNcCFSubsetVariables;
+  @FeatureFlag public boolean ncHeaderMakeFile = false;
   @FeatureFlag public boolean useSisISO19115 = false;
   @FeatureFlag public boolean useSisISO19139 = false;
   @FeatureFlag public boolean useHeadersForUrl = true;
@@ -671,6 +672,7 @@ public class EDConfig {
         getSetupEVBoolean(setup, ev, "variablesMustHaveIoosCategory", true);
     warName = getSetupEVString(setup, ev, "warName", "erddap");
     includeNcCFSubsetVariables = getSetupEVBoolean(setup, ev, "includeNcCFSubsetVariables", false);
+    ncHeaderMakeFile = getSetupEVBoolean(setup, ev, "ncHeaderMakeFile", false);
     useSisISO19115 = getSetupEVBoolean(setup, ev, "useSisISO19115", false);
     useSisISO19139 = getSetupEVBoolean(setup, ev, "useSisISO19139", false);
     generateCroissantSchema = getSetupEVBoolean(setup, ev, "generateCroissantSchema", true);

--- a/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
@@ -1,0 +1,1554 @@
+package gov.noaa.pfel.erddap.filetypes;
+
+import com.cohort.util.File2;
+import gov.noaa.pfel.erddap.dataset.EDD;
+import gov.noaa.pfel.erddap.util.EDStatic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import testDataset.EDDTestDataset;
+import testDataset.Initialization;
+
+/**
+ * This tests making an nc header file. This is supporting ncHeaderMakeFile true and false. There
+ * are a number of lines from the output that vary slightly depending on the setting, to allow tests
+ * to pass either way, we don't test those lines. The way \' is put into output between the two
+ * settings varies, so we avoid checking those lines. In some cases the old approach does not have
+ * range information geospatial_lat/lon_min/max, etc... In those tests we remove those lines as
+ * well. Once we fully migrate to ncHeaderMakeFile false we can simplify these tests.
+ */
+public class NcHeaderFilesTests {
+
+  @BeforeAll
+  static void init() {
+    Initialization.edStatic();
+  }
+
+  /**
+   * @throws Throwable if trouble
+   */
+  @Test
+  void testJsonlCSV() throws Throwable {
+    int language = 0;
+    String tName, results, expected;
+
+    EDD edd = EDDTestDataset.gettestJsonlCSV();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results =
+        results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromJsonlCSVFiles.nc {");
+    expected =
+"""
+netcdf EDDTableFromJsonlCSVFiles.nc {
+  dimensions:
+    row = 6;
+    ship_strlen = 15;
+  variables:
+    char ship(row=6, ship_strlen=15);
+      :_Encoding = "ISO-8859-1";
+      :cf_role = "trajectory_id";
+      :ioos_category = "Identifier";
+      :long_name = "Ship";
+
+    double time(row=6);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.4902299E9, 1.4903055E9; // double
+      :axis = "T";
+      :ioos_category = "Time";
+      :long_name = "Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    float latitude(row=6);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 27.9998f, 28.0003f; // float
+      :axis = "Y";
+      :colorBarMaximum = 90.0; // double
+      :colorBarMinimum = -90.0; // double
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    float longitude(row=6);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = -132.0014f, -130.2576f; // float
+      :axis = "X";
+      :colorBarMaximum = 180.0; // double
+      :colorBarMinimum = -180.0; // double
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    char status(row=6);
+      :actual_range = "\\t", "?";
+      :ioos_category = "Other";
+      :long_name = "Status";
+
+    double testLong(row=6);
+      :_FillValue = 9.223372036854776E18; // double
+      :actual_range = -9.223372036854776E18, 9.223372036854776E18; // double
+      :ioos_category = "Other";
+      :long_name = "Test Long";
+
+    float sst(row=6);
+      :actual_range = 10.0f, 99.0f; // float
+      :ioos_category = "Temperature";
+      :long_name = "Sea Surface Temperature";
+      :units = "degree_C";
+
+  // global attributes:
+  :cdm_data_type = "Trajectory";
+  :cdm_trajectory_variables = "ship";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :Easternmost_Easting = -130.2576f; // float
+  :featureType = "Trajectory";
+  :geospatial_lat_max = 28.0003f; // float
+  :geospatial_lat_min = 27.9998f; // float
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = -130.2576f; // float
+  :geospatial_lon_min = -132.0014f; // float
+  :geospatial_lon_units = "degrees_east";
+  :history = "YYYY-MM-DDTHH:mm:ssZ (local files)
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/tabledap/testJsonlCSV.ncHeader";
+  :id = "testJsonlCSV";
+  :infoUrl = "https://jsonlines.org/examples/";
+  :institution = "jsonlines.org";
+  :keywords = "data, latitude, local, long, longitude, sea, ship, source, sst, status, surface, temperature, test, testLong, time";
+  :license = "The data may be used and redistributed for free but is not intended
+for legal use, since it may contain inaccuracies. Neither the data
+Contributor, ERD, NOAA, nor the United States Government, nor any
+of their employees or contractors, makes any warranty, express or
+implied, including warranties of merchantability and fitness for a
+particular purpose, or assumes any legal liability for the accuracy,
+completeness, or usefulness, of this information.";
+  :Northernmost_Northing = 28.0003f; // float
+  :sourceUrl = "(local files)";
+  :Southernmost_Northing = 27.9998f; // float
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :subsetVariables = "ship";
+  :summary = "This is the sample summary.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Test of JSON Lines CSV";
+  :Westernmost_Easting = -132.0014f; // float
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :license = "))
+            + expected.substring(expected.indexOf("  :sourceUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :license = "))
+            + results.substring(results.indexOf("  :sourceUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("    char status(row=6);"))
+            + expected.substring(expected.indexOf("    double testLong(row=6);"));
+    results =
+        results.substring(0, results.indexOf("    char status(row=6);"))
+            + results.substring(results.indexOf("    double testLong(row=6);"));
+    expected = removeLineStartsWithIfExist("  :Easternmost_Easting = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lat_max = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lat_min = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lon_max = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lon_min = ", expected);
+    expected = removeLineStartsWithIfExist("  :Northernmost_Northing = ", expected);
+    expected = removeLineStartsWithIfExist("  :Southernmost_Northing = ", expected);
+    expected = removeLineStartsWithIfExist("  :Westernmost_Easting = ", expected);
+    results = removeLineStartsWithIfExist("  :Easternmost_Easting = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lat_max = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lat_min = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lon_max = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lon_min = ", results);
+    results = removeLineStartsWithIfExist("  :Northernmost_Northing = ", results);
+    results = removeLineStartsWithIfExist("  :Southernmost_Northing = ", results);
+    results = removeLineStartsWithIfExist("  :Westernmost_Easting = ", results);
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "time,ship,sst&time=2017-03-23T02:45",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className() + "_1time",
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results =
+        results.replaceFirst(
+            "^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromJsonlCSVFiles_1time.nc {");
+    expected =
+"""
+netcdf EDDTableFromJsonlCSVFiles_1time.nc {
+  dimensions:
+    row = 1;
+    ship_strlen = 15;
+  variables:
+    double time(row=1);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.4902371E9, 1.4902371E9; // double
+      :axis = "T";
+      :ioos_category = "Time";
+      :long_name = "Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    char ship(row=1, ship_strlen=15);
+      :_Encoding = "ISO-8859-1";
+      :cf_role = "trajectory_id";
+      :ioos_category = "Identifier";
+      :long_name = "Ship";
+
+    float sst(row=1);
+      :actual_range = 10.7f, 10.7f; // float
+      :ioos_category = "Temperature";
+      :long_name = "Sea Surface Temperature";
+      :units = "degree_C";
+
+  // global attributes:
+  :cdm_data_type = "Trajectory";
+  :cdm_trajectory_variables = "ship";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :Easternmost_Easting = -130.2576; // double
+  :featureType = "Trajectory";
+  :geospatial_lat_max = 28.0003; // double
+  :geospatial_lat_min = 27.9998; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = -130.2576; // double
+  :geospatial_lon_min = -132.0014; // double
+  :geospatial_lon_units = "degrees_east";
+  :history = "YYYY-MM-DDTHH:mm:ssZ (local files)
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/tabledap/testJsonlCSV.ncHeader?time,ship,sst&time=2017-03-23T02:45";
+  :id = "testJsonlCSV";
+  :infoUrl = "https://jsonlines.org/examples/";
+  :institution = "jsonlines.org";
+  :keywords = "data, latitude, local, long, longitude, sea, ship, source, sst, status, surface, temperature, test, testLong, time";
+  :license = "The data may be used and redistributed for free but is not intended
+for legal use, since it may contain inaccuracies. Neither the data
+Contributor, ERD, NOAA, nor the United States Government, nor any
+of their employees or contractors, makes any warranty, express or
+implied, including warranties of merchantability and fitness for a
+particular purpose, or assumes any legal liability for the accuracy,
+completeness, or usefulness, of this information.";
+  :sourceUrl = "(local files)";
+  :Southernmost_Northing = 27.9998; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :subsetVariables = "ship";
+  :summary = "This is the sample summary.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Test of JSON Lines CSV";
+  :Westernmost_Easting = -132.0014; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :license = "))
+            + expected.substring(expected.indexOf("  :sourceUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :license = "))
+            + results.substring(results.indexOf("  :sourceUrl = "));
+    expected = removeLineStartsWithIfExist("  :Easternmost_Easting = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lat_max = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lat_min = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lon_max = ", expected);
+    expected = removeLineStartsWithIfExist("  :geospatial_lon_min = ", expected);
+    expected = removeLineStartsWithIfExist("  :Northernmost_Northing = ", expected);
+    expected = removeLineStartsWithIfExist("  :Southernmost_Northing = ", expected);
+    expected = removeLineStartsWithIfExist("  :Westernmost_Easting = ", expected);
+    results = removeLineStartsWithIfExist("  :Easternmost_Easting = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lat_max = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lat_min = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lon_max = ", results);
+    results = removeLineStartsWithIfExist("  :geospatial_lon_min = ", results);
+    results = removeLineStartsWithIfExist("  :Northernmost_Northing = ", results);
+    results = removeLineStartsWithIfExist("  :Southernmost_Northing = ", results);
+    results = removeLineStartsWithIfExist("  :Westernmost_Easting = ", results);
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+  }
+
+  private static String removeLineStartsWithIfExist(String toFind, String longString) {
+    int po = longString.indexOf(toFind);
+    if (po >= 0) {
+      int endLine = longString.indexOf('\n', po);
+      if (endLine >= 0) {
+        longString = longString.substring(0, po) + longString.substring(endLine + 1);
+      } else {
+        longString = longString.substring(0, po);
+      }
+    }
+    return longString;
+  }
+
+  /**
+   * @throws Throwable if trouble
+   */
+  @Test
+  void testGridFromDap() throws Throwable {
+    int language = 0;
+    String tName, results, expected;
+
+    EDD edd = EDDTestDataset.gethawaii_d90f_20ee_c4cb();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "temp[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],"
+                + "salt[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],"
+                + "u[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],"
+                + "v[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],"
+                + "w[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)]",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results = results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDGridFromDap.nc {");
+    expected =
+"""
+netcdf EDDGridFromDap.nc {
+  dimensions:
+    time = 1;
+    depth = 19;
+    latitude = 1;
+    longitude = 1;
+  variables:
+    double time(time=1);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.0083744E9, 1.0083744E9; // double
+      :axis = "T";
+      :ioos_category = "Time";
+      :legacy_time_adjust = "true";
+      :long_name = "Centered Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    double depth(depth=19);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "down";
+      :actual_range = 5.01, 465.91; // double
+      :axis = "Z";
+      :ioos_category = "Location";
+      :long_name = "Depth";
+      :positive = "down";
+      :standard_name = "depth";
+      :units = "m";
+
+    double latitude(latitude=1);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 23.25, 23.25; // double
+      :axis = "Y";
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double longitude(longitude=1);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = 185.25, 185.25; // double
+      :axis = "X";
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float temp(time=1, depth=19, latitude=1, longitude=1);
+      :_FillValue = -9.99E33f; // float
+      :colorBarMaximum = 32.0; // double
+      :colorBarMinimum = 0.0; // double
+      :ioos_category = "Temperature";
+      :long_name = "Sea Water Temperature";
+      :missing_value = -9.99E33f; // float
+      :standard_name = "sea_water_temperature";
+      :units = "degree_C";
+
+    float salt(time=1, depth=19, latitude=1, longitude=1);
+      :_FillValue = -9.99E33f; // float
+      :colorBarMaximum = 37.0; // double
+      :colorBarMinimum = 32.0; // double
+      :ioos_category = "Salinity";
+      :long_name = "Sea Water Practical Salinity";
+      :missing_value = -9.99E33f; // float
+      :standard_name = "sea_water_practical_salinity";
+      :units = "PSU";
+
+    float u(time=1, depth=19, latitude=1, longitude=1);
+      :_FillValue = -9.99E33f; // float
+      :colorBarMaximum = 0.5; // double
+      :colorBarMinimum = -0.5; // double
+      :ioos_category = "Currents";
+      :long_name = "Eastward Sea Water Velocity";
+      :missing_value = -9.99E33f; // float
+      :standard_name = "eastward_sea_water_velocity";
+      :units = "m s-1";
+
+    float v(time=1, depth=19, latitude=1, longitude=1);
+      :_FillValue = -9.99E33f; // float
+      :colorBarMaximum = 0.5; // double
+      :colorBarMinimum = -0.5; // double
+      :ioos_category = "Currents";
+      :long_name = "Northward Sea Water Velocity";
+      :missing_value = -9.99E33f; // float
+      :standard_name = "northward_sea_water_velocity";
+      :units = "m s-1";
+
+    float w(time=1, depth=19, latitude=1, longitude=1);
+      :_FillValue = -9.99E33f; // float
+      :colorBarMaximum = 1.0E-5; // double
+      :colorBarMinimum = -1.0E-5; // double
+      :comment = "WARNING: Please use this variable\\'s data with caution.";
+      :ioos_category = "Currents";
+      :long_name = "Upward Sea Water Velocity";
+      :missing_value = -9.99E33f; // float
+      :standard_name = "upward_sea_water_velocity";
+      :units = "m s-1";
+
+  // global attributes:
+  :cdm_data_type = "Grid";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :dataType = "Grid";
+  :defaultDataQuery = "temp[last][0][0:last][0:last],salt[last][0][0:last][0:last],u[last][0][0:last][0:last],v[last][0][0:last][0:last],w[last][0][0:last][0:last]";
+  :defaultGraphQuery = "temp[last][0][0:last][0:last]&.draw=surface&.vars=longitude|latitude|temp";
+  :documentation = "http://apdrc.soest.hawaii.edu/datadoc/soda_2.2.4.php";
+  :Easternmost_Easting = 185.25; // double
+  :geospatial_lat_max = 23.25; // double
+  :geospatial_lat_min = 23.25; // double
+  :geospatial_lat_resolution = 0.5; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = 185.25; // double
+  :geospatial_lon_min = 185.25; // double
+  :geospatial_lon_resolution = 0.5; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 465.91; // double
+  :geospatial_vertical_min = 5.01; // double
+  :geospatial_vertical_positive = "down";
+  :geospatial_vertical_units = "m";
+  :history = "Fri Nov 07 05:28:17 HST 2025 : imported by GrADS Data Server 2.0
+YYYY-MM-DDTHH:mm:ssZ http://apdrc.soest.hawaii.edu/dods/public_data/SODA/soda_pop2.2.4
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/griddap/hawaii_d90f_20ee_c4cb.ncHeader?temp[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],salt[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],u[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],v[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)],w[(2001-12-15T00:00:00)][(5.01):(500)][(23.1)][(185.2)]";
+  :infoUrl = "https://www.atmos.umd.edu/~ocean/";
+  :institution = "TAMU/UMD";
+  :keywords = "circulation, currents, density, depths, Earth Science > Oceans > Ocean Circulation > Ocean Currents, Earth Science > Oceans > Ocean Temperature > Water Temperature, Earth Science > Oceans > Salinity/Density > Salinity, eastward, eastward_sea_water_velocity, means, monthly, northward, northward_sea_water_velocity, ocean, oceans, pop, salinity, sea, sea_water_practical_salinity, sea_water_temperature, seawater, soda, tamu, temperature, umd, upward, upward_sea_water_velocity, velocity, water";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended
+for legal use, since it may contain inaccuracies. Neither the data
+Contributor, ERD, NOAA, nor the United States Government, nor any
+of their employees or contractors, makes any warranty, express or
+implied, including warranties of merchantability and fitness for a
+particular purpose, or assumes any legal liability for the accuracy,
+completeness, or usefulness, of this information.";
+  :Northernmost_Northing = 23.25; // double
+  :sourceUrl = "http://apdrc.soest.hawaii.edu/dods/public_data/SODA/soda_pop2.2.4";
+  :Southernmost_Northing = 23.25; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :summary = "Simple Ocean Data Assimilation (SODA) version 2.2.4 - A reanalysis of ocean\s
+climate. SODA uses the GFDL modular ocean model version 2.2. The model is\s
+forced by observed surface wind stresses from the COADS data set (from 1958\s
+to 1992) and from NCEP (after 1992). Note that the wind stresses were\s
+detrended before use due to inconsistencies with observed sea level pressure\s
+trends. The model is also constrained by constant assimilation of observed\s
+temperatures, salinities, and altimetry using an optimal data assimilation\s
+technique. The observed data comes from: 1) The World Ocean Atlas 1994 which\s
+contains ocean temperatures and salinities from mechanical\s
+bathythermographs, expendable bathythermographs and conductivity-temperature-
+depth probes. 2) The expendable bathythermograph archive 3) The TOGA-TAO\s
+thermistor array 4) The Soviet SECTIONS tropical program 5) Satellite\s
+altimetry from Geosat, ERS/1 and TOPEX/Poseidon.\s
+We are now exploring an eddy-permitting reanalysis based on the Parallel\s
+Ocean Program POP-1.4 model with 40 levels in the vertical and a 0.4x0.25\s
+degree displaced pole grid (25 km resolution in the western North\s
+Atlantic).  The first version of this we will release is SODA1.2, a\s
+reanalysis driven by ERA-40 winds covering the period 1958-2001 (extended to\s
+the current year using available altimetry).";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "SODA - POP 2.2.4 Monthly Means, 1871-2010 (At Depths)";
+  :Westernmost_Easting = 185.25; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :license = "))
+            + expected.substring(expected.indexOf("  :Northernmost_Northing = "));
+    results =
+        results.substring(0, results.indexOf("  :license = "))
+            + results.substring(results.indexOf("  :Northernmost_Northing = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    int commentStart = expected.indexOf("      :comment = ");
+    expected =
+        expected.substring(0, commentStart)
+            + expected.substring(expected.indexOf("      :ioos_category = ", commentStart));
+    commentStart = results.indexOf("      :comment = ");
+    results =
+        results.substring(0, commentStart)
+            + results.substring(results.indexOf("      :ioos_category = ", commentStart));
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+  }
+
+  /**
+   * @throws Throwable if trouble
+   */
+  @Test
+  void testgridCopy() throws Throwable {
+    int language = 0;
+    String tName, results, expected;
+
+    EDD edd = EDDTestDataset.gettestGridCopy();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results = results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDGridCopy.nc {");
+    expected =
+"""
+netcdf EDDGridCopy.nc {
+  dimensions:
+    time = 10;
+    altitude = 1;
+    latitude = 720;
+    longitude = 1440;
+  variables:
+    double time(time=10);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.1991888E9, 1.1999664E9; // double
+      :axis = "T";
+      :fraction_digits = 0; // int
+      :ioos_category = "Time";
+      :long_name = "Centered Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    double altitude(altitude=1);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "up";
+      :actual_range = 0.0, 0.0; // double
+      :axis = "Z";
+      :fraction_digits = 0; // int
+      :ioos_category = "Location";
+      :long_name = "Altitude";
+      :positive = "up";
+      :standard_name = "altitude";
+      :units = "m";
+
+    double latitude(latitude=720);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = -89.875, 89.875; // double
+      :axis = "Y";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :point_spacing = "even";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double longitude(longitude=1440);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = 0.125, 359.875; // double
+      :axis = "X";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :point_spacing = "even";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float x_wind(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Zonal Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "x_wind";
+      :units = "m s-1";
+
+    float y_wind(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Meridional Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "y_wind";
+      :units = "m s-1";
+
+    float mod(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 18.0; // double
+      :colorBarMinimum = 0.0; // double
+      :colorBarPalette = "WhiteRedBlack";
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Modulus of Wind";
+      :missing_value = -9999999.0f; // float
+      :units = "m s-1";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD";
+  :cdm_data_type = "Grid";
+  :composite = "true";
+  :contributor_name = "Remote Sensing Systems, Inc";
+  :contributor_role = "Source of level 2 data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA CoastWatch, West Coast Node";
+  :creator_url = "https://coastwatch.pfeg.noaa.gov";
+  :date_created = "2008-08-29";
+  :date_issued = "2008-08-29";
+  :Easternmost_Easting = 359.875; // double
+  :geospatial_lat_max = 89.875; // double
+  :geospatial_lat_min = -89.875; // double
+  :geospatial_lat_resolution = 0.25; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = 359.875; // double
+  :geospatial_lon_min = 0.125; // double
+  :geospatial_lon_resolution = 0.25; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 0.0; // double
+  :geospatial_vertical_min = 0.0; // double
+  :geospatial_vertical_positive = "up";
+  :geospatial_vertical_units = "m";
+  :history = "Remote Sensing Systems, Inc
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/griddap/testGridCopy.ncHeader";
+  :infoUrl = "https://coastwatch.pfeg.noaa.gov/infog/QS_ux10_las.html";
+  :institution = "NOAA CoastWatch, West Coast Node";
+  :keywords = "Earth Science > Oceans > Ocean Winds > Surface Winds";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 89.875; // double
+  :origin = "Remote Sensing Systems, Inc";
+  :processing_level = "3";
+  :project = "CoastWatch (https://coastwatch.noaa.gov/)";
+  :projection = "geographic";
+  :projection_type = "mapped";
+  :references = "RSS Inc. Winds: http://www.remss.com/ .";
+  :satellite = "QuikSCAT";
+  :sensor = "SeaWinds";
+  :source = "satellite observation: QuikSCAT, SeaWinds";
+  :sourceUrl = "http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day";
+  :Southernmost_Northing = -89.875; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :summary = "Remote Sensing Inc. distributes science quality wind velocity data from the SeaWinds instrument onboard NASA\\'s QuikSCAT satellite.  SeaWinds is a microwave scatterometer designed to measure surface winds over the global ocean.  Wind velocity fields are provided in zonal, meriodonal, and modulus sets. The reference height for all wind velocities is 10 meters.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)";
+  :Westernmost_Easting = 0.125; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className() + "_ywind",
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results = results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDGridCopy_ywind.nc {");
+    expected =
+"""
+netcdf EDDGridCopy_ywind.nc {
+  dimensions:
+    time = 1;
+    altitude = 1;
+    latitude = 1;
+    longitude = 11;
+  variables:
+    double time(time=1);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.1999664E9, 1.1999664E9; // double
+      :axis = "T";
+      :fraction_digits = 0; // int
+      :ioos_category = "Time";
+      :long_name = "Centered Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    double altitude(altitude=1);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "up";
+      :actual_range = 0.0, 0.0; // double
+      :axis = "Z";
+      :fraction_digits = 0; // int
+      :ioos_category = "Location";
+      :long_name = "Altitude";
+      :positive = "up";
+      :standard_name = "altitude";
+      :units = "m";
+
+    double latitude(latitude=1);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 36.625, 36.625; // double
+      :axis = "Y";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :point_spacing = "even";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double longitude(longitude=11);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = 230.125, 237.625; // double
+      :axis = "X";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :point_spacing = "even";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float y_wind(time=1, altitude=1, latitude=1, longitude=11);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Meridional Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "y_wind";
+      :units = "m s-1";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD";
+  :cdm_data_type = "Grid";
+  :composite = "true";
+  :contributor_name = "Remote Sensing Systems, Inc";
+  :contributor_role = "Source of level 2 data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA CoastWatch, West Coast Node";
+  :creator_url = "https://coastwatch.pfeg.noaa.gov";
+  :date_created = "2008-08-29";
+  :date_issued = "2008-08-29";
+  :Easternmost_Easting = 237.625; // double
+  :geospatial_lat_max = 36.625; // double
+  :geospatial_lat_min = 36.625; // double
+  :geospatial_lat_resolution = 0.25; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = 237.625; // double
+  :geospatial_lon_min = 230.125; // double
+  :geospatial_lon_resolution = 0.25; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 0.0; // double
+  :geospatial_vertical_min = 0.0; // double
+  :geospatial_vertical_positive = "up";
+  :geospatial_vertical_units = "m";
+  :history = "Remote Sensing Systems, Inc
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/griddap/testGridCopy.ncHeader?y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
+  :infoUrl = "https://coastwatch.pfeg.noaa.gov/infog/QS_ux10_las.html";
+  :institution = "NOAA CoastWatch, West Coast Node";
+  :keywords = "Earth Science > Oceans > Ocean Winds > Surface Winds";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 36.625; // double
+  :origin = "Remote Sensing Systems, Inc";
+  :processing_level = "3";
+  :project = "CoastWatch (https://coastwatch.noaa.gov/)";
+  :projection = "geographic";
+  :projection_type = "mapped";
+  :references = "RSS Inc. Winds: http://www.remss.com/ .";
+  :satellite = "QuikSCAT";
+  :sensor = "SeaWinds";
+  :source = "satellite observation: QuikSCAT, SeaWinds";
+  :sourceUrl = "http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day";
+  :Southernmost_Northing = 36.625; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :summary = "Remote Sensing Inc. distributes science quality wind velocity data from the SeaWinds instrument onboard NASA\\'s QuikSCAT satellite.  SeaWinds is a microwave scatterometer designed to measure surface winds over the global ocean.  Wind velocity fields are provided in zonal, meriodonal, and modulus sets. The reference height for all wind velocities is 10 meters.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)";
+  :Westernmost_Easting = 230.125; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+  }
+
+  /**
+   * @throws Throwable if trouble
+   */
+  @Test
+  void testGridNcFiles() throws Throwable {
+    int language = 0;
+    String tName, results, expected;
+
+    EDD edd = EDDTestDataset.gettestGriddedNcFiles();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results = results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDGridFromNcFiles.nc {");
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    expected =
+"""
+netcdf EDDGridFromNcFiles.nc {
+  dimensions:
+    time = 10;
+    altitude = 1;
+    latitude = 720;
+    longitude = 1440;
+  variables:
+    double time(time=10);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.1991888E9, 1.1999664E9; // double
+      :axis = "T";
+      :fraction_digits = 0; // int
+      :ioos_category = "Time";
+      :long_name = "Centered Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    double altitude(altitude=1);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "up";
+      :actual_range = 0.0, 0.0; // double
+      :axis = "Z";
+      :fraction_digits = 0; // int
+      :ioos_category = "Location";
+      :long_name = "Altitude";
+      :positive = "up";
+      :standard_name = "altitude";
+      :units = "m";
+
+    double latitude(latitude=720);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = -89.875, 89.875; // double
+      :axis = "Y";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :point_spacing = "even";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double longitude(longitude=1440);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = 0.125, 359.875; // double
+      :axis = "X";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :point_spacing = "even";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float x_wind(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Zonal Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "x_wind";
+      :units = "m s-1";
+
+    float y_wind(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Meridional Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "y_wind";
+      :units = "m s-1";
+
+    float mod(time=10, altitude=1, latitude=720, longitude=1440);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 18.0; // double
+      :colorBarMinimum = 0.0; // double
+      :colorBarPalette = "WhiteRedBlack";
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Modulus of Wind";
+      :missing_value = -9999999.0f; // float
+      :units = "m s-1";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD";
+  :cdm_data_type = "Grid";
+  :composite = "true";
+  :contributor_name = "Remote Sensing Systems, Inc";
+  :contributor_role = "Source of level 2 data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA CoastWatch, West Coast Node";
+  :creator_url = "https://coastwatch.pfeg.noaa.gov";
+  :date_created = "2008-08-29";
+  :date_issued = "2008-08-29";
+  :Easternmost_Easting = 359.875; // double
+  :geospatial_lat_max = 89.875; // double
+  :geospatial_lat_min = -89.875; // double
+  :geospatial_lat_resolution = 0.25; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = 359.875; // double
+  :geospatial_lon_min = 0.125; // double
+  :geospatial_lon_resolution = 0.25; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 0.0; // double
+  :geospatial_vertical_min = 0.0; // double
+  :geospatial_vertical_positive = "up";
+  :geospatial_vertical_units = "m";
+  :history = "Remote Sensing Systems, Inc
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/griddap/testGriddedNcFiles.ncHeader";
+  :infoUrl = "https://coastwatch.pfeg.noaa.gov/infog/QS_ux10_las.html";
+  :institution = "NOAA CoastWatch, West Coast Node";
+  :keywords = "Earth Science > Oceans > Ocean Winds > Surface Winds";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 89.875; // double
+  :origin = "Remote Sensing Systems, Inc";
+  :processing_level = "3";
+  :project = "CoastWatch (https://coastwatch.noaa.gov/)";
+  :projection = "geographic";
+  :projection_type = "mapped";
+  :references = "RSS Inc. Winds: http://www.remss.com/ .";
+  :satellite = "QuikSCAT";
+  :sensor = "SeaWinds";
+  :source = "satellite observation: QuikSCAT, SeaWinds";
+  :sourceUrl = "http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day";
+  :Southernmost_Northing = -89.875; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :summary = "Remote Sensing Inc. distributes science quality wind velocity data from the SeaWinds instrument onboard NASA\\'s QuikSCAT satellite.  SeaWinds is a microwave scatterometer designed to measure surface winds over the global ocean.  Wind velocity fields are provided in zonal, meriodonal, and modulus sets. The reference height for all wind velocities is 10 meters.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)";
+  :Westernmost_Easting = 0.125; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    results = results.replaceAll("\\'", "'");
+    expected = expected.replaceAll("\\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className() + "_ywind",
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDGridFromNcFiles_ywind.nc {");
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    expected =
+"""
+netcdf EDDGridFromNcFiles_ywind.nc {
+  dimensions:
+    time = 1;
+    altitude = 1;
+    latitude = 1;
+    longitude = 11;
+  variables:
+    double time(time=1);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.1999664E9, 1.1999664E9; // double
+      :axis = "T";
+      :fraction_digits = 0; // int
+      :ioos_category = "Time";
+      :long_name = "Centered Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    double altitude(altitude=1);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "up";
+      :actual_range = 0.0, 0.0; // double
+      :axis = "Z";
+      :fraction_digits = 0; // int
+      :ioos_category = "Location";
+      :long_name = "Altitude";
+      :positive = "up";
+      :standard_name = "altitude";
+      :units = "m";
+
+    double latitude(latitude=1);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 36.625, 36.625; // double
+      :axis = "Y";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :point_spacing = "even";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double longitude(longitude=11);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = 230.125, 237.625; // double
+      :axis = "X";
+      :coordsys = "geographic";
+      :fraction_digits = 2; // int
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :point_spacing = "even";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float y_wind(time=1, altitude=1, latitude=1, longitude=11);
+      :_FillValue = -9999999.0f; // float
+      :colorBarMaximum = 15.0; // double
+      :colorBarMinimum = -15.0; // double
+      :coordsys = "geographic";
+      :fraction_digits = 1; // int
+      :ioos_category = "Wind";
+      :long_name = "Meridional Wind";
+      :missing_value = -9999999.0f; // float
+      :standard_name = "y_wind";
+      :units = "m s-1";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD";
+  :cdm_data_type = "Grid";
+  :composite = "true";
+  :contributor_name = "Remote Sensing Systems, Inc";
+  :contributor_role = "Source of level 2 data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA CoastWatch, West Coast Node";
+  :creator_url = "https://coastwatch.pfeg.noaa.gov";
+  :date_created = "2008-08-29";
+  :date_issued = "2008-08-29";
+  :Easternmost_Easting = 237.625; // double
+  :geospatial_lat_max = 36.625; // double
+  :geospatial_lat_min = 36.625; // double
+  :geospatial_lat_resolution = 0.25; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = 237.625; // double
+  :geospatial_lon_min = 230.125; // double
+  :geospatial_lon_resolution = 0.25; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 0.0; // double
+  :geospatial_vertical_min = 0.0; // double
+  :geospatial_vertical_positive = "up";
+  :geospatial_vertical_units = "m";
+  :history = "Remote Sensing Systems, Inc
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/griddap/testGriddedNcFiles.ncHeader?y_wind[(1.1999664e9)][0][(36.5)][(230):3:(238)]";
+  :infoUrl = "https://coastwatch.pfeg.noaa.gov/infog/QS_ux10_las.html";
+  :institution = "NOAA CoastWatch, West Coast Node";
+  :keywords = "Earth Science > Oceans > Ocean Winds > Surface Winds";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 36.625; // double
+  :origin = "Remote Sensing Systems, Inc";
+  :processing_level = "3";
+  :project = "CoastWatch (https://coastwatch.noaa.gov/)";
+  :projection = "geographic";
+  :projection_type = "mapped";
+  :references = "RSS Inc. Winds: http://www.remss.com/ .";
+  :satellite = "QuikSCAT";
+  :sensor = "SeaWinds";
+  :source = "satellite observation: QuikSCAT, SeaWinds";
+  :sourceUrl = "http://192.168.31.18/thredds/dodsC/satellite/QS/ux10/1day";
+  :Southernmost_Northing = 36.625; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :summary = "Remote Sensing Inc. distributes science quality wind velocity data from the SeaWinds instrument onboard NASA\\'s QuikSCAT satellite.  SeaWinds is a microwave scatterometer designed to measure surface winds over the global ocean.  Wind velocity fields are provided in zonal, meriodonal, and modulus sets. The reference height for all wind velocities is 10 meters.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Wind, QuikSCAT, Global, Science Quality (1 Day Composite)";
+  :Westernmost_Easting = 230.125; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+  }
+
+  /**
+   * @throws Throwable if trouble
+   */
+  @Test
+  void testTableNcFiles() throws Throwable {
+    int language = 0;
+    String tName, results, expected;
+
+    EDD edd = EDDTestDataset.geterdCinpKfmSFNH();
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className(),
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results = results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromNcFiles.nc {");
+    expected =
+"""
+netcdf EDDTableFromNcFiles.nc {
+  dimensions:
+    row = 263242;
+    id_strlen = 35;
+    common_name_strlen = 22;
+    species_name_strlen = 31;
+  variables:
+    char id(row=263242, id_strlen=35);
+      :_Encoding = "ISO-8859-1";
+      :cf_role = "timeseries_id";
+      :ioos_category = "Identifier";
+      :long_name = "Station Identifier";
+
+    double longitude(row=263242);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = -120.4, -118.4; // double
+      :axis = "X";
+      :colorBarMaximum = -118.4; // double
+      :colorBarMinimum = -120.4; // double
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    double latitude(row=263242);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 32.8, 34.05; // double
+      :axis = "Y";
+      :colorBarMaximum = 34.5; // double
+      :colorBarMinimum = 32.5; // double
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double depth(row=263242);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "down";
+      :actual_range = 5.0, 17.0; // double
+      :axis = "Z";
+      :colorBarMaximum = 20.0; // double
+      :colorBarMinimum = 0.0; // double
+      :ioos_category = "Location";
+      :long_name = "Depth";
+      :positive = "down";
+      :standard_name = "depth";
+      :units = "m";
+
+    double time(row=263242);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 4.89024E8, 1.183248E9; // double
+      :axis = "T";
+      :colorBarMaximum = 1.183248E9; // double
+      :colorBarMinimum = 4.89024E8; // double
+      :ioos_category = "Time";
+      :long_name = "Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    char common_name(row=263242, common_name_strlen=22);
+      :_Encoding = "ISO-8859-1";
+      :ioos_category = "Taxonomy";
+      :long_name = "Common Name";
+
+    char species_name(row=263242, species_name_strlen=31);
+      :_Encoding = "ISO-8859-1";
+      :ioos_category = "Taxonomy";
+      :long_name = "Species Name";
+
+    short size(row=263242);
+      :_FillValue = 32767S; // short
+      :actual_range = 1S, 385S; // short
+      :ioos_category = "Biology";
+      :long_name = "Size";
+      :units = "mm";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD, Channel Islands National Park, National Park Service";
+  :cdm_data_type = "TimeSeries";
+  :cdm_timeseries_variables = "id, longitude, latitude";
+  :contributor_email = "David_Kushner@nps.gov";
+  :contributor_name = "Channel Islands National Park, National Park Service";
+  :contributor_role = "Source of data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA NMFS SWFSC ERD";
+  :creator_type = "institution";
+  :creator_url = "https://www.pfeg.noaa.gov";
+  :date_created = "YYYY-MM-DDTHH:mm:ssZ";
+  :date_issued = "YYYY-MM-DDTHH:mm:ssZ";
+  :Easternmost_Easting = -118.4; // double
+  :featureType = "TimeSeries";
+  :geospatial_lat_max = 34.05; // double
+  :geospatial_lat_min = 32.8; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = -118.4; // double
+  :geospatial_lon_min = -120.4; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 17.0; // double
+  :geospatial_vertical_min = 5.0; // double
+  :geospatial_vertical_positive = "down";
+  :geospatial_vertical_units = "m";
+  :history = "Channel Islands National Park, National Park Service
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ (local files)
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/tabledap/erdCinpKfmSFNH.ncHeader";
+  :id = "erdCinpKfmSFNH";
+  :infoUrl = "https://www.nps.gov/chis/naturescience/index.htm";
+  :institution = "CINP";
+  :keywords = "aquatic, atmosphere, biology, biosphere, channel, cinp, coastal, common, depth, Earth Science > Biosphere > Aquatic Ecosystems > Coastal Habitat, Earth Science > Biosphere > Aquatic Ecosystems > Marine Habitat, ecosystems, forest, frequency, habitat, height, identifier, islands, kelp, marine, monitoring, name, natural, size, species, station, taxonomy, time";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.  National Park Service Disclaimer: The National Park Service shall not be held liable for improper or incorrect use of the data described and/or contained herein. These data and related graphics are not legal documents and are not intended to be used as such. The information contained in these data is dynamic and may change over time. The data are not better than the original sources from which they were derived. It is the responsibility of the data user to use the data appropriately and consistent within the limitation of geospatial data in general and these data in particular. The related graphics are intended to aid the data user in acquiring relevant data; it is not appropriate to use the related graphics as data. The National Park Service gives no warranty, expressed or implied, as to the accuracy, reliability, or completeness of these data. It is strongly recommended that these data are directly acquired from an NPS server and not indirectly through other sources which may have changed the data in some way. Although these data have been processed successfully on computer systems at the National Park Service, no warranty expressed or implied is made regarding the utility of the data on other systems for general or scientific purposes, nor shall the act of distribution constitute any such warranty. This disclaimer applies both to individual use of the data and aggregate use with other data.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 34.05; // double
+  :observationDimension = "row";
+  :project = "NOAA NMFS SWFSC ERD (https://www.pfeg.noaa.gov/)";
+  :references = "Channel Islands National Parks Inventory and Monitoring information: http://nature.nps.gov/im/units/medn . Kelp Forest Monitoring Protocols: http://www.nature.nps.gov/im/units/chis/Reports_PDF/Marine/KFM-HandbookVol1.pdf .";
+  :sourceUrl = "(local files)";
+  :Southernmost_Northing = 32.8; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :subsetVariables = "id, longitude, latitude, common_name, species_name";
+  :summary = "This dataset has measurements of the size of selected animal species at selected locations in the Channel Islands National Park. Sampling is conducted annually between the months of May-October, so the Time data in this file is July 1 of each year (a nominal value). The size frequency measurements were taken within 10 meters of the transect line at each site.  Depths at the site vary some, but we describe the depth of the site along the transect line where that station\\'s temperature logger is located, a typical depth for the site.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Channel Islands, Kelp Forest Monitoring, Size and Frequency, Natural Habitat, 1985-2007";
+  :Westernmost_Easting = -120.4; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+
+    tName =
+        edd.makeNewFileForDapQuery(
+            language,
+            null,
+            null,
+            "&longitude=-119.05&latitude=33.46666666666&time=2005-07-01T00:00:00",
+            EDStatic.config.fullTestCacheDirectory,
+            edd.className() + "_1time",
+            ".ncHeader");
+    results = File2.directReadFrom88591File(EDStatic.config.fullTestCacheDirectory + tName);
+    results =
+        results.replaceAll("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z", "YYYY-MM-DDTHH:mm:ssZ");
+    results =
+        results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromNcFiles_1time.nc {");
+    expected =
+"""
+netcdf EDDTableFromNcFiles_1time.nc {
+  dimensions:
+    row = 681;
+    id_strlen = 30;
+    common_name_strlen = 21;
+    species_name_strlen = 31;
+  variables:
+    char id(row=681, id_strlen=30);
+      :_Encoding = "ISO-8859-1";
+      :cf_role = "timeseries_id";
+      :ioos_category = "Identifier";
+      :long_name = "Station Identifier";
+
+    double longitude(row=681);
+      :_CoordinateAxisType = "Lon";
+      :actual_range = -119.05, -119.05; // double
+      :axis = "X";
+      :colorBarMaximum = -118.4; // double
+      :colorBarMinimum = -120.4; // double
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    double latitude(row=681);
+      :_CoordinateAxisType = "Lat";
+      :actual_range = 33.4666666666667, 33.4666666666667; // double
+      :axis = "Y";
+      :colorBarMaximum = 34.5; // double
+      :colorBarMinimum = 32.5; // double
+      :ioos_category = "Location";
+      :long_name = "Latitude";
+      :standard_name = "latitude";
+      :units = "degrees_north";
+
+    double depth(row=681);
+      :_CoordinateAxisType = "Height";
+      :_CoordinateZisPositive = "down";
+      :actual_range = 14.0, 14.0; // double
+      :axis = "Z";
+      :colorBarMaximum = 20.0; // double
+      :colorBarMinimum = 0.0; // double
+      :ioos_category = "Location";
+      :long_name = "Depth";
+      :positive = "down";
+      :standard_name = "depth";
+      :units = "m";
+
+    double time(row=681);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.120176E9, 1.120176E9; // double
+      :axis = "T";
+      :colorBarMaximum = 1.183248E9; // double
+      :colorBarMinimum = 4.89024E8; // double
+      :ioos_category = "Time";
+      :long_name = "Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since YYYY-MM-DDTHH:mm:ssZ";
+
+    char common_name(row=681, common_name_strlen=21);
+      :_Encoding = "ISO-8859-1";
+      :ioos_category = "Taxonomy";
+      :long_name = "Common Name";
+
+    char species_name(row=681, species_name_strlen=31);
+      :_Encoding = "ISO-8859-1";
+      :ioos_category = "Taxonomy";
+      :long_name = "Species Name";
+
+    short size(row=681);
+      :_FillValue = 32767S; // short
+      :actual_range = 5S, 171S; // short
+      :ioos_category = "Biology";
+      :long_name = "Size";
+      :units = "mm";
+
+  // global attributes:
+  :acknowledgement = "NOAA NESDIS COASTWATCH, NOAA SWFSC ERD, Channel Islands National Park, National Park Service";
+  :cdm_data_type = "TimeSeries";
+  :cdm_timeseries_variables = "id, longitude, latitude";
+  :contributor_email = "David_Kushner@nps.gov";
+  :contributor_name = "Channel Islands National Park, National Park Service";
+  :contributor_role = "Source of data.";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :creator_email = "erd.data@noaa.gov";
+  :creator_name = "NOAA NMFS SWFSC ERD";
+  :creator_type = "institution";
+  :creator_url = "https://www.pfeg.noaa.gov";
+  :date_created = "YYYY-MM-DDTHH:mm:ssZ";
+  :date_issued = "YYYY-MM-DDTHH:mm:ssZ";
+  :Easternmost_Easting = -119.05; // double
+  :featureType = "TimeSeries";
+  :geospatial_lat_max = 33.4666666666667; // double
+  :geospatial_lat_min = 33.4666666666667; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = -119.05; // double
+  :geospatial_lon_min = -119.05; // double
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 14.0; // double
+  :geospatial_vertical_min = 14.0; // double
+  :geospatial_vertical_positive = "down";
+  :geospatial_vertical_units = "m";
+  :history = "Channel Islands National Park, National Park Service
+YYYY-MM-DDTHH:mm:ssZ NOAA CoastWatch (West Coast Node) and NOAA SFSC ERD
+YYYY-MM-DDTHH:mm:ssZ (local files)
+YYYY-MM-DDTHH:mm:ssZ http://localhost:8080/erddap/tabledap/erdCinpKfmSFNH.ncHeader?&longitude=-119.05&latitude=33.46666666666&time=2005-07-01T00:00:00";
+  :id = "erdCinpKfmSFNH";
+  :infoUrl = "https://www.nps.gov/chis/naturescience/index.htm";
+  :institution = "CINP";
+  :keywords = "aquatic, atmosphere, biology, biosphere, channel, cinp, coastal, common, depth, Earth Science > Biosphere > Aquatic Ecosystems > Coastal Habitat, Earth Science > Biosphere > Aquatic Ecosystems > Marine Habitat, ecosystems, forest, frequency, habitat, height, identifier, islands, kelp, marine, monitoring, name, natural, size, species, station, taxonomy, time";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :license = "The data may be used and redistributed for free but is not intended for legal use, since it may contain inaccuracies. Neither the data Contributor, CoastWatch, NOAA, nor the United States Government, nor any of their employees or contractors, makes any warranty, express or implied, including warranties of merchantability and fitness for a particular purpose, or assumes any legal liability for the accuracy, completeness, or usefulness, of this information.  National Park Service Disclaimer: The National Park Service shall not be held liable for improper or incorrect use of the data described and/or contained herein. These data and related graphics are not legal documents and are not intended to be used as such. The information contained in these data is dynamic and may change over time. The data are not better than the original sources from which they were derived. It is the responsibility of the data user to use the data appropriately and consistent within the limitation of geospatial data in general and these data in particular. The related graphics are intended to aid the data user in acquiring relevant data; it is not appropriate to use the related graphics as data. The National Park Service gives no warranty, expressed or implied, as to the accuracy, reliability, or completeness of these data. It is strongly recommended that these data are directly acquired from an NPS server and not indirectly through other sources which may have changed the data in some way. Although these data have been processed successfully on computer systems at the National Park Service, no warranty expressed or implied is made regarding the utility of the data on other systems for general or scientific purposes, nor shall the act of distribution constitute any such warranty. This disclaimer applies both to individual use of the data and aggregate use with other data.";
+  :naming_authority = "gov.noaa.pfeg.coastwatch";
+  :Northernmost_Northing = 33.4666666666667; // double
+  :observationDimension = "row";
+  :project = "NOAA NMFS SWFSC ERD (https://www.pfeg.noaa.gov/)";
+  :references = "Channel Islands National Parks Inventory and Monitoring information: http://nature.nps.gov/im/units/medn . Kelp Forest Monitoring Protocols: http://www.nature.nps.gov/im/units/chis/Reports_PDF/Marine/KFM-HandbookVol1.pdf .";
+  :sourceUrl = "(local files)";
+  :Southernmost_Northing = 33.4666666666667; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :subsetVariables = "id, longitude, latitude, common_name, species_name";
+  :summary = "This dataset has measurements of the size of selected animal species at selected locations in the Channel Islands National Park. Sampling is conducted annually between the months of May-October, so the Time data in this file is July 1 of each year (a nominal value). The size frequency measurements were taken within 10 meters of the transect line at each site.  Depths at the site vary some, but we describe the depth of the site along the transect line where that station\\'s temperature logger is located, a typical depth for the site.";
+  :time_coverage_end = "YYYY-MM-DDTHH:mm:ssZ";
+  :time_coverage_start = "YYYY-MM-DDTHH:mm:ssZ";
+  :title = "Channel Islands, Kelp Forest Monitoring, Size and Frequency, Natural Habitat, 1985-2007";
+  :Westernmost_Easting = -119.05; // double
+}
+            """;
+    expected = expected.replaceAll("\r\n", "\n");
+    results = results.replaceAll("\r\n", "\n");
+    expected =
+        expected.substring(0, expected.indexOf("  :history = "))
+            + expected.substring(expected.indexOf("  :infoUrl = "));
+    results =
+        results.substring(0, results.indexOf("  :history = "))
+            + results.substring(results.indexOf("  :infoUrl = "));
+    expected =
+        expected.substring(0, expected.indexOf("  :summary = "))
+            + expected.substring(expected.indexOf("  :time_coverage_end = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    results = results.replaceAll("\'", "'");
+    expected = expected.replaceAll("\'", "'");
+    com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
+  }
+}

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -10633,6 +10633,9 @@ class JettyTests {
         globecBottle.makeNewFileForDapQuery(
             language, null, null, tUserDapQuery, dir, globecBottle.className() + "_Data", ".nc");
     results = NcHelper.ncdump(dir + tName, "");
+    results =
+        results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromNcFiles_Data.nc {");
+    results = results.replaceAll("\r\n", "\n");
     String tHeader1 =
         "netcdf EDDTableFromNcFiles_Data.nc {\n"
             + "  dimensions:\n"
@@ -10779,17 +10782,107 @@ class JettyTests {
             ".ncHeader");
     // TestUtil.displayInBrowser("file://" + dir + tName);
     results = File2.directReadFromUtf8File(dir + tName);
-    String2.log(results);
 
+    results = results.replaceAll("\r\n", "\n");
+    results =
+        results.replaceFirst("^netcdf\\s+(.+?)\\s*\\{", "netcdf EDDTableFromNcFiles_Data.nc {");
+    tHeader1 =
+"""
+netcdf EDDTableFromNcFiles_Data.nc {
+  dimensions:
+    row = 1007;
+    ship_strlen = 11;
+  variables:
+    float longitude(row=1007);
+      :_CoordinateAxisType = "Lon";
+      :_FillValue = 327.67f; // float
+      :actual_range = -126.0f, -124.1f; // float
+      :axis = "X";
+      :ioos_category = "Location";
+      :long_name = "Longitude";
+      :missing_value = 327.67f; // float
+      :standard_name = "longitude";
+      :units = "degrees_east";
+
+    float NO3(row=1007);
+      :_FillValue = -99.0f; // float
+      :actual_range = 0.0f, 99.79f; // float
+      :colorBarMaximum = 50.0; // double
+      :colorBarMinimum = 0.0; // double
+      :ioos_category = "Dissolved Nutrients";
+      :long_name = "Nitrate";
+      :missing_value = -9999.0f; // float
+      :standard_name = "mole_concentration_of_nitrate_in_sea_water";
+      :units = "micromoles L-1";
+
+    double time(row=1007);
+      :_CoordinateAxisType = "Time";
+      :actual_range = 1.02833814E9, 1.02978828E9; // double
+      :axis = "T";
+      :cf_role = "profile_id";
+      :ioos_category = "Time";
+      :long_name = "Time";
+      :standard_name = "time";
+      :time_origin = "01-JAN-1970 00:00:00";
+      :units = "seconds since 1970-01-01T00:00:00Z";
+
+    char ship(row=1007, ship_strlen=11);
+      :_Encoding = "ISO-8859-1";
+      :ioos_category = "Identifier";
+      :long_name = "Ship";
+
+  // global attributes:
+  :cdm_data_type = "TrajectoryProfile";
+  :cdm_profile_variables = "cast, longitude, latitude, time";
+  :cdm_trajectory_variables = "cruise_id, ship";
+  :Conventions = "COARDS, CF-1.6, ACDD-1.3";
+  :Easternmost_Easting = -124.1f; // float
+  :featureType = "TrajectoryProfile";
+  :geospatial_lat_max = 44.65; // double
+  :geospatial_lat_min = 41.9; // double
+  :geospatial_lat_units = "degrees_north";
+  :geospatial_lon_max = -124.1f; // float
+  :geospatial_lon_min = -126.0f; // float
+  :geospatial_lon_units = "degrees_east";
+  :geospatial_vertical_max = 0.0; // double
+  :geospatial_vertical_min = 0.0; // double
+  :geospatial_vertical_positive = "up";
+  :geospatial_vertical_units = "m";
+  :history = """;
+    tHeader1 = tHeader1.replaceAll("\r\n", "\n");
     tResults = results.substring(0, tHeader1.length());
     Test.ensureEqual(tResults, tHeader1, "\nresults=\n" + results);
 
-    expected = tHeader2 + "}\n";
-    tPo = results.indexOf(expected.substring(0, 17));
+    tHeader2 =
+"""
+/erddap/tabledap/testGlobecBottle.ncHeader?longitude,NO3,time,ship&latitude>0&altitude>-5&time>=2002-08-03";
+  :id = "Globec_bottle_data_2002";
+  :infoUrl = "https://en.wikipedia.org/wiki/Global_Ocean_Ecosystem_Dynamics";
+  :institution = "GLOBEC";
+  :keywords = "10um, active, after, ammonia, ammonium, attenuation, biosphere, bottle, cast, chemistry, chlorophyll, chlorophyll-a, color, concentration, concentration_of_chlorophyll_in_sea_water, cruise, data, density, dissolved, dissolved nutrients, dissolved o2, Earth Science > Biosphere > Vegetation > Photosynthetically Active Radiation, Earth Science > Oceans > Ocean Chemistry > Ammonia, Earth Science > Oceans > Ocean Chemistry > Chlorophyll, Earth Science > Oceans > Ocean Chemistry > Nitrate, Earth Science > Oceans > Ocean Chemistry > Nitrite, Earth Science > Oceans > Ocean Chemistry > Nitrogen, Earth Science > Oceans > Ocean Chemistry > Oxygen, Earth Science > Oceans > Ocean Chemistry > Phosphate, Earth Science > Oceans > Ocean Chemistry > Pigments, Earth Science > Oceans > Ocean Chemistry > Silicate, Earth Science > Oceans > Ocean Optics > Attenuation/Transmission, Earth Science > Oceans > Ocean Temperature > Water Temperature, Earth Science > Oceans > Salinity/Density > Salinity, fluorescence, fraction, from, globec, identifier, mass, mole, mole_concentration_of_ammonium_in_sea_water, mole_concentration_of_nitrate_in_sea_water, mole_concentration_of_nitrite_in_sea_water, mole_concentration_of_phosphate_in_sea_water, mole_concentration_of_silicate_in_sea_water, moles, moles_of_nitrate_and_nitrite_per_unit_mass_in_sea_water, n02, nep, nh4, nitrate, nitrite, nitrogen, no3, number, nutrients, o2, ocean, ocean color, oceans, optical, optical properties, optics, oxygen, passing, per, phaeopigments, phosphate, photosynthetically, pigments, plus, po4, properties, radiation, rosette, salinity, screen, sea, sea_water_practical_salinity, sea_water_temperature, seawater, sensor, sensors, ship, silicate, temperature, time, total, transmission, transmissivity, unit, vegetation, voltage, volume, volume_fraction_of_oxygen_in_sea_water, water";
+  :keywords_vocabulary = "GCMD Science Keywords";
+  :Northernmost_Northing = 44.65; // double
+  :sourceUrl = "(local files; contact erd.data@noaa.gov)";
+  :Southernmost_Northing = 41.9; // double
+  :standard_name_vocabulary = "CF Standard Name Table v70";
+  :subsetVariables = "cruise_id, ship, cast, longitude, latitude, time";
+  :time_coverage_end = "2002-08-19T20:18:00Z";
+  :time_coverage_start = "2002-08-03T01:29:00Z";
+  :title = "GLOBEC NEP Rosette Bottle Data (2002)";
+  :Westernmost_Easting = -126.0f; // float
+}
+                """;
+    results =
+        results.substring(0, results.indexOf("  :license = "))
+            + results.substring(results.indexOf("  :Northernmost_Northing = "));
+    results =
+        results.substring(0, results.indexOf("  :summary = "))
+            + results.substring(results.indexOf("  :time_coverage_end = "));
+    tPo = results.indexOf(tHeader2.substring(0, 17));
     Test.ensureTrue(tPo >= 0, "tPo=-1 results=\n" + results);
     Test.ensureEqual(
-        results.substring(tPo, Math.min(results.length(), tPo + expected.length())),
-        expected,
+        results.substring(tPo, Math.min(results.length(), tPo + tHeader2.length())),
+        tHeader2,
         "results=\n" + results);
 
     // .odvTxt
@@ -13880,6 +13973,8 @@ class JettyTests {
     results =
         results.replaceAll(
             ":actual_range = -?[0-9]+.[0-9]+f, -?[0-9]+.[0-9]+f", ":actual_range = MIN, MAX");
+    results = results.replaceAll("\r\n", "\n");
+    expected = expected.replaceAll("\r\n", "\n");
     tPo = results.indexOf("  variables:\n");
     Test.ensureTrue(tPo >= 0, "tPo=-1 results=\n" + results);
     Test.ensureEqual(
@@ -13899,6 +13994,7 @@ class JettyTests {
       results =
           results.replaceAll(
               ":actual_range = -?[0-9]+.[0-9]+f, -?[0-9]+.[0-9]+f", ":actual_range = MIN, MAX");
+      results = results.replaceAll("\r\n", "\n");
       tPo = results.indexOf("  variables:\n");
       Test.ensureTrue(tPo >= 0, "tPo=-1 results=\n" + results);
       Test.ensureEqual(


### PR DESCRIPTION
# Description

There are some very minor changes to the output for the new ncheader files. Mainly some extra metadata, and slightly different handling of ' character.

Besides reducing cache usage (by not writing the nc file to disk), this also drastically speeds up some requests (my profiling says most EDDGrid requests for NCHeader files are now approximately an order of magnitude faster. EDDTable does not get as much benefit since we do more or less the full query (but avoid needing to write the whole thing to disk).

Fixes #264 (already marked as fixed, but this is will drastically reduce the cache used for ncheader requests)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [coming with release updates] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
