### PR TITLE
Optimize Docker entrypoint preinitialization time

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,6 +13,9 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
       export ERDDAP_flagKeyKey=$(cat /proc/sys/kernel/random/uuid)
     fi
 
+    echo "Starting preinitialization"
+    PREINIT_START=$(date +%s%3N)
+
     USER_ID=${TOMCAT_USER_ID:-1000}
     GROUP_ID=${TOMCAT_GROUP_ID:-1000}
 
@@ -35,9 +38,23 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
     # Restrict permissions on conf
     ###
 
-    chown -R $USER_ID:$GROUP_ID ${CATALINA_HOME} && find ${CATALINA_HOME}/conf \
-        -type d -exec chmod 755 {} \; -o -type f -exec chmod 400 {} \;
-    chown -R $USER_ID:$GROUP_ID /erddapData
+    chown -R $USER_ID:$GROUP_ID \
+         ${CATALINA_HOME}/bin \
+         ${CATALINA_HOME}/conf \
+         ${CATALINA_HOME}/content \
+         ${CATALINA_HOME}/logs \
+         ${CATALINA_HOME}/temp \
+         ${CATALINA_HOME}/work
+    find ${CATALINA_HOME}/webapps/erddap -type d -exec chown $USER_ID:$GROUP_ID {} +
+    find ${CATALINA_HOME}/webapps/erddap -type f -name '*.sh' -exec chown $USER_ID:$GROUP_ID {} +
+    find ${CATALINA_HOME}/conf -type d -exec chmod 755 {} +
+    find ${CATALINA_HOME}/conf -type f -exec chmod 400 {} +
+
+    if [ "${SKIP_ERDDAP_DATA_CHOWN:-0}" = "1" ]; then
+      echo "Skipping /erddapData chown due to SKIP_ERDDAP_DATA_CHOWN setting"
+    else
+      chown -R $USER_ID:$GROUP_ID /erddapData
+    fi
     sync
 
     ###
@@ -57,6 +74,9 @@ if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
         fi
       done
     fi
+
+    PREINIT_END=$(date +%s%3N)
+    echo "Preinitialization finished in $(( $PREINIT_END - $PREINIT_START ))ms"
 
     exec setpriv --reuid $USER_ID --regid $GROUP_ID --init-groups "$@"
 fi


### PR DESCRIPTION
# Description

Avoid chowning ERDDAP classes and dependency jars during container start up to speed up launch time. Also add an environment variable SKIP_ERDDAP_DATA_CHOWN to optionally avoid chowing the (potentially large) /erddapData directory. Also time the preinitialization steps and output the total time taken in milliseconds.

Credit @ItaloBorrelli for investigation and optimization suggestions

https://github.com/ERDDAP/erddap/discussions/465