### PR TITLE
add context attribute containing a reference to the Erddap servlet

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -71,6 +71,7 @@ import gov.noaa.pfel.erddap.variable.EDVLatGridAxis;
 import gov.noaa.pfel.erddap.variable.EDVLonGridAxis;
 import gov.noaa.pfel.erddap.variable.EDVTimeGridAxis;
 import io.prometheus.metrics.model.snapshots.Unit;
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -388,6 +389,14 @@ public class Erddap extends HttpServlet {
     public void run() {
       EDStatic.destroy();
     }
+  }
+
+  public static final String ERDDAP_CONTEXT_ATTRIBUTE = "ERDDAP";
+
+  @Override
+  public void init(ServletConfig servletConfig) {
+    // add servlet to context so other servlets can access ERDDAP datasets directly
+    servletConfig.getServletContext().setAttribute(ERDDAP_CONTEXT_ATTRIBUTE, this);
   }
 
   /**


### PR DESCRIPTION
# Description

Add a servlet context attribute that references the Erddap servlet instance. We use this in other servlets to access the active datasets hashmaps in Erddap. Previously these datasets were in the EDStatic, and we developed servlets that accessed the datasets directly. This allows those servlets to still work.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
