### PR TITLE
Add ncoJson as info output format, support short format info URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,48 @@ While many of the tests interact with external servers, for example to load data
 
 The external tests should be run periodically (maybe around release time), but are unlikely to be relevant to day to day ERDDAP development&trade;.
 
+### Useful test invocation commands
+
+Run a single unit test
+
+```
+mvn -Dtest=EDDTableFromAsciiFilesTests#testBasic test
+```
+
+Attach a debugger to a single unit test (debugging port 8000 by default):
+
+```
+mvnDebug -DforkCount=0 -Dtest=EDDTableFromAsciiFilesTests#testBasic test
+```
+
+or
+
+```
+MAVEN_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000" \
+   mvn -DforkCount=0 -Dtest=EDDTableFromAsciiFilesTests#testBasic test
+```
+
+Run a single integration test:
+
+```
+mvn -Dtest=foo -Dsurefire.failIfNoSpecifiedTests=false -Dgcf.skip -Dit.test=JettyTests#displayInformation verify
+```
+
+Attach a debugger to a single integration test (debugging port 8000 by default):
+
+```
+mvnDebug -DforkCount=0 -Dtest=foo -Dsurefire.failIfNoSpecifiedTests=false -Dgcf.skip \
+  -Dit.test=JettyTests#displayInformation verify
+```
+
+or
+
+```
+MAVEN_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000" \
+  mvn -DforkCount=0 -Dtest=foo -Dsurefire.failIfNoSpecifiedTests=false -Dgcf.skip \
+  -Dit.test=JettyTests#testEDDGridNcoJsonMetadata verify
+```
+
 ### Metrics
 
 Metrics are collected using [Prometheus](https://prometheus.github.io/client_java/). You can see the metrics on a local server at [/erddap/metrics](http://localhost:8080/erddap/metrics?debug=text).

--- a/WEB-INF/classes/com/cohort/array/Attributes.java
+++ b/WEB-INF/classes/com/cohort/array/Attributes.java
@@ -914,15 +914,16 @@ public class Attributes {
   /**
    * This writes the attributes for a variable (or *GLOBAL*) to a String using NCO JSON lvl=2
    * pedantic style. See https://nco.sourceforge.net/nco.html#json This doesn't change any of the
-   * attributes. See issues in javadoc for EDDTable.saveAsNcoJson().
+   * attributes. See issues in javadoc for NcoJsonFiles.
    *
    * <p>String attributes are written as type="char". See comments in EDDTable.
    *
    * @param indent a String a spaces for the start of each line
+   * @param includeTrailingComma if true, a comma is included after the closing } of the attributes
    * @return a string with all of the attributes for a variable (or *GLOBAL*) formatted for NCO
    *     JSON, with a comma after the closing }.
    */
-  public String toNcoJsonString(String indent) {
+  public String toNcoJsonString(String indent, boolean includeTrailingComma) {
     StringBuilder sb = new StringBuilder();
 
     // "attributes": {
@@ -986,7 +987,9 @@ public class Attributes {
         (somethingWritten ? "\n" : "")
             + // end previous line
             indent
-            + "},\n");
+            + "}"
+            + (includeTrailingComma ? "," : "")
+            + "\n");
     return sb.toString();
   }
 

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -56,6 +56,7 @@ import gov.noaa.pfel.erddap.dataset.TableWriterJsonl;
 import gov.noaa.pfel.erddap.dataset.TableWriterNccsv;
 import gov.noaa.pfel.erddap.dataset.TableWriterSeparatedValue;
 import gov.noaa.pfel.erddap.dataset.WaitThenTryAgainException;
+import gov.noaa.pfel.erddap.filetypes.NcoJsonFiles;
 import gov.noaa.pfel.erddap.filetypes.TransparentPngFiles;
 import gov.noaa.pfel.erddap.handlers.SaxParsingContext;
 import gov.noaa.pfel.erddap.util.CfToFromGcmd;
@@ -181,6 +182,7 @@ public class Erddap extends HttpServlet {
           ".mat",
           ".nc",
           ".nccsv",
+          ".ncoJson",
           ".tsv",
           ".xhtml");
 
@@ -5413,6 +5415,10 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
           "<li>.nccsv - a flat, table-like, NetCDF-like, ASCII CSV file.\n" +
               "(<a rel=\"help\" href=\"https://erddap.github.io/docs/user/nccsv-1.20\">more&nbsp;information" +
               EDStatic.externalLinkHtml(language, tErddapUrl) + "</a>)\n" +
+          "<li>.ncoJson - a JSON file (NCO-style) with the dataset's metadata only (global attributes," +
+              "dimensions, and variables with their attributes, type, and shape) and no data values." +
+              "(<a rel="help" href="https://nco.sourceforge.net/nco.html#json">more&nbsp;information" +
+              "&externalLinkHtml;</a>)" +
           "<li>.tsv - a tab-separated ASCII text table.\n" +
               "(<a rel=\"help\" href=\"https://jkorpela.fi/TSV.html\">more&nbsp;information" +
               EDStatic.externalLinkHtml(language, tErddapUrl) + "</a>)\n" +
@@ -17663,8 +17669,21 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     String parts[] = String2.split(endOfRequestUrl, '/');
     int nParts = parts.length;
+    if (nParts == 1 && !parts[0].startsWith("index.") && String2.countAll(parts[0], ".") == 1) {
+      // This is a /info/<datasetID>.<metadataFormat> request,
+      // reformat to /info/<datasetID>/index.<metadataFormat>
+      // for processing below. (This is a convenience for users.)
+      String[] datasetIDAndExt = String2.split(parts[0], '.');
+      if (datasetIDAndExt.length == 2
+          && datasetIDAndExt[0].length() > 0
+          && datasetIDAndExt[1].length() > 0) {
+        parts = new String[] {datasetIDAndExt[0], "index." + datasetIDAndExt[1]};
+        nParts = 2;
+      }
+    }
     if (nParts == 0 || !parts[nParts - 1].startsWith("index.")) {
       StringArray sa = new StringArray(parts);
+
       sa.add("index.html");
       parts = sa.toArray();
       nParts = parts.length;
@@ -17687,6 +17706,22 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     }
     EDStatic.tally.add("Info File Type (since startup)", fileTypeName);
     EDStatic.tally.add("Info File Type (since last daily report)", fileTypeName);
+    if (fileTypeName.equals(".ncoJson") && nParts < 2) {
+      // .ncoJson info is the metadata of a single dataset; there is no such document
+      // for the list of all datasets (bad request)
+      sendHttpError(
+          requestNumber,
+          request,
+          response,
+          EDStatic.bilingual(
+              language,
+              MessageFormat.format(
+                  EDStatic.messages.get(Message.UNSUPPORTED_FILE_TYPE, 0), fileTypeName),
+              MessageFormat.format(
+                  EDStatic.messages.get(Message.UNSUPPORTED_FILE_TYPE, language), fileTypeName)),
+          HttpServletResponse.SC_BAD_REQUEST);
+      return;
+    }
     if (nParts < 2) {
       // *** info/index.xxx    view all datasets
 
@@ -17937,6 +17972,45 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
     // request is valid -- make the table
     EDStatic.tally.add("Info (since startup)", tID);
     EDStatic.tally.add("Info (since last daily report)", tID);
+
+    if (fileTypeName.equals(".ncoJson")) {
+      // write metadata-only ncoJson response (no data)
+      // these should always be very fast because we're not reading any actual data!
+      NcoJsonFiles ncoJsonFiles = new NcoJsonFiles();
+      String jsonp = request.getParameter("jsonp");
+      String fileName = edd.suggestFileName(loggedInAs, tID, fileTypeName);
+      OutputStreamSource outSource =
+          new OutputStreamFromHttpResponse(
+              request,
+              response,
+              fileName,
+              jsonp == null ? ".ncoJson" : ".jsonp", // .jsonp pseudo fileType for correct mime type
+              fileTypeName);
+      if (edd instanceof EDDTable) {
+        ncoJsonFiles.saveTableAsNcoJson(
+            outSource,
+            new NcoJsonFiles().new NcoJsonEDDTableMetadataProvider((EDDTable) edd, language),
+            null,
+            jsonp);
+      } else if (edd instanceof EDDGrid) {
+        GridDataAccessor gridDataAccessor =
+            new GridDataAccessor(
+                language,
+                (EDDGrid) edd,
+                null, // requestUrl
+                null, // userDapQuery
+                true,
+                false,
+                false);
+        ncoJsonFiles.saveGridAsNcoJson(
+            outSource, (EDDGrid) edd, null, gridDataAccessor, jsonp, false);
+      } else {
+        throw new RuntimeException(
+            "Unsupported EDD type for .ncoJson: " + edd.getClass().getName());
+      }
+      return;
+    }
+
     Table table = new Table();
     StringArray rowTypeSA = new StringArray();
     StringArray variableNameSA = new StringArray();
@@ -23900,8 +23974,27 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
    */
   public static void sendResourceNotFoundError(
       int requestNumber, HttpServletRequest request, HttpServletResponse response, String message) {
+    sendHttpError(requestNumber, request, response, message, HttpServletResponse.SC_NOT_FOUND);
+  }
 
-    EDStatic.lowSendError(requestNumber, response, HttpServletResponse.SC_NOT_FOUND, message);
+  /**
+   * This sends the HTTP error with the specified error code. This always also sends the error to
+   * String2.log.
+   *
+   * @param requestNumber The requestNumber assigned to this request by doGet().
+   * @param request The user's request.
+   * @param response The response to be written to.
+   * @param message use "" if nothing specific.
+   * @param errorCode the HTTP error code to send
+   */
+  public static void sendHttpError(
+      int requestNumber,
+      HttpServletRequest request,
+      HttpServletResponse response,
+      String message,
+      int errorCode) {
+
+    EDStatic.lowSendError(requestNumber, response, errorCode, message);
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/RunLoadDatasets.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/RunLoadDatasets.java
@@ -28,7 +28,7 @@ public class RunLoadDatasets extends Thread {
   public static boolean verbose = false;
 
   // *** things set by constructor
-  protected Erddap erddap;
+  public Erddap erddap;
 
   // *** things set by run()
   public LoadDatasets loadDatasets;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/GridDataAccessor.java
@@ -92,6 +92,18 @@ public class GridDataAccessor implements AutoCloseable {
 
   protected Table tDirTable, tFileTable; // null, unless eddGrid is EDDGridFromFiles
 
+  /** GridDataAccessor with default tAddToHistory=true. See full constructor for details. */
+  public GridDataAccessor(
+      int tLanguage,
+      EDDGrid tEDDGrid,
+      String tRequestUrl,
+      String tUserDapQuery,
+      boolean tRowMajor,
+      boolean tConvertToNaN)
+      throws Throwable {
+    this(tLanguage, tEDDGrid, tRequestUrl, tUserDapQuery, tRowMajor, tConvertToNaN, true);
+  }
+
   /**
    * This is the constructor. This constructor sets everything up, but doesn't get any grid data.
    *
@@ -105,6 +117,8 @@ public class GridDataAccessor implements AutoCloseable {
    * @param tConvertToNaN set this to true if you want the GridDataAccessor to convert stand-in
    *     missing values (e.g., -9999999.0, as identified by the missing_value or _FillValue
    *     metadata) to NaNs.
+   * @param tAddToHistory whether the history global attribute should be updated with info about
+   *     this request
    * @throws Throwable if trouble
    */
   public GridDataAccessor(
@@ -113,7 +127,8 @@ public class GridDataAccessor implements AutoCloseable {
       String tRequestUrl,
       String tUserDapQuery,
       boolean tRowMajor,
-      boolean tConvertToNaN)
+      boolean tConvertToNaN,
+      boolean tAddToHistory)
       throws Throwable {
 
     language = tLanguage;
@@ -151,12 +166,18 @@ public class GridDataAccessor implements AutoCloseable {
     globalAttributes = eddGrid.combinedGlobalAttributes().toAttributes(language); // make a copy
 
     // fix up global attributes  (always to a local COPY of global attributes)
-    EDD.addToHistory(globalAttributes, eddGrid.publicSourceUrl(language));
-    EDD.addToHistory(
-        globalAttributes,
-        EDStatic.config.baseUrl
-            + tRequestUrl
-            + (tUserDapQuery == null || tUserDapQuery.length() == 0 ? "" : "?" + tUserDapQuery));
+    if (tAddToHistory) {
+      EDD.addToHistory(globalAttributes, eddGrid.publicSourceUrl(language));
+      if (tRequestUrl != null) {
+        EDD.addToHistory(
+            globalAttributes,
+            EDStatic.config.baseUrl
+                + tRequestUrl
+                + (tUserDapQuery == null || tUserDapQuery.length() == 0
+                    ? ""
+                    : "?" + tUserDapQuery));
+      }
+    }
 
     // make axisValues and axisAttributes
     nAxisVariables = eddGrid.axisVariables.length;

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
@@ -50,23 +50,145 @@ public class NcoJsonFiles extends TableWriterFileType {
       throws Throwable {
     if (tableWriter instanceof TableWriterAllWithMetadata twalwm) {
       String jsonp = EDStatic.getJsonpFromQuery(requestInfo.language(), requestInfo.userDapQuery());
-      saveAsNcoJson(requestInfo.outputStream(), twalwm, jsonp);
+      saveTableAsNcoJson(
+          requestInfo.outputStream(),
+          new NcoJsonTableWriterTableMetadataProvider(twalwm),
+          twalwm,
+          jsonp);
     }
   }
 
   @Override
   public void writeGridToStream(DapRequestInfo requestInfo) throws Throwable {
-    saveAsNcoJson(
-        requestInfo.language(),
-        requestInfo.requestUrl(),
-        requestInfo.userDapQuery(),
+    // did query include &.jsonp= ?
+    String jsonp = EDStatic.getJsonpFromQuery(requestInfo.language(), requestInfo.userDapQuery());
+
+    AxisDataAccessor axisDataAccessor = null;
+    GridDataAccessor gridDataAccessor = null;
+    if (requestInfo.getEDDGrid().isAxisDapQuery(requestInfo.userDapQuery())) {
+      // get axisDataAccessor first, in case of error when parsing query
+      axisDataAccessor =
+          new AxisDataAccessor(
+              requestInfo.language(),
+              requestInfo.getEDDGrid(),
+              requestInfo.requestUrl(),
+              requestInfo.userDapQuery());
+    } else {
+      gridDataAccessor =
+          new GridDataAccessor(
+              requestInfo.language(),
+              requestInfo.getEDDGrid(),
+              requestInfo.requestUrl(),
+              requestInfo.userDapQuery(),
+              true,
+              false);
+    }
+
+    saveGridAsNcoJson(
         requestInfo.outputStream(),
-        requestInfo.getEDDGrid());
+        requestInfo.getEDDGrid(),
+        axisDataAccessor,
+        gridDataAccessor,
+        jsonp,
+        true);
   }
 
   @Override
   public String getHelpText(int language) {
     return EDStatic.messages.get(Message.FILE_HELP_NCO_JSON, language);
+  }
+
+  /** Interface for providing metadata about a table in needed to write ncoJson. */
+  public interface NcoJsonTableMetadataProvider {
+    public abstract Attributes globalAttributes();
+
+    public abstract int nColumns();
+
+    public abstract String columnName(int col);
+
+    public abstract PAType columnType(int col);
+
+    public abstract Attributes columnAttributes(int col);
+
+    public abstract long columnMaxStringLength(int col);
+
+    public abstract long nRows();
+  }
+
+  /** Implementation of NcoJsonTableMetadataProvider for TableWriterAllWithMetadata. */
+  public class NcoJsonTableWriterTableMetadataProvider implements NcoJsonTableMetadataProvider {
+    final TableWriterAllWithMetadata twawm;
+
+    public NcoJsonTableWriterTableMetadataProvider(TableWriterAllWithMetadata twawm) {
+      this.twawm = twawm;
+    }
+
+    public Attributes globalAttributes() {
+      return twawm.globalAttributes();
+    }
+
+    public int nColumns() {
+      return twawm.nColumns();
+    }
+
+    public String columnName(int col) {
+      return twawm.columnName(col);
+    }
+
+    public PAType columnType(int col) {
+      return twawm.columnType(col);
+    }
+
+    public Attributes columnAttributes(int col) {
+      return twawm.columnAttributes(col);
+    }
+
+    public long columnMaxStringLength(int col) {
+      return twawm.columnMaxStringLength(col);
+    }
+
+    public long nRows() {
+      return twawm.nRows();
+    }
+  }
+
+  /** Implementation of NcoJsonTableMetadataProvider for EDDTable. */
+  public class NcoJsonEDDTableMetadataProvider implements NcoJsonTableMetadataProvider {
+    final EDDTable edd;
+    final int language;
+
+    public NcoJsonEDDTableMetadataProvider(EDDTable edd, int language) {
+      this.edd = edd;
+      this.language = language;
+    }
+
+    public Attributes globalAttributes() {
+      return edd.combinedGlobalAttributes().toAttributes(language);
+    }
+
+    public int nColumns() {
+      return edd.dataVariables().length;
+    }
+
+    public String columnName(int col) {
+      return edd.dataVariables()[col].destinationName();
+    }
+
+    public PAType columnType(int col) {
+      return edd.dataVariables()[col].destinationDataPAType();
+    }
+
+    public Attributes columnAttributes(int col) {
+      return edd.dataVariables()[col].combinedAttributes().toAttributes(language);
+    }
+
+    public long columnMaxStringLength(int col) {
+      return 0; // metadata only
+    }
+
+    public long nRows() {
+      return 0; // metadata only
+    }
   }
 
   /**
@@ -106,8 +228,10 @@ public class NcoJsonFiles extends TableWriterFileType {
    *
    * @param language the index of the selected language
    * @param outputStreamSource
+   * @param njtmp the NcoJsonTableMetadataProvider
    * @param twawm all the results data, with missingValues stored as destinationMissingValues or
-   *     destinationFillValues (they are converted to NaNs)
+   *     destinationFillValues (they are converted to NaNs). If null, data will not be written (only
+   *     metadata).
    * @param jsonp the not-percent-encoded jsonp functionName to be prepended to the results (or null
    *     if none). See https://niryariv.wordpress.com/2009/05/05/jsonp-quickly/ and
    *     https://bob.pythonmac.org/archives/2005/12/05/remote-json-jsonp/ and
@@ -116,10 +240,13 @@ public class NcoJsonFiles extends TableWriterFileType {
    *     String2.isVariableNameSafe.
    * @throws Throwable
    */
-  private void saveAsNcoJson(
-      OutputStreamSource outputStreamSource, TableWriterAllWithMetadata twawm, String jsonp)
+  public void saveTableAsNcoJson(
+      OutputStreamSource outputStreamSource,
+      NcoJsonTableMetadataProvider njtmp,
+      TableWriterAllWithMetadata twawm,
+      String jsonp)
       throws Throwable {
-    if (EDDTable.reallyVerbose) String2.log("EDDTable.saveAsNcoJson");
+    if (EDDTable.reallyVerbose) String2.log("NcoJsonFiles.saveTableAsNcoJson");
     long time = System.currentTimeMillis();
 
     // for now, write strings as if in nc3 file: char arrays with extra dimension for strlen
@@ -128,10 +255,10 @@ public class NcoJsonFiles extends TableWriterFileType {
     String stringCloseBracket = writeStringsAsStrings ? "" : "]";
 
     // make sure there is data
-    long nRows = twawm.nRows();
-    if (nRows == 0)
-      throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (at start of saveAsNcoJson)");
-    int nCols = twawm.nColumns();
+    long nRows = njtmp.nRows();
+    if (twawm != null && nRows == 0)
+      throw new SimpleException(MustBe.THERE_IS_NO_DATA + " (at start of saveTableAsNcoJson)");
+    int nCols = njtmp.nColumns();
 
     // create a writer
     try (BufferedWriter writer =
@@ -142,7 +269,7 @@ public class NcoJsonFiles extends TableWriterFileType {
       writer.write("{\n");
 
       // write the global attributes
-      writer.write(twawm.globalAttributes().toNcoJsonString("  "));
+      writer.write(njtmp.globalAttributes().toNcoJsonString("  ", true));
 
       // write row dimension
       // {
@@ -154,16 +281,16 @@ public class NcoJsonFiles extends TableWriterFileType {
       String stringDim[] = new String[nCols];
       if (!writeStringsAsStrings) {
         for (int col = 0; col < nCols; col++) {
-          boolean isString = twawm.columnType(col) == PAType.STRING;
+          boolean isString = njtmp.columnType(col) == PAType.STRING;
           if (isString) {
-            stringDim[col] = String2.toJson(twawm.columnName(col) + NcHelper.StringLengthSuffix);
+            stringDim[col] = String2.toJson(njtmp.columnName(col) + NcHelper.StringLengthSuffix);
             writer.write(
                 ",\n"
                     + // end of previous line
                     "    "
                     + stringDim[col]
                     + ": "
-                    + Math.max(1, twawm.columnMaxStringLength(col)));
+                    + Math.max(1, njtmp.columnMaxStringLength(col)));
           }
         }
       }
@@ -182,8 +309,8 @@ public class NcoJsonFiles extends TableWriterFileType {
         //      "attributes": { ... },
         //      "data": [10.0, 10.10, 10.20, 10.30, 10.40101, 10.50, 10.60, 10.70, 10.80, 10.990]
         //    }
-        Attributes atts = twawm.columnAttributes(col);
-        String tType = PAType.toCohortString(twawm.columnType(col));
+        Attributes atts = njtmp.columnAttributes(col);
+        String tType = PAType.toCohortString(njtmp.columnType(col));
         boolean isString = tType.equals("String");
         boolean isChar = tType.equals("char");
         int bufferSize =
@@ -194,7 +321,7 @@ public class NcoJsonFiles extends TableWriterFileType {
         else if (tType.equals("ulong")) tType = "uint64";
         writer.write(
             "    "
-                + String2.toJson(twawm.columnName(col))
+                + String2.toJson(njtmp.columnName(col))
                 + ": {\n"
                 + "      \"shape\": [\"row\""
                 + (isString && !writeStringsAsStrings ? ", " + stringDim[col] : "")
@@ -202,66 +329,66 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(atts.toNcoJsonString("      "));
-        writer.write("      \"data\": [");
-        try (DataInputStream dis = twawm.dataInputStream(col)) {
-          // create the bufferPA
-          PrimitiveArray pa = null;
-          long nRowsRead = 0;
-          while (nRowsRead < nRows) {
-            int nToRead = (int) Math.min(bufferSize, nRows - nRowsRead);
-            if (pa == null) {
-              pa = twawm.columnEmptyPA(col);
-              pa.ensureCapacity(nToRead);
+        // if twawm is not null, we need to write data as well
+        writer.write(atts.toNcoJsonString("      ", twawm != null));
+        if (twawm != null) {
+          writer.write("      \"data\": [");
+          try (DataInputStream dis = twawm.dataInputStream(col)) {
+            // create the bufferPA
+            PrimitiveArray pa = null;
+            long nRowsRead = 0;
+            while (nRowsRead < nRows) {
+              int nToRead = (int) Math.min(bufferSize, nRows - nRowsRead);
+              if (pa == null) {
+                pa = twawm.columnEmptyPA(col);
+                pa.ensureCapacity(nToRead);
+              }
+              pa.clear();
+              pa.setMaxIsMV(twawm.columnMaxIsMV(col)); // reset after clear()
+              pa.readDis(dis, nToRead);
+              if (isChar) {
+                // write it as one string with chars concatenated
+                // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
+                //  "shape": ["lev"],          //dim lev size=3
+                //  ...
+                //  "data": ["abc"]
+                // here: write it in buffersize chunks
+                if (nRowsRead == 0) writer.write("\""); // start the string
+                String s = String2.toJson(new String(((CharArray) pa).toArray()));
+                writer.write(s.substring(1, s.length() - 1)); // remove start and end "
+              } else if (isString) {
+                // Arrays of Strings are written oddly: (example from
+                // http://dust.ess.uci.edu/tmp/in.json.fmt2)
+                //    "date_rec": {
+                //      "shape": ["time", "char_dmn_lng26"],
+                //      "type": "char",
+                //      "attributes": ...,
+                //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
+                // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
+                // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
+                // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
+                // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
+                //    },
+                if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
+                ssb.setLength(0);
+                for (int row = 0; row < nToRead; row++)
+                  ssb.append(
+                      (row == 0 ? "" : ", ")
+                          + stringOpenBracket
+                          + String2.toJson(pa.getString(row))
+                          + stringCloseBracket);
+                writer.write(ssb.toString());
+              } else {
+                if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
+                writer.write(pa.toJsonCsvString());
+              }
+              nRowsRead += nToRead;
             }
-            pa.clear();
-            pa.setMaxIsMV(twawm.columnMaxIsMV(col)); // reset after clear()
-            pa.readDis(dis, nToRead);
-            if (isChar) {
-              // write it as one string with chars concatenated
-              // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
-              //  "shape": ["lev"],          //dim lev size=3
-              //  ...
-              //  "data": ["abc"]
-              // here: write it in buffersize chunks
-              if (nRowsRead == 0) writer.write("\""); // start the string
-              String s = String2.toJson(new String(((CharArray) pa).toArray()));
-              writer.write(s.substring(1, s.length() - 1)); // remove start and end "
-            } else if (isString) {
-              // Arrays of Strings are written oddly: (example from
-              // http://dust.ess.uci.edu/tmp/in.json.fmt2)
-              //    "date_rec": {
-              //      "shape": ["time", "char_dmn_lng26"],
-              //      "type": "char",
-              //      "attributes": ...,
-              //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
-              // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
-              // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
-              // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
-              // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
-              //    },
-              if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
-              ssb.setLength(0);
-              for (int row = 0; row < nToRead; row++)
-                ssb.append(
-                    (row == 0 ? "" : ", ")
-                        + stringOpenBracket
-                        + String2.toJson(pa.getString(row))
-                        + stringCloseBracket);
-              writer.write(ssb.toString());
-            } else {
-              if (nRowsRead > 0) writer.write(",\n    "); // separate and write on next line
-              writer.write(pa.toJsonCsvString());
-            }
-            nRowsRead += nToRead;
           }
+          if (isChar) writer.write('\"'); // terminate the string
+          writer.write("]\n"); // end of data
         }
-        if (isChar) writer.write('\"'); // terminate the string
-        writer.write(
-            "]\n"
-                + // end of data
-                "    }"
-                + (col < nCols - 1 ? ",\n" : "\n")); // end of variable
+        writer.write("    }" + (col < nCols - 1 ? ",\n" : "\n")); // end of variable
       }
       writer.write(
           "  }\n" + // end of variables object
@@ -274,43 +401,36 @@ public class NcoJsonFiles extends TableWriterFileType {
 
     if (EDDTable.reallyVerbose)
       String2.log(
-          "  EDDTable.saveAsNcoJson done. TIME=" + (System.currentTimeMillis() - time) + "ms\n");
+          "  NcoJsonFiles.saveTableAsNcoJson done. TIME="
+              + (System.currentTimeMillis() - time)
+              + "ms\n");
   }
 
   /**
    * Save the grid data in an NCO JSON .ncoJson file. See https://nco.sourceforge.net/nco.html#json
-   * See issues in JavaDocs for EDDTable.saveAsNcoJson().
    *
    * <p>This gives up a few things (e.g., actual_range) in order to make this a streaming response
    * (not write file then transfer file).
    *
-   * @param language the index of the selected language
-   * @param ncVersion either NetcdfFileFormat.NETCDF3 or NETCDF4.
-   * @param requestUrl the part of the user's request, after EDStatic.config.baseUrl, before '?'.
-   * @param userDapQuery an OPeNDAP DAP-style query string, still percentEncoded (shouldn't be
-   *     null). e.g., ATssta[45:1:45][0:1:0][120:10:140][130:10:160]
    * @throws Throwable
    */
-  private void saveAsNcoJson(
-      int language,
-      String requestUrl,
-      String userDapQuery,
+  public void saveGridAsNcoJson(
       OutputStreamSource outputStreamSource,
-      EDDGrid grid)
+      EDDGrid grid,
+      AxisDataAccessor ada,
+      GridDataAccessor gda,
+      String jsonp,
+      boolean writeData)
       throws Throwable {
-    if (EDDGrid.reallyVerbose) String2.log("  EDDGrid.saveAsNc");
+    if (EDDGrid.reallyVerbose) String2.log("  NcoJsonFiles.saveGridAsNcoJson");
 
     // for now, write strings as if in nc3 file: char arrays with extra dimension for strlen
     boolean writeStringsAsStrings = false; // if false, they are written as chars
     String stringOpenBracket = writeStringsAsStrings ? "" : "[";
     String stringCloseBracket = writeStringsAsStrings ? "" : "]";
 
-    // did query include &.jsonp= ?
-    String jsonp = EDStatic.getJsonpFromQuery(language, userDapQuery);
     // handle axisDapQuery
-    if (grid.isAxisDapQuery(userDapQuery)) {
-      // get axisDataAccessor first, in case of error when parsing query
-      AxisDataAccessor ada = new AxisDataAccessor(language, grid, requestUrl, userDapQuery);
+    if (ada != null) {
       int nRAV = ada.nRequestedAxisVariables();
 
       // create a writer
@@ -322,7 +442,7 @@ public class NcoJsonFiles extends TableWriterFileType {
         writer.write("{\n");
 
         // write the global attributes
-        writer.write(ada.globalAttributes().toNcoJsonString("  "));
+        writer.write(ada.globalAttributes().toNcoJsonString("  ", true));
 
         // write dimensions
         // {
@@ -376,14 +496,15 @@ public class NcoJsonFiles extends TableWriterFileType {
                   + "      \"type\": \""
                   + tType
                   + "\",\n");
-          writer.write(ada.axisAttributes(avi).toNcoJsonString("      "));
-          writer.write("      \"data\": [");
-          writer.write(ada.axisValues(avi).toJsonCsvString());
-          writer.write(
-              "]\n"
-                  + // end of data
-                  "    }"
-                  + (avi < nRAV - 1 ? ",\n" : "\n")); // end of variable
+          writer.write(ada.axisAttributes(avi).toNcoJsonString("      ", writeData));
+          if (writeData) {
+            writer.write("      \"data\": [");
+            writer.write(ada.axisValues(avi).toJsonCsvString());
+            writer.write("]\n");
+            // end of data
+          }
+          writer.write("    }" + (avi < nRAV - 1 ? ",\n" : "\n"));
+          // end of variable
         }
         writer.write(
             "  }\n" + // end of variables object
@@ -397,10 +518,7 @@ public class NcoJsonFiles extends TableWriterFileType {
     BufferedWriter writer = null;
     // Need to use GridDataAllAccessor because need to know max String lengths.
     // Get this early so error thrown before writer created.
-    try (GridDataAccessor gda =
-            new GridDataAccessor(
-                language, grid, requestUrl, userDapQuery, true, false); // tRowMajor, tConvertToNaN
-        GridDataAllAccessor gdaa = new GridDataAllAccessor(gda)) {
+    try (GridDataAllAccessor gdaa = writeData ? new GridDataAllAccessor(gda) : null) {
 
       int nAV = grid.axisVariables().length;
       int nRDV = gda.dataVariables().length;
@@ -413,7 +531,7 @@ public class NcoJsonFiles extends TableWriterFileType {
       writer.write("{\n");
 
       // write the global attributes
-      writer.write(gda.globalAttributes().toNcoJsonString("  "));
+      writer.write(gda.globalAttributes().toNcoJsonString("  ", true));
 
       // write dimensions
       // {
@@ -437,9 +555,11 @@ public class NcoJsonFiles extends TableWriterFileType {
           EDV dv = gda.dataVariables()[dvi];
           if (dv.destinationDataPAType() == PAType.STRING) {
             int max = 1;
-            long n = gda.totalIndex().size();
-            try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
-              for (int i = 0; i < n; i++) max = Math.max(max, dis.readUTF().length());
+            if (writeData) {
+              long n = gda.totalIndex().size();
+              try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
+                for (int i = 0; i < n; i++) max = Math.max(max, dis.readUTF().length());
+              }
             }
             writer.write(
                 ",\n"
@@ -484,14 +604,16 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(gda.axisAttributes(avi).toNcoJsonString("      "));
 
-        writer.write("      \"data\": [");
-        writer.write(gda.axisValues(avi).toJsonCsvString());
-        writer.write(
-            "]\n"
-                + // end of data
-                "    },\n"); // end of variable
+        writer.write(gda.axisAttributes(avi).toNcoJsonString("      ", writeData));
+
+        if (writeData) {
+          writer.write("      \"data\": [");
+          writer.write(gda.axisValues(avi).toJsonCsvString());
+          writer.write("]\n");
+          // end of data
+        }
+        writer.write("    },\n"); // end of variable
       }
 
       // dataVariables
@@ -536,76 +658,78 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(atts.toNcoJsonString("      "));
+        writer.write(atts.toNcoJsonString("      ", writeData));
+        if (writeData) {
+          writer.write("      \"data\":\n");
+          for (int avi = 0; avi < nAV; avi++) writer.write("[ ");
+          try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
 
-        writer.write("      \"data\":\n");
-        for (int avi = 0; avi < nAV; avi++) writer.write("[ ");
-        try (DataInputStream dis = gdaa.getDataInputStream(dvi)) {
+            // create the bufferPA
+            PrimitiveArray pa =
+                PrimitiveArray.factory(
+                    dv.destinationDataPAType(), 1, false); // safe since checked above
+            CharArray ca = isChar ? (CharArray) pa : null;
+            if (isChar) writer.write("\""); // start the string
+            tIndex.reset();
+            tIndex.increment(); // so we're at 1st datum
+            for (long nRowsRead = 0; nRowsRead < nRows; nRowsRead++) {
 
-          // create the bufferPA
-          PrimitiveArray pa =
-              PrimitiveArray.factory(
-                  dv.destinationDataPAType(), 1, false); // safe since checked above
-          CharArray ca = isChar ? (CharArray) pa : null;
-          if (isChar) writer.write("\""); // start the string
-          tIndex.reset();
-          tIndex.increment(); // so we're at 1st datum
-          for (long nRowsRead = 0; nRowsRead < nRows; nRowsRead++) {
+              // String2.log(">> preCurrent=" + String2.toCSSVString(preCurrent));
+              pa.clear();
+              pa.readDis(dis, 1);
 
-            // String2.log(">> preCurrent=" + String2.toCSSVString(preCurrent));
-            pa.clear();
-            pa.readDis(dis, 1);
-
-            // write one data value
-            if (isChar) {
-              // write it as one string with chars concatenated
-              // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
-              //  "shape": ["lev"],          //dim lev size=3
-              //  ...
-              //  "data": ["abc"]
-              writer.write(String2.charToJsonString(ca.get(0), 127, true)); // encodeNewline
-            } else if (isString) {
-              // Arrays of Strings are written oddly: (example from
-              // http://dust.ess.uci.edu/tmp/in.json.fmt2)
-              //    "date_rec": {
-              //      "shape": ["time", "char_dmn_lng26"],
-              //      "type": "char",
-              //      "attributes": ...,
-              //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
-              // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
-              // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
-              // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
-              // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
-              //    },
-              writer.write(
-                  stringOpenBracket + String2.toJson(pa.getString(0)) + stringCloseBracket);
-            } else {
-              writer.write(pa.toJsonCsvString());
-            }
-
-            // write commas and brackets
-            // This was difficult for me: It took me a while to figure out:
-            // Given n (tIndex.nDimensionschanged()),
-            //  the proper separators between data items are
-            //  n-1 close brackets, 1 comma, n-1 open brackets.
-            if (tIndex.increment()) {
-              int nDimChanged = tIndex.nDimensionsChanged();
-              if (nDimChanged == 1) {
-                // easier to deal with this specially
-                if (!isChar) writer.write(", ");
+              // write one data value
+              if (isChar) {
+                // write it as one string with chars concatenated
+                // see "md5_abc" in in http://dust.ess.uci.edu/tmp/in.json.fmt2
+                //  "shape": ["lev"],          //dim lev size=3
+                //  ...
+                //  "data": ["abc"]
+                writer.write(String2.charToJsonString(ca.get(0), 127, true)); // encodeNewline
+              } else if (isString) {
+                // Arrays of Strings are written oddly: (example from
+                // http://dust.ess.uci.edu/tmp/in.json.fmt2)
+                //    "date_rec": {
+                //      "shape": ["time", "char_dmn_lng26"],
+                //      "type": "char",
+                //      "attributes": ...,
+                //      "data": [["2010-11-01T00:00:00.000000"], ["2010-11-01T01:00:00.000000"],
+                // ["2010-11-01T02:00:00.000000"], ["2010-11-01T03:00:00.000000"],
+                // ["2010-11-01T04:00:00.000000"], ["2010-11-01T05:00:00.000000"],
+                // ["2010-11-01T06:00:00.000000"], ["2010-11-01T07:00:00.000000"],
+                // ["2010-11-01T08:00:00.000000"], ["2010-11-01T09:00:00.000000"]]
+                //    },
+                writer.write(
+                    stringOpenBracket + String2.toJson(pa.getString(0)) + stringCloseBracket);
               } else {
-                if (isChar) writer.write('\"'); // close the quote
-                for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write(" ]");
-                writer.write(",\n");
-                for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write("[ ");
-                if (isChar) writer.write('\"'); // open the quote
+                writer.write(pa.toJsonCsvString());
               }
-            } // else it is the end of the data. Handle brackets specially below...
-          } // end of data
+
+              // write commas and brackets
+              // This was difficult for me: It took me a while to figure out:
+              // Given n (tIndex.nDimensionschanged()),
+              //  the proper separators between data items are
+              //  n-1 close brackets, 1 comma, n-1 open brackets.
+              if (tIndex.increment()) {
+                int nDimChanged = tIndex.nDimensionsChanged();
+                if (nDimChanged == 1) {
+                  // easier to deal with this specially
+                  if (!isChar) writer.write(", ");
+                } else {
+                  if (isChar) writer.write('\"'); // close the quote
+                  for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write(" ]");
+                  writer.write(",\n");
+                  for (int dim = 0; dim < nDimChanged - 1; dim++) writer.write("[ ");
+                  if (isChar) writer.write('\"'); // open the quote
+                }
+              } // else it is the end of the data. Handle brackets specially below...
+            } // end of data
+            if (isChar) writer.write("\""); // start the string
+          }
+          for (int avi = 0; avi < nAV; avi++) writer.write(" ]");
+          writer.write("\n"); // end of data
         }
-        if (isChar) writer.write("\""); // start the string
-        for (int avi = 0; avi < nAV; avi++) writer.write(" ]");
-        writer.write("\n" + "    }" + (dvi < nRDV - 1 ? "," : "") + "\n"); // end of variable
+        writer.write("    }" + (dvi < nRDV - 1 ? "," : "") + "\n"); // end of variable
       }
       writer.write(
           "  }\n" + // end of variables object

--- a/src/main/resources/gov/noaa/pfel/erddap/util/messages.xml
+++ b/src/main/resources/gov/noaa/pfel/erddap/util/messages.xml
@@ -4903,6 +4903,10 @@ results as a table of data in these common, computer-program friendly, file type
 <li>.nccsv - a flat, table-like, NetCDF-like, ASCII CSV file.
     (<a rel="help" href="https://erddap.github.io/docs/user/nccsv-1.20">more&nbsp;information
     &externalLinkHtml;</a>)
+<li>.ncoJson - a JSON file (NCO-style) with the dataset's metadata only (global attributes,
+    dimensions, and variables with their attributes, type, and shape) and no data values.
+    (<a rel="help" href="https://nco.sourceforge.net/nco.html#json">more&nbsp;information
+    &externalLinkHtml;</a>)
 <li>.tsv - a tab-separated ASCII text table.
     (<a rel="help" href="https://jkorpela.fi/TSV.html">more&nbsp;information
     &externalLinkHtml;</a>)

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -1,7 +1,11 @@
 package jetty;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -33,6 +37,8 @@ import gov.noaa.pfel.coastwatch.util.SSR;
 import gov.noaa.pfel.coastwatch.util.TestSSR;
 import gov.noaa.pfel.erddap.Erddap;
 import gov.noaa.pfel.erddap.GenerateDatasetsXml;
+import gov.noaa.pfel.erddap.LoadDatasets;
+import gov.noaa.pfel.erddap.RunLoadDatasets;
 import gov.noaa.pfel.erddap.dataset.EDD;
 import gov.noaa.pfel.erddap.dataset.EDDGrid;
 import gov.noaa.pfel.erddap.dataset.EDDGridFromDap;
@@ -58,6 +64,7 @@ import gov.noaa.pfel.erddap.variable.DataVariableInfo;
 import gov.noaa.pfel.erddap.variable.EDV;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigDecimal;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
@@ -82,6 +89,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Jetty;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -113,8 +121,10 @@ class JettyTests extends WireMockLifecycle {
   private static Server server;
   private static Integer PORT = 8080;
   static boolean initialCroissantSetting = false;
+  static boolean initialForceSynchronousLoadingSetting = false;
 
   @BeforeAll
+  @SuppressWarnings("DoNotCall") // tell errorprone to ignore LoadDatasets.run
   public static void setUp() throws Throwable {
     Initialization.edStatic();
     EDDTestDataset.generateDatasetsXml();
@@ -133,11 +143,43 @@ class JettyTests extends WireMockLifecycle {
 
     server.start();
 
-    // Delay the tests to give the server a chance to load all of the data.
-    // If the cache/data folder is cold some machines might need longer. If
-    // all of the data is already loaded on the machine, this can probably be
-    // shortened.
-    Thread.sleep(12 * 60 * 1000);
+    // Wait for the server to load all of the data.
+    initialForceSynchronousLoadingSetting = EDStatic.config.forceSynchronousLoading;
+    EDStatic.config.forceSynchronousLoading = true;
+    final long dataLoadStartTime = System.currentTimeMillis();
+    System.out.println("Waiting for server to finish initial load datasets");
+    String dataLoadMaxWaitTimeSecondsProperty =
+        System.getProperty("jettyTests.dataLoadMaxWaitTimeSeconds");
+    long dataLoadMaxWaitTimeSeconds =
+        dataLoadMaxWaitTimeSecondsProperty != null
+            ? Long.parseLong(dataLoadMaxWaitTimeSecondsProperty)
+            : 12 * 60;
+    await()
+        .atMost(dataLoadMaxWaitTimeSeconds, SECONDS)
+        .pollInterval(1, SECONDS)
+        .until(() -> !EDStatic.initialLoadDatasets());
+    int dataLoadTimeSeconds = (int) ((System.currentTimeMillis() - dataLoadStartTime) / 1000);
+    System.out.println("Initial dataset loading completed in " + dataLoadTimeSeconds + " seconds");
+
+    // Run a second loadDatasets to load datasets that don't load the first time,
+    // in particular miniNdbc4103 which is a child dataset of EDDTableAggregateRows miniNdbc410
+    // see EDDTestDataset.xmlFragment_miniNdbc410
+    // FIXME likely related to https://github.com/ERDDAP/erddap/issues/440
+    // All legitimate datasets should load during the first pass if forceSynchronousLoading is set
+    // Child dataset miniNdbc4103 is in the expected dataset list in JettyTests.testJsonld
+    System.out.println("Waiting for second dataset loading pass");
+    final long dataLoadSecondPassStartTime = System.currentTimeMillis();
+    new LoadDatasets(
+            ((RunLoadDatasets) EDStatic.runningThreads.get("runLoadDatasets")).erddap,
+            EDStatic.config.datasetsRegex,
+            null,
+            true)
+        .run();
+    int dataLoadSecondPassTimeSeconds =
+        (int) ((System.currentTimeMillis() - dataLoadSecondPassStartTime) / 1000);
+    System.out.println(
+        "Second dataset loading pass completed in " + dataLoadSecondPassTimeSeconds + " seconds");
+
     initialCroissantSetting = EDStatic.config.generateCroissantSchema;
   }
 
@@ -149,6 +191,7 @@ class JettyTests extends WireMockLifecycle {
   @AfterAll
   public static void tearDown() throws Exception {
     server.stop();
+    EDStatic.config.forceSynchronousLoading = initialForceSynchronousLoadingSetting;
   }
 
   /** Check if the Institution row attributes are being displayed correctly */
@@ -4062,6 +4105,882 @@ class JettyTests extends WireMockLifecycle {
     Test.ensureEqual(
         table.columnAttributes(t25Col).getString("ioos_category"), "Temperature", ncHeader);
     Test.ensureEqual(table.columnAttributes(t25Col).getString("units"), "degree_C", ncHeader);
+  }
+
+  /** A simple class to hold the name, type, and data of an ncoJson attribute for testing. */
+  private class NcoJsonAttribute {
+    String name;
+    String type;
+    Object data;
+
+    public NcoJsonAttribute(String name, String type, Object data) {
+      this.name = name;
+      this.type = type;
+      this.data = data;
+    }
+  }
+
+  /**
+   * Assert that the given ncoJson attribute is present in the given attributes JSONObject and has
+   * the expected type and data.
+   *
+   * @param attrs the JSONObject containing the attributes
+   * @param nja the expected NcoJsonAttribute
+   */
+  private void assertNcoAttribute(JSONObject attrs, NcoJsonAttribute nja) {
+    assertTrue(attrs.has(nja.name), "ncoJson attribute " + nja.name + " not found");
+    JSONObject attr = attrs.getJSONObject(nja.name);
+    assertTrue(attr.has("type"), "ncoJson attribute " + nja.name + " has no type");
+    assertEquals(
+        nja.type, attr.getString("type"), "ncoJson attribute " + nja.name + " has unexpected type");
+    assertTrue(attr.has("data"), "ncoJson attribute " + nja.name + " has no data");
+    Object dataVal = attr.get("data");
+    String unexpectedDataMessage = "ncoJson attribute " + nja.name + " has unexpected data";
+    if (dataVal instanceof JSONArray) {
+      JSONArray dataArray = (JSONArray) dataVal;
+      if (!dataArray.isEmpty() && dataArray.get(0) instanceof BigDecimal) {
+        // convert JSONArray of BigDecimal to List<Double>
+        List<Double> doubleList = new ArrayList<>();
+        for (int i = 0; i < dataArray.length(); i++) {
+          doubleList.add(dataArray.getBigDecimal(i).doubleValue());
+        }
+        assertEquals(nja.data, doubleList, unexpectedDataMessage);
+      } else {
+        assertEquals(nja.data, dataArray.toList(), unexpectedDataMessage);
+      }
+    } else if (dataVal instanceof BigDecimal) {
+      // convert BigDecimal to double for comparison
+      assertEquals(nja.data, ((BigDecimal) dataVal).doubleValue(), unexpectedDataMessage);
+    } else if (dataVal == JSONObject.NULL) {
+      assertNull(nja.data, unexpectedDataMessage);
+    } else {
+      assertEquals(nja.data, dataVal, unexpectedDataMessage);
+    }
+  }
+
+  /**
+   * Assert that the given ncoJson dimension is present in the given dimensions JSONObject and has
+   * the expected length.
+   *
+   * @param dims the JSONObject containing the dimensions
+   * @param dimKey the key of the dimension to check
+   * @param dimLength the expected length of the dimension
+   */
+  private void assertNcoDimension(JSONObject dims, String dimKey, int dimLength) {
+    assertTrue(dims.has(dimKey), "ncoJson dimension " + dimKey + " not found");
+    assertEquals(
+        dimLength, dims.getInt(dimKey), "ncoJson dimension " + dimKey + " has unexpected length");
+  }
+
+  /**
+   * Assert that the given ncoJson variable is present in the given variables JSONObject and has the
+   * expected shape, type, and attributes.
+   *
+   * @param vars the JSONObject containing the variables
+   * @param varKey the key of the variable to check
+   * @param shape the expected shape of the variable
+   * @param type the expected type of the variable
+   * @param njas the expected attributes of the variable
+   */
+  private void assertNcoVariable(
+      JSONObject vars, String varKey, List<String> shape, String type, NcoJsonAttribute... njas) {
+    assertTrue(vars.has(varKey), "ncoJson variables " + varKey + " not found");
+    JSONObject var = vars.getJSONObject(varKey);
+    assertTrue(var.has("shape"), "ncoJson variable " + varKey + " has no shape");
+    assertEquals(
+        shape,
+        var.getJSONArray("shape").toList(),
+        "ncoJson variable " + varKey + " has unexpected shape");
+    assertTrue(var.has("type"), "ncoJson variable " + varKey + " has no type");
+    assertEquals(
+        type, var.getString("type"), "ncoJson variable " + varKey + " has unexpected type");
+    assertTrue(var.has("attributes"), "ncoJson variable " + varKey + " has no attributes");
+
+    JSONObject varAttrs = var.getJSONObject("attributes");
+    for (NcoJsonAttribute nja : njas) {
+      assertNcoAttribute(varAttrs, nja);
+    }
+
+    // verify that the variable has no "data" key
+    assertFalse(var.has("data"), "ncoJson variable " + varKey + " should not have data");
+  }
+
+  /**
+   * Ensure /info/index.ncoJson returns a 400 (bad request), because the list of all ERDDAP datasets
+   * is not representable by ncoJson
+   *
+   * @throws Exception if trouble
+   */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void testListDatasetsNcoJsonBadRequest() throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+    HttpResponse<String> response =
+        client.send(
+            HttpRequest.newBuilder(server.getURI().resolve("/erddap/info/index.ncoJson"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(400, response.statusCode());
+  }
+
+  /**
+   * Test short metadata URL (e.g. /info/<datasetID>.json)
+   *
+   * @throws Exception if trouble
+   */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void testShortDatasetInfoUrl() throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+
+    HttpResponse<String> response =
+        client.send(
+            HttpRequest.newBuilder(server.getURI().resolve("/erddap/info/pmelTaoDySst/index.json"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    String longUrlResponseStr = response.body();
+
+    response =
+        client.send(
+            HttpRequest.newBuilder(server.getURI().resolve("/erddap/info/pmelTaoDySst.json"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    String shortUrlResponseStr = response.body();
+
+    assertEquals(longUrlResponseStr, shortUrlResponseStr);
+  }
+
+  /**
+   * Test EDDTable ncoJson /info (metadata) response/output.
+   *
+   * @throws Exception if trouble
+   */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void testEDDTableNcoJsonMetadata() throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+
+    HttpResponse<String> response =
+        client.send(
+            HttpRequest.newBuilder(
+                    server.getURI().resolve("/erddap/info/pmelTaoDySst/index.ncoJson"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    String pmelTaoDySstNcoJsonResponseStr = response.body();
+    JSONObject pmelTaoDySstNcoJsonResponse = new JSONObject(pmelTaoDySstNcoJsonResponseStr);
+    assertNotNull(pmelTaoDySstNcoJsonResponse);
+    assertTrue(
+        pmelTaoDySstNcoJsonResponse.has("attributes"),
+        "pmelTaoDySst ncoJson metadata has no attributes");
+    assertTrue(
+        pmelTaoDySstNcoJsonResponse.has("dimensions"),
+        "pmelTaoDySst ncoJson metadata has no dimensions");
+    assertTrue(
+        pmelTaoDySstNcoJsonResponse.has("variables"),
+        "pmelTaoDySst ncoJson metadata has no variables");
+
+    JSONObject globalAttrs = pmelTaoDySstNcoJsonResponse.getJSONObject("attributes");
+    // full ncoJson is tested below so global attr testing doesn't need to be exhaustive here
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("cdm_data_type", "char", "TimeSeries"));
+    assertNcoAttribute(
+        globalAttrs,
+        new NcoJsonAttribute(
+            "cdm_timeseries_variables",
+            "char",
+            "array, station, wmo_platform_code, longitude, latitude, depth"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("Conventions", "char", "COARDS, CF-1.6, ACDD-1.3"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("creator_email", "char", "Dai.C.McClurg@noaa.gov"));
+    assertNcoAttribute(
+        globalAttrs,
+        new NcoJsonAttribute("creator_name", "char", "GTMBA Project Office/NOAA/PMEL"));
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("creator_type", "char", "group"));
+    assertNcoAttribute(
+        globalAttrs,
+        new NcoJsonAttribute("creator_url", "char", "https://www.pmel.noaa.gov/gtmba/mission"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("geospatial_vertical_max", "double", 15.0));
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("geospatial_vertical_min", "double", 1.0));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("project", "char", "TAO/TRITON, RAMA, PIRATA"));
+    assertNcoAttribute(
+        globalAttrs,
+        new NcoJsonAttribute(
+            "title",
+            "char",
+            "TAO/TRITON, RAMA, and PIRATA Buoys, Daily, 1977-present, Sea Surface Temperature"));
+
+    JSONObject dimensions = pmelTaoDySstNcoJsonResponse.getJSONObject("dimensions");
+    assertNcoDimension(dimensions, "row", 0);
+    assertNcoDimension(dimensions, "array_strlen", 1);
+    assertNcoDimension(dimensions, "station_strlen", 1);
+
+    JSONObject variables = pmelTaoDySstNcoJsonResponse.getJSONObject("variables");
+    assertNcoVariable(
+        variables,
+        "array",
+        List.of("row", "array_strlen"),
+        "char",
+        new NcoJsonAttribute("ioos_category", "char", "Identifier"),
+        new NcoJsonAttribute("long_name", "char", "Array"));
+
+    assertNcoVariable(
+        variables,
+        "station",
+        List.of("row", "station_strlen"),
+        "char",
+        new NcoJsonAttribute("cf_role", "char", "timeseries_id"),
+        new NcoJsonAttribute("ioos_category", "char", "Identifier"),
+        new NcoJsonAttribute("long_name", "char", "Station"));
+
+    assertNcoVariable(
+        variables,
+        "wmo_platform_code",
+        List.of("row"),
+        "int",
+        new NcoJsonAttribute("actual_range", "int", List.of(13001, 56055)),
+        new NcoJsonAttribute("ioos_category", "char", "Identifier"),
+        new NcoJsonAttribute("long_name", "char", "WMO Platform Code"),
+        new NcoJsonAttribute("missing_value", "int", 2147483647));
+
+    assertNcoVariable(
+        variables,
+        "longitude",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Lon"),
+        new NcoJsonAttribute("actual_range", "float", List.of(0.0, 357.0)),
+        new NcoJsonAttribute("axis", "char", "X"),
+        new NcoJsonAttribute("epic_code", "int", 502),
+        new NcoJsonAttribute("ioos_category", "char", "Location"),
+        new NcoJsonAttribute("long_name", "char", "Nominal Longitude"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("standard_name", "char", "longitude"),
+        new NcoJsonAttribute("type", "char", "EVEN"),
+        new NcoJsonAttribute("units", "char", "degrees_east"));
+
+    assertNcoVariable(
+        variables,
+        "latitude",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Lat"),
+        new NcoJsonAttribute("actual_range", "float", List.of(-25.0, 21.0)),
+        new NcoJsonAttribute("axis", "char", "Y"),
+        new NcoJsonAttribute("epic_code", "int", 500),
+        new NcoJsonAttribute("ioos_category", "char", "Location"),
+        new NcoJsonAttribute("long_name", "char", "Nominal Latitude"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("standard_name", "char", "latitude"),
+        new NcoJsonAttribute("type", "char", "EVEN"),
+        new NcoJsonAttribute("units", "char", "degrees_north"));
+
+    assertNcoVariable(
+        variables,
+        "time",
+        List.of("row"),
+        "double",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Time"),
+        new NcoJsonAttribute("actual_range", "double", List.of(2.474064E8, 1.6389648E9)),
+        new NcoJsonAttribute("axis", "char", "T"),
+        new NcoJsonAttribute("ioos_category", "char", "Time"),
+        new NcoJsonAttribute("long_name", "char", "Centered Time"),
+        new NcoJsonAttribute("standard_name", "char", "time"),
+        new NcoJsonAttribute("time_origin", "char", "01-JAN-1970 00:00:00"),
+        new NcoJsonAttribute("type", "char", "EVEN"),
+        new NcoJsonAttribute("units", "char", "seconds since 1970-01-01T00:00:00Z"));
+
+    assertNcoVariable(
+        variables,
+        "depth",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Height"),
+        new NcoJsonAttribute("_CoordinateZisPositive", "char", "down"),
+        new NcoJsonAttribute("actual_range", "float", List.of(1.0, 15.0)),
+        new NcoJsonAttribute("axis", "char", "Z"),
+        new NcoJsonAttribute("epic_code", "int", 3),
+        new NcoJsonAttribute("ioos_category", "char", "Location"),
+        new NcoJsonAttribute("long_name", "char", "Depth"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("positive", "char", "down"),
+        new NcoJsonAttribute("standard_name", "char", "depth"),
+        new NcoJsonAttribute("type", "char", "EVEN"),
+        new NcoJsonAttribute("units", "char", "m"));
+
+    assertNcoVariable(
+        variables,
+        "T_25",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("actual_range", "float", List.of(17.12, 35.4621)),
+        new NcoJsonAttribute("colorBarMaximum", "double", 32.0),
+        new NcoJsonAttribute("colorBarMinimum", "double", 0.0),
+        new NcoJsonAttribute("epic_code", "int", 25),
+        new NcoJsonAttribute("generic_name", "char", "temp"),
+        new NcoJsonAttribute("ioos_category", "char", "Temperature"),
+        new NcoJsonAttribute("long_name", "char", "Sea Surface Temperature"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("name", "char", "T"),
+        new NcoJsonAttribute("standard_name", "char", "sea_surface_temperature"),
+        new NcoJsonAttribute("units", "char", "degree_C"));
+
+    assertNcoVariable(
+        variables,
+        "QT_5025",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("actual_range", "float", List.of(0.0, 5.0)),
+        new NcoJsonAttribute("colorBarContinuous", "char", "false"),
+        new NcoJsonAttribute("colorBarMaximum", "double", 6.0),
+        new NcoJsonAttribute("colorBarMinimum", "double", 0.0),
+        new NcoJsonAttribute(
+            "description",
+            "char",
+            "Quality: 0=missing data, 1=highest, 2=standard, 3=lower, 4=questionable, 5=bad, -9=contact Dai.C.McClurg@noaa.gov.  To get probably valid data only, request QT_5025>=1 and QT_5025<=3."),
+        new NcoJsonAttribute("epic_code", "int", 5025),
+        new NcoJsonAttribute("generic_name", "char", "qt"),
+        new NcoJsonAttribute("ioos_category", "char", "Quality"),
+        new NcoJsonAttribute("long_name", "char", "Sea Surface Temperature Quality"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("name", "char", "QT"));
+
+    assertNcoVariable(
+        variables,
+        "ST_6025",
+        List.of("row"),
+        "float",
+        new NcoJsonAttribute("actual_range", "float", List.of(0.0, 5.0)),
+        new NcoJsonAttribute("colorBarContinuous", "char", "false"),
+        new NcoJsonAttribute("colorBarMaximum", "double", 8.0),
+        new NcoJsonAttribute("colorBarMinimum", "double", 0.0),
+        new NcoJsonAttribute(
+            "description",
+            "char",
+            "Source Codes:\n0 = No Sensor, No Data\n1 = Real Time (Telemetered Mode)\n2 = Derived from Real Time\n3 = Temporally Interpolated from Real Time\n4 = Source Code Inactive at Present\n5 = Recovered from Instrument RAM (Delayed Mode)\n6 = Derived from RAM\n7 = Temporally Interpolated from RAM"),
+        new NcoJsonAttribute("epic_code", "int", 6025),
+        new NcoJsonAttribute("generic_name", "char", "st"),
+        new NcoJsonAttribute("ioos_category", "char", "Other"),
+        new NcoJsonAttribute("long_name", "char", "Sea Surface Temperature Source"),
+        new NcoJsonAttribute("missing_value", "float", 1.0E35),
+        new NcoJsonAttribute("name", "char", "ST"));
+
+    // compare full ncoJson response string literal to expected
+    // NOTE: set a breakpoint to access ncoJson metadata from the test server at
+    // http://localhost:8080/erddap/info/pmelTaoDySst/index.ncoJson
+    // newline \n and quote \" characters must be double escaped to \\n and \\" respectively
+    String expectedPmelTaoDySstNcoJsonResponseStr =
+        """
+        {
+          "attributes": {
+            "cdm_data_type": {"type": "char", "data": "TimeSeries"},
+            "cdm_timeseries_variables": {"type": "char", "data": "array, station, wmo_platform_code, longitude, latitude, depth"},
+            "Conventions": {"type": "char", "data": "COARDS, CF-1.6, ACDD-1.3"},
+            "creator_email": {"type": "char", "data": "Dai.C.McClurg@noaa.gov"},
+            "creator_name": {"type": "char", "data": "GTMBA Project Office/NOAA/PMEL"},
+            "creator_type": {"type": "char", "data": "group"},
+            "creator_url": {"type": "char", "data": "https://www.pmel.noaa.gov/gtmba/mission"},
+            "Data_Source": {"type": "char", "data": "Global Tropical Moored Buoy Array Project Office/NOAA/PMEL"},
+            "defaultGraphQuery": {"type": "char", "data": "longitude,latitude,T_25&time>=now-7days"},
+            "Easternmost_Easting": {"type": "double", "data": 357.0},
+            "featureType": {"type": "char", "data": "TimeSeries"},
+            "File_info": {"type": "char", "data": "Contact: Dai.C.McClurg@noaa.gov"},
+            "geospatial_lat_max": {"type": "double", "data": 21.0},
+            "geospatial_lat_min": {"type": "double", "data": -25.0},
+            "geospatial_lat_units": {"type": "char", "data": "degrees_north"},
+            "geospatial_lon_max": {"type": "double", "data": 357.0},
+            "geospatial_lon_min": {"type": "double", "data": 0.0},
+            "geospatial_lon_units": {"type": "char", "data": "degrees_east"},
+            "geospatial_vertical_max": {"type": "double", "data": 15.0},
+            "geospatial_vertical_min": {"type": "double", "data": 1.0},
+            "geospatial_vertical_positive": {"type": "char", "data": "down"},
+            "geospatial_vertical_units": {"type": "char", "data": "m"},
+            "history": {"type": "char", "data": "This dataset has data from the TAO/TRITON, RAMA, and PIRATA projects.\\nThis dataset is a product of the TAO Project Office at NOAA/PMEL.\\n2018-08-02 Bob Simons at NOAA/NMFS/SWFSC/ERD (bob.simons@noaa.gov) fully refreshed ERD's copy of this dataset by downloading all of the .cdf files from the PMEL TAO FTP site.  Since then, the dataset has been partially refreshed everyday by downloading and merging the latest version of the last 25 days worth of data."},
+            "infoUrl": {"type": "char", "data": "https://www.pmel.noaa.gov/gtmba/mission"},
+            "institution": {"type": "char", "data": "NOAA PMEL, TAO/TRITON, RAMA, PIRATA"},
+            "keywords": {"type": "char", "data": "buoys, centered, daily, depth, Earth Science > Oceans > Ocean Temperature > Sea Surface Temperature, identifier, noaa, ocean, oceans, pirata, pmel, quality, rama, sea, sea_surface_temperature, source, station, surface, tao, temperature, time, triton"},
+            "keywords_vocabulary": {"type": "char", "data": "GCMD Science Keywords"},
+            "license": {"type": "char", "data": "Request for Acknowledgement: If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115\\n\\nThe data may be used and redistributed for free but is not intended\\nfor legal use, since it may contain inaccuracies. Neither the data\\nContributor, ERD, NOAA, nor the United States Government, nor any\\nof their employees or contractors, makes any warranty, express or\\nimplied, including warranties of merchantability and fitness for a\\nparticular purpose, or assumes any legal liability for the accuracy,\\ncompleteness, or usefulness, of this information."},
+            "Northernmost_Northing": {"type": "double", "data": 21.0},
+            "project": {"type": "char", "data": "TAO/TRITON, RAMA, PIRATA"},
+            "Request_for_acknowledgement": {"type": "char", "data": "If you use these data in publications or presentations, please acknowledge the GTMBA Project Office of NOAA/PMEL. Also, we would appreciate receiving a preprint and/or reprint of publications utilizing the data for inclusion in our bibliography. Relevant publications should be sent to: GTMBA Project Office, NOAA/Pacific Marine Environmental Laboratory, 7600 Sand Point Way NE, Seattle, WA 98115"},
+            "sourceUrl": {"type": "char", "data": "(local files)"},
+            "Southernmost_Northing": {"type": "double", "data": -25.0},
+            "standard_name_vocabulary": {"type": "char", "data": "CF Standard Name Table v70"},
+            "subsetVariables": {"type": "char", "data": "array, station, wmo_platform_code, longitude, latitude, depth"},
+            "summary": {"type": "char", "data": "This dataset has daily Sea Surface Temperature (SST) data from the\\nTAO/TRITON (Pacific Ocean, https://www.pmel.noaa.gov/gtmba/ ),\\nRAMA (Indian Ocean, https://www.pmel.noaa.gov/gtmba/pmel-theme/indian-ocean-rama ), and\\nPIRATA (Atlantic Ocean, https://www.pmel.noaa.gov/gtmba/pirata/ )\\narrays of moored buoys which transmit oceanographic and meteorological data to shore in real-time via the Argos satellite system.  These buoys are major components of the CLIVAR climate analysis project and the GOOS, GCOS, and GEOSS observing systems.  Daily averages are computed starting at 00:00Z and are assigned an observation 'time' of 12:00Z.  For more information, see\\nhttps://www.pmel.noaa.gov/gtmba/mission ."},
+            "testOutOfDate": {"type": "char", "data": "now-3days"},
+            "time_coverage_end": {"type": "char", "data": "2021-12-08T12:00:00Z"},
+            "time_coverage_start": {"type": "char", "data": "1977-11-03T12:00:00Z"},
+            "title": {"type": "char", "data": "TAO/TRITON, RAMA, and PIRATA Buoys, Daily, 1977-present, Sea Surface Temperature"},
+            "Westernmost_Easting": {"type": "double", "data": 0.0}
+          },
+          "dimensions": {
+            "row": 0,
+            "array_strlen": 1,
+            "station_strlen": 1
+          },
+          "variables": {
+            "array": {
+              "shape": ["row", "array_strlen"],
+              "type": "char",
+              "attributes": {
+                "ioos_category": {"type": "char", "data": "Identifier"},
+                "long_name": {"type": "char", "data": "Array"}
+              }
+            },
+            "station": {
+              "shape": ["row", "station_strlen"],
+              "type": "char",
+              "attributes": {
+                "cf_role": {"type": "char", "data": "timeseries_id"},
+                "ioos_category": {"type": "char", "data": "Identifier"},
+                "long_name": {"type": "char", "data": "Station"}
+              }
+            },
+            "wmo_platform_code": {
+              "shape": ["row"],
+              "type": "int",
+              "attributes": {
+                "actual_range": {"type": "int", "data": [13001, 56055]},
+                "ioos_category": {"type": "char", "data": "Identifier"},
+                "long_name": {"type": "char", "data": "WMO Platform Code"},
+                "missing_value": {"type": "int", "data": 2147483647}
+              }
+            },
+            "longitude": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "_CoordinateAxisType": {"type": "char", "data": "Lon"},
+                "actual_range": {"type": "float", "data": [0.0, 357.0]},
+                "axis": {"type": "char", "data": "X"},
+                "epic_code": {"type": "int", "data": 502},
+                "ioos_category": {"type": "char", "data": "Location"},
+                "long_name": {"type": "char", "data": "Nominal Longitude"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "standard_name": {"type": "char", "data": "longitude"},
+                "type": {"type": "char", "data": "EVEN"},
+                "units": {"type": "char", "data": "degrees_east"}
+              }
+            },
+            "latitude": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "_CoordinateAxisType": {"type": "char", "data": "Lat"},
+                "actual_range": {"type": "float", "data": [-25.0, 21.0]},
+                "axis": {"type": "char", "data": "Y"},
+                "epic_code": {"type": "int", "data": 500},
+                "ioos_category": {"type": "char", "data": "Location"},
+                "long_name": {"type": "char", "data": "Nominal Latitude"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "standard_name": {"type": "char", "data": "latitude"},
+                "type": {"type": "char", "data": "EVEN"},
+                "units": {"type": "char", "data": "degrees_north"}
+              }
+            },
+            "time": {
+              "shape": ["row"],
+              "type": "double",
+              "attributes": {
+                "_CoordinateAxisType": {"type": "char", "data": "Time"},
+                "actual_range": {"type": "double", "data": [2.474064E8, 1.6389648E9]},
+                "axis": {"type": "char", "data": "T"},
+                "ioos_category": {"type": "char", "data": "Time"},
+                "long_name": {"type": "char", "data": "Centered Time"},
+                "standard_name": {"type": "char", "data": "time"},
+                "time_origin": {"type": "char", "data": "01-JAN-1970 00:00:00"},
+                "type": {"type": "char", "data": "EVEN"},
+                "units": {"type": "char", "data": "seconds since 1970-01-01T00:00:00Z"}
+              }
+            },
+            "depth": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "_CoordinateAxisType": {"type": "char", "data": "Height"},
+                "_CoordinateZisPositive": {"type": "char", "data": "down"},
+                "actual_range": {"type": "float", "data": [1.0, 15.0]},
+                "axis": {"type": "char", "data": "Z"},
+                "epic_code": {"type": "int", "data": 3},
+                "ioos_category": {"type": "char", "data": "Location"},
+                "long_name": {"type": "char", "data": "Depth"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "positive": {"type": "char", "data": "down"},
+                "standard_name": {"type": "char", "data": "depth"},
+                "type": {"type": "char", "data": "EVEN"},
+                "units": {"type": "char", "data": "m"}
+              }
+            },
+            "T_25": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "actual_range": {"type": "float", "data": [17.12, 35.4621]},
+                "colorBarMaximum": {"type": "double", "data": 32.0},
+                "colorBarMinimum": {"type": "double", "data": 0.0},
+                "epic_code": {"type": "int", "data": 25},
+                "generic_name": {"type": "char", "data": "temp"},
+                "ioos_category": {"type": "char", "data": "Temperature"},
+                "long_name": {"type": "char", "data": "Sea Surface Temperature"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "name": {"type": "char", "data": "T"},
+                "standard_name": {"type": "char", "data": "sea_surface_temperature"},
+                "units": {"type": "char", "data": "degree_C"}
+              }
+            },
+            "QT_5025": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "actual_range": {"type": "float", "data": [0.0, 5.0]},
+                "colorBarContinuous": {"type": "char", "data": "false"},
+                "colorBarMaximum": {"type": "double", "data": 6.0},
+                "colorBarMinimum": {"type": "double", "data": 0.0},
+                "description": {"type": "char", "data": "Quality: 0=missing data, 1=highest, 2=standard, 3=lower, 4=questionable, 5=bad, -9=contact Dai.C.McClurg@noaa.gov.  To get probably valid data only, request QT_5025>=1 and QT_5025<=3."},
+                "epic_code": {"type": "int", "data": 5025},
+                "generic_name": {"type": "char", "data": "qt"},
+                "ioos_category": {"type": "char", "data": "Quality"},
+                "long_name": {"type": "char", "data": "Sea Surface Temperature Quality"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "name": {"type": "char", "data": "QT"}
+              }
+            },
+            "ST_6025": {
+              "shape": ["row"],
+              "type": "float",
+              "attributes": {
+                "actual_range": {"type": "float", "data": [0.0, 5.0]},
+                "colorBarContinuous": {"type": "char", "data": "false"},
+                "colorBarMaximum": {"type": "double", "data": 8.0},
+                "colorBarMinimum": {"type": "double", "data": 0.0},
+                "description": {"type": "char", "data": "Source Codes:\\n0 = No Sensor, No Data\\n1 = Real Time (Telemetered Mode)\\n2 = Derived from Real Time\\n3 = Temporally Interpolated from Real Time\\n4 = Source Code Inactive at Present\\n5 = Recovered from Instrument RAM (Delayed Mode)\\n6 = Derived from RAM\\n7 = Temporally Interpolated from RAM"},
+                "epic_code": {"type": "int", "data": 6025},
+                "generic_name": {"type": "char", "data": "st"},
+                "ioos_category": {"type": "char", "data": "Other"},
+                "long_name": {"type": "char", "data": "Sea Surface Temperature Source"},
+                "missing_value": {"type": "float", "data": 1.0E35},
+                "name": {"type": "char", "data": "ST"}
+              }
+            }
+          }
+        }
+        """;
+
+    assertEquals(
+        expectedPmelTaoDySstNcoJsonResponseStr,
+        pmelTaoDySstNcoJsonResponseStr,
+        "pmelTaoDySst ncoJson metadata response does not match expected: "
+            + String2.differentLine(
+                expectedPmelTaoDySstNcoJsonResponseStr, pmelTaoDySstNcoJsonResponseStr));
+
+    // ensure that the ncoJson metadata response is exactly like an ncoJson data response
+    // ignoring the history global attribute and variable data
+    client.send(
+        HttpRequest.newBuilder(
+                server.getURI().resolve("/erddap/tabledap/pmelTaoDySst.ncoJson?&time=max(time)"))
+            .GET()
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    JSONObject dataResponse = new JSONObject(response.body());
+    // remove history from global attributes and data from variables
+    dataResponse.getJSONObject("attributes").remove("history");
+    for (String varName : dataResponse.getJSONObject("variables").keySet()) {
+      dataResponse.getJSONObject("variables").getJSONObject(varName).remove("data");
+    }
+    pmelTaoDySstNcoJsonResponse.getJSONObject("attributes").remove("history");
+    assertTrue(
+        pmelTaoDySstNcoJsonResponse.similar(dataResponse),
+        "testEDDGridFromNcFilesUnpacked ncoJson data response with data attributes removed from vars does not match expected:"
+            + String2.differentLine(
+                pmelTaoDySstNcoJsonResponse.toString(2), dataResponse.toString(2)));
+  }
+
+  /**
+   * Test EDDGrid ncoJson /info (metadata) response/output.
+   *
+   * @throws Exception if trouble
+   */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void testEDDGridNcoJsonMetadata() throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+
+    HttpResponse<String> response =
+        client.send(
+            HttpRequest.newBuilder(
+                    server
+                        .getURI()
+                        .resolve("/erddap/info/testEDDGridFromNcFilesUnpacked/index.ncoJson"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    String testEDDGridFromNcFilesUnpackedNcoJsonResponseStr = response.body();
+    JSONObject testEDDGridFromNcFilesUnpackedNcoJsonResponse =
+        new JSONObject(testEDDGridFromNcFilesUnpackedNcoJsonResponseStr);
+    assertNotNull(testEDDGridFromNcFilesUnpackedNcoJsonResponse);
+    assertTrue(
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.has("attributes"),
+        "testEDDGridFromNcFilesUnpacked ncoJson metadata has no attributes");
+    assertTrue(
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.has("dimensions"),
+        "testEDDGridFromNcFilesUnpacked ncoJson metadata has no dimensions");
+    assertTrue(
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.has("variables"),
+        "testEDDGridFromNcFilesUnpacked ncoJson metadata has no variables");
+
+    JSONObject globalAttrs =
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.getJSONObject("attributes");
+    // full ncoJson is tested below so global attr testing doesn't need to be exhaustive here
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("cdm_data_type", "char", "Grid"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("contact", "char", "ghrsst@podaac.jpl.nasa.gov"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("Conventions", "char", "CF-1.6, COARDS, ACDD-1.3"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("creator_email", "char", "ghrsst@podaac.jpl.nasa.gov"));
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("creator_name", "char", "GHRSST"));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("creator_url", "char", "https://podaac.jpl.nasa.gov/"));
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("geospatial_lat_max", "float", 20.0995));
+    assertNcoAttribute(globalAttrs, new NcoJsonAttribute("geospatial_lat_min", "float", 20.0006));
+    assertNcoAttribute(
+        globalAttrs, new NcoJsonAttribute("geospatial_lat_units", "char", "degrees_north"));
+    assertNcoAttribute(
+        globalAttrs,
+        new NcoJsonAttribute(
+            "title", "char", "Daily MUR SST, Interim near-real-time (nrt) product"));
+
+    JSONObject dimensions =
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.getJSONObject("dimensions");
+    assertNcoDimension(dimensions, "time", 2);
+    assertNcoDimension(dimensions, "latitude", 10);
+    assertNcoDimension(dimensions, "longitude", 10);
+
+    JSONObject variables = testEDDGridFromNcFilesUnpackedNcoJsonResponse.getJSONObject("variables");
+    assertNcoVariable(
+        variables,
+        "time",
+        List.of("time"),
+        "double",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Time"),
+        new NcoJsonAttribute("actual_range", "double", List.of(1.4440356E9, 1.444122E9)),
+        new NcoJsonAttribute("axis", "char", "T"),
+        new NcoJsonAttribute("ioos_category", "char", "Time"),
+        new NcoJsonAttribute("long_name", "char", "reference time of sst field"),
+        new NcoJsonAttribute("standard_name", "char", "time"),
+        new NcoJsonAttribute("time_origin", "char", "01-JAN-1970 00:00:00"),
+        new NcoJsonAttribute("units", "char", "seconds since 1970-01-01T00:00:00Z"));
+    assertNcoVariable(
+        variables,
+        "latitude",
+        List.of("latitude"),
+        "float",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Lat"),
+        new NcoJsonAttribute("actual_range", "float", List.of(20.0006, 20.0995)),
+        new NcoJsonAttribute("axis", "char", "Y"),
+        new NcoJsonAttribute("ioos_category", "char", "Location"),
+        new NcoJsonAttribute("long_name", "char", "Latitude"),
+        new NcoJsonAttribute("standard_name", "char", "latitude"),
+        new NcoJsonAttribute("units", "char", "degrees_north"),
+        new NcoJsonAttribute("valid_max", "float", 90.0),
+        new NcoJsonAttribute("valid_min", "float", -90.0));
+
+    assertNcoVariable(
+        variables,
+        "longitude",
+        List.of("longitude"),
+        "float",
+        new NcoJsonAttribute("_CoordinateAxisType", "char", "Lon"),
+        new NcoJsonAttribute("actual_range", "float", List.of(-134.995, -134.896)),
+        new NcoJsonAttribute("axis", "char", "X"),
+        new NcoJsonAttribute("ioos_category", "char", "Location"),
+        new NcoJsonAttribute("long_name", "char", "Longitude"),
+        new NcoJsonAttribute("standard_name", "char", "longitude"),
+        new NcoJsonAttribute("units", "char", "degrees_east"),
+        new NcoJsonAttribute("valid_max", "float", 180.0),
+        new NcoJsonAttribute("valid_min", "float", -180.0));
+
+    assertNcoVariable(
+        variables,
+        "analysed_sst",
+        List.of("time", "latitude", "longitude"),
+        "double",
+        new NcoJsonAttribute("_FillValue", "double", null),
+        new NcoJsonAttribute("colorBarMaximum", "double", 305.0),
+        new NcoJsonAttribute("colorBarMinimum", "double", 273.0),
+        new NcoJsonAttribute(
+            "comment",
+            "char",
+            "Interim near-real-time (nrt) version; to be replaced by Final version"),
+        new NcoJsonAttribute("ioos_category", "char", "Temperature"),
+        new NcoJsonAttribute("long_name", "char", "analysed sea surface temperature"),
+        new NcoJsonAttribute("standard_name", "char", "sea_surface_foundation_temperature"),
+        new NcoJsonAttribute("units", "char", "degree_K"),
+        new NcoJsonAttribute("valid_max", "double", 330.917),
+        new NcoJsonAttribute("valid_min", "double", 265.383));
+
+    // compare full ncoJson response string literal to expected
+    // NOTE: set a breakpoint to access ncoJson metadata from the test server at
+    // http://localhost:8080/erddap/info/testEDDGridFromNcFilesUnpacked/index.ncoJson
+    // newline \n and quote \" characters must be double escaped to \\n and \\" respectively
+    String expectedTestEDDGridFromNcFilesUnpackedNcoJsonResponse =
+        """
+      {
+        "attributes": {
+          "cdm_data_type": {"type": "char", "data": "Grid"},
+          "comment": {"type": "char", "data": "Interim-MUR(nrt) will be replaced by MUR-Final in about 3 days; MUR = \\"Multi-scale Ultra-high Resolution\\"; produced under NASA MEaSUREs program."},
+          "contact": {"type": "char", "data": "ghrsst@podaac.jpl.nasa.gov"},
+          "Conventions": {"type": "char", "data": "CF-1.6, COARDS, ACDD-1.3"},
+          "creation_date": {"type": "char", "data": "2015-10-06"},
+          "creator_email": {"type": "char", "data": "ghrsst@podaac.jpl.nasa.gov"},
+          "creator_name": {"type": "char", "data": "GHRSST"},
+          "creator_url": {"type": "char", "data": "https://podaac.jpl.nasa.gov/"},
+          "DSD_entry_id": {"type": "char", "data": "JPL-L4UHfnd-GLOB-MUR"},
+          "Easternmost_Easting": {"type": "float", "data": -134.896},
+          "file_quality_index": {"type": "char", "data": "0"},
+          "GDS_version_id": {"type": "char", "data": "GDS-v1.0-rev1.6"},
+          "geospatial_lat_max": {"type": "float", "data": 20.0995},
+          "geospatial_lat_min": {"type": "float", "data": 20.0006},
+          "geospatial_lat_units": {"type": "char", "data": "degrees_north"},
+          "geospatial_lon_max": {"type": "float", "data": -134.896},
+          "geospatial_lon_min": {"type": "float", "data": -134.995},
+          "geospatial_lon_resolution": {"type": "double", "data": 0.011000000000001996},
+          "geospatial_lon_units": {"type": "char", "data": "degrees_east"},
+          "history": {"type": "char", "data": "Interim near-real-time (nrt) version created at nominal 1-day latency."},
+          "infoUrl": {"type": "char", "data": "https://podaac.jpl.nasa.gov/"},
+          "institution": {"type": "char", "data": "Jet Propulsion Laboratory"},
+          "keywords": {"type": "char", "data": "analysed, analysed_sst, daily, data, day, earth, Earth Science > Oceans > Ocean Temperature > Sea Surface Temperature, environments, foundation, high, interim, jet, laboratory, making, measures, multi, multi-scale, mur, near, near real time, near-real-time, nrt, ocean, oceans, product, propulsion, real, records, research, resolution, scale, sea, sea_surface_foundation_temperature, sst, surface, system, temperature, time, ultra, ultra-high, use"},
+          "keywords_vocabulary": {"type": "char", "data": "GCMD Science Keywords"},
+          "license": {"type": "char", "data": "The data may be used and redistributed for free but is not intended\\nfor legal use, since it may contain inaccuracies. Neither the data\\nContributor, ERD, NOAA, nor the United States Government, nor any\\nof their employees or contractors, makes any warranty, express or\\nimplied, including warranties of merchantability and fitness for a\\nparticular purpose, or assumes any legal liability for the accuracy,\\ncompleteness, or usefulness, of this information."},
+          "netcdf_version_id": {"type": "char", "data": "3.5"},
+          "Northernmost_Northing": {"type": "float", "data": 20.0995},
+          "product_version": {"type": "char", "data": "04nrt"},
+          "references": {"type": "char", "data": "ftp://mariana.jpl.nasa.gov/mur_sst/tmchin/docs/ATBD/"},
+          "source_data": {"type": "char", "data": "AVHRR19_G-NAVO, AVHRR_METOP_A-EUMETSAT, MODIS_A-JPL, MODIS_T-JPL, WSAT-REMSS, iQUAM-NOAA/NESDIS, Ice_Conc-OSISAF"},
+          "sourceUrl": {"type": "char", "data": "(local files)"},
+          "Southernmost_Northing": {"type": "float", "data": 20.0006},
+          "spatial_resolution": {"type": "char", "data": "0.011 degrees"},
+          "standard_name_vocabulary": {"type": "char", "data": "CF Standard Name Table v70"},
+          "summary": {"type": "char", "data": "Interim-Multi-scale Ultra-high Resolution (MUR)(nrt) will be replaced by MUR-Final in about 3 days; MUR = \\"Multi-scale Ultra-high Resolution\\"; produced under NASA Making Earth System Data Records for Use in Research Environments (MEaSUREs) program."},
+          "time_coverage_end": {"type": "char", "data": "2015-10-06T09:00:00Z"},
+          "time_coverage_start": {"type": "char", "data": "2015-10-05T09:00:00Z"},
+          "title": {"type": "char", "data": "Daily MUR SST, Interim near-real-time (nrt) product"},
+          "Westernmost_Easting": {"type": "float", "data": -134.995}
+        },
+        "dimensions": {
+          "time": 2,
+          "latitude": 10,
+          "longitude": 10
+        },
+        "variables": {
+          "time": {
+            "shape": ["time"],
+            "type": "double",
+            "attributes": {
+              "_CoordinateAxisType": {"type": "char", "data": "Time"},
+              "actual_range": {"type": "double", "data": [1.4440356E9, 1.444122E9]},
+              "axis": {"type": "char", "data": "T"},
+              "ioos_category": {"type": "char", "data": "Time"},
+              "long_name": {"type": "char", "data": "reference time of sst field"},
+              "standard_name": {"type": "char", "data": "time"},
+              "time_origin": {"type": "char", "data": "01-JAN-1970 00:00:00"},
+              "units": {"type": "char", "data": "seconds since 1970-01-01T00:00:00Z"}
+            }
+          },
+          "latitude": {
+            "shape": ["latitude"],
+            "type": "float",
+            "attributes": {
+              "_CoordinateAxisType": {"type": "char", "data": "Lat"},
+              "actual_range": {"type": "float", "data": [20.0006, 20.0995]},
+              "axis": {"type": "char", "data": "Y"},
+              "ioos_category": {"type": "char", "data": "Location"},
+              "long_name": {"type": "char", "data": "Latitude"},
+              "standard_name": {"type": "char", "data": "latitude"},
+              "units": {"type": "char", "data": "degrees_north"},
+              "valid_max": {"type": "float", "data": 90.0},
+              "valid_min": {"type": "float", "data": -90.0}
+            }
+          },
+          "longitude": {
+            "shape": ["longitude"],
+            "type": "float",
+            "attributes": {
+              "_CoordinateAxisType": {"type": "char", "data": "Lon"},
+              "actual_range": {"type": "float", "data": [-134.995, -134.896]},
+              "axis": {"type": "char", "data": "X"},
+              "ioos_category": {"type": "char", "data": "Location"},
+              "long_name": {"type": "char", "data": "Longitude"},
+              "standard_name": {"type": "char", "data": "longitude"},
+              "units": {"type": "char", "data": "degrees_east"},
+              "valid_max": {"type": "float", "data": 180.0},
+              "valid_min": {"type": "float", "data": -180.0}
+            }
+          },
+          "analysed_sst": {
+            "shape": ["time", "latitude", "longitude"],
+            "type": "double",
+            "attributes": {
+              "_FillValue": {"type": "double", "data": null},
+              "colorBarMaximum": {"type": "double", "data": 305.0},
+              "colorBarMinimum": {"type": "double", "data": 273.0},
+              "comment": {"type": "char", "data": "Interim near-real-time (nrt) version; to be replaced by Final version"},
+              "ioos_category": {"type": "char", "data": "Temperature"},
+              "long_name": {"type": "char", "data": "analysed sea surface temperature"},
+              "standard_name": {"type": "char", "data": "sea_surface_foundation_temperature"},
+              "units": {"type": "char", "data": "degree_K"},
+              "valid_max": {"type": "double", "data": 330.917},
+              "valid_min": {"type": "double", "data": 265.383}
+            }
+          }
+        }
+      }
+      """;
+    assertEquals(
+        expectedTestEDDGridFromNcFilesUnpackedNcoJsonResponse,
+        testEDDGridFromNcFilesUnpackedNcoJsonResponseStr,
+        "testEDDGridFromNcFilesUnpacked ncoJson metadata response does not match expected: "
+            + String2.differentLine(
+                expectedTestEDDGridFromNcFilesUnpackedNcoJsonResponse,
+                testEDDGridFromNcFilesUnpackedNcoJsonResponseStr));
+
+    // ensure that the ncoJson metadata response is exactly like an ncoJson data response
+    // ignoring the history global attribute and variable data
+    response =
+        client.send(
+            HttpRequest.newBuilder(
+                    server
+                        .getURI()
+                        .resolve("/erddap/griddap/testEDDGridFromNcFilesUnpacked.ncoJson"))
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(200, response.statusCode());
+    JSONObject dataResponse = new JSONObject(response.body());
+    // remove history from global attributes and data from variables
+    dataResponse.getJSONObject("attributes").remove("history");
+    for (String varName : dataResponse.getJSONObject("variables").keySet()) {
+      dataResponse.getJSONObject("variables").getJSONObject(varName).remove("data");
+    }
+    testEDDGridFromNcFilesUnpackedNcoJsonResponse.getJSONObject("attributes").remove("history");
+    assertTrue(
+        testEDDGridFromNcFilesUnpackedNcoJsonResponse.similar(dataResponse),
+        "testEDDGridFromNcFilesUnpacked ncoJson data response with history and data removed does not match expected: "
+            + String2.differentLine(
+                testEDDGridFromNcFilesUnpackedNcoJsonResponse.toString(2),
+                dataResponse.toString(2)));
   }
 
   /* FileVisitorDNLS */


### PR DESCRIPTION
# Description

* Add ncoJson as a metadata/info format (/erddap/info/datasetId/index.ncoJson, reusing and slightly refactoring existing ncoJson generation code in NcoJsonFiles)
* Support short form info URLs (e.g. /erddap/info/datasetId.ncoJson)
* Update JettyTests to use EDStatic.initialLoadDatasets() to determine how long to wait for test server to load test datasets

May address #39 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
