### PR TITLE
Support more complex regex for paths

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/FileVisitorDNLS.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/util/FileVisitorDNLS.java
@@ -212,10 +212,24 @@ public class FileVisitorDNLS extends SimpleFileVisitor<Path> {
       return FileVisitResult.CONTINUE;
     }
 
-    // skip because it doesn't match pathRegex?
-    if (pathPattern != null && !pathPattern.matcher(ttDir).matches()) {
-      if (debugMode) String2.log(">> doesn't match pathRegex: " + ttDir + " regex=" + pathRegex);
-      return FileVisitResult.SKIP_SUBTREE;
+    // Validate if directory might match pathRegex
+    if (pathPattern != null) {
+      Matcher matcher = pathPattern.matcher(ttDir);
+      if (!matcher.matches()) {
+        if (recursive && matcher.hitEnd()) {
+          if (debugMode)
+            String2.log(
+                ">> directory path might match pathRegex but doesn't: "
+                    + ttDir
+                    + " regex="
+                    + pathRegex);
+          return FileVisitResult.CONTINUE; // keep looking in subdirs
+        }
+        if (debugMode)
+          String2.log(
+              ">> directory path doesn't match pathRegex: " + ttDir + " regex=" + pathRegex);
+        return FileVisitResult.SKIP_SUBTREE;
+      }
     }
 
     if (directoriesToo) {
@@ -244,6 +258,23 @@ public class FileVisitorDNLS extends SimpleFileVisitor<Path> {
 
       // getParent returns \\ or /, without trailing /
       String ttDir = String2.replaceAll(file.getParent().toString(), fromSlash, toSlash) + toSlash;
+
+      // Validate the full file path against pathRegex (matching S3 behavior)
+      // Using matches() here because we now have the complete file path
+      String fullFilePath = ttDir + name;
+      // Don't apply pathRegex to the initial dir itself, but do apply it to all subdirs and files.
+      if (!(ttDir.equals(dir) && attrs.isRegularFile())
+          && pathPattern != null
+          && !pathPattern.matcher(fullFilePath).matches()) {
+        if (debugMode)
+          String2.log(
+              ">> file's full path doesn't match pathRegex: "
+                  + fullFilePath
+                  + " regex="
+                  + pathRegex);
+        return FileVisitResult.CONTINUE;
+      }
+
       if (debugMode) String2.log(">> add fileName: " + ttDir + name);
       directoryPA.add(ttDir);
       namePA.add(name);

--- a/src/test/java/gov/noaa/pfel/coastwatch/util/FileVisitorDNLSTests.java
+++ b/src/test/java/gov/noaa/pfel/coastwatch/util/FileVisitorDNLSTests.java
@@ -1606,4 +1606,52 @@ class FileVisitorDNLSTests {
     // }
     File2.delete(tgzName);
   }
+
+  /** This tests multi-level pathRegex matching. */
+  @org.junit.jupiter.api.Test
+  void testMultiLevelPathRegex() throws Throwable {
+    String2.log("\n*** FileVisitorDNLS.testMultiLevelPathRegex()");
+
+    String dirPath =
+        File2.addSlash(
+            Path.of(FileVisitorDNLSTests.class.getResource("/data/CFPointConventions/").toURI())
+                .toString()
+                .replace('\\', '/'));
+
+    // Test with pathRegex that requires traversing multiple subdirectories
+    // This tests the fix for the bug where complex path regex patterns didn't work
+    // because intermediate directories were incorrectly filtered out.
+    // The pattern .*/trajectory-Incomplete-Multidimensional.* matches directories containing
+    // "trajectory-Incomplete-Multidimensional" anywhere in their path.
+    Table table =
+        FileVisitorDNLS.oneStep(
+            dirPath,
+            ".*\\.nc$", // match .nc files
+            true, // recursive
+            ".*/trajectory/trajectory-Incomplete-Multidimensional.*", // path regex requiring
+            // traversal through named
+            // subdirectories
+            false /* directories */);
+
+    StringArray directoryPA = (StringArray) table.getColumn(FileVisitorDNLS.DIRECTORY);
+    StringArray namePA = (StringArray) table.getColumn(FileVisitorDNLS.NAME);
+
+    // Should find .nc files in directories matching the pattern
+    Test.ensureTrue(
+        table.nRows() > 0, "Should find at least 1 file matching multi-level pathRegex");
+
+    // All files should be in paths containing "Incomplete-Multidimensional"
+    for (int i = 0; i < table.nRows(); i++) {
+      String fullPath = directoryPA.get(i);
+      Test.ensureTrue(
+          fullPath.contains("Incomplete-Multidimensional"),
+          "File path should contain 'Incomplete-Multidimensional': " + fullPath);
+    }
+
+    // Verify .nc files are found
+    for (int i = 0; i < table.nRows(); i++) {
+      String name = namePA.get(i);
+      Test.ensureTrue(name.endsWith(".nc"), "File name should end with .nc: " + name);
+    }
+  }
 }


### PR DESCRIPTION
# Description

This is to fix an issue raised on the Google Group: https://groups.google.com/g/erddap/c/1vbY652pRuo
Specifcally that complex (multiple folder levels for example) path regex do not behave as expected.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
