### PR TITLE
Docs: add troubleshooting note for corrupted ETOPO download during setup

### DIFF
--- a/PROGRAMMER_GUIDE.md
+++ b/PROGRAMMER_GUIDE.md
@@ -1,2 +1,8 @@
 Moved, now at:
 [https://erddap.github.io/docs/contributing/programmer-guide](https://erddap.github.io/docs/contributing/programmer-guide)
+
+### Troubleshooting Setup
+If `mvn compile` fails with "Archive is not a ZIP archive" for `etopo1_ice_g_i2.zip`:
+1. The download likely timed out and corrupted the file.
+2. Delete `WEB-INF/ref/etopo1_ice_g_i2.zip` and retry.
+3. Workaround: Use `-DskipResourceDownload` to skip the download.


### PR DESCRIPTION
While setting up ERDDAP locally using the Programmer’s Guide, I ran into a Maven build failure related to the etopo1_ice_g_i2.zip download. The initial download timed out, and on the next run Maven skipped re-downloading the file because it already existed, but then failed since the zip was partially downloaded and corrupted.

It took a bit of digging to understand what was going on, so this PR adds a small troubleshooting note to PROGRAMMER_GUIDE.md explaining the issue and how to resolve it. The note suggests deleting the corrupted file and retrying the build, and also mentions -DskipResourceDownload as a workaround when appropriate.

The intention here is to save time for anyone else setting up ERDDAP for the first time who might hit the same problem.