### PR TITLE
Upgrade docker compose nginx-proxy profile images to current releases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       - monitoring
     
   nginx-proxy:
-    image: nginxproxy/nginx-proxy:1.7
+    image: nginxproxy/nginx-proxy:1.11
     ports:
       - "${NGINX_PROXY_HTTP_PORT:-80}:80"
       - "${NGINX_PROXY_HTTPS_PORT:-443}:443"
@@ -154,7 +154,7 @@ services:
       - nginx-proxy
 
   acme-companion:
-    image: nginxproxy/acme-companion:2.5
+    image: nginxproxy/acme-companion:2.7
     volumes_from:
       - nginx-proxy
     volumes:


### PR DESCRIPTION
Upgrades the Docker images used on the Docker Compose stack nginx-proxy profile to use up to date/secure version:

nginx-proxy 1.7 -> 1.11
acme-companion 2.5 -> 2.7