### PR TITLE
Create a JSON webservice for ERDDAP's variable attribute suggestions

### DIFF
--- a/WEB-INF/classes/com/cohort/array/Attributes.java
+++ b/WEB-INF/classes/com/cohort/array/Attributes.java
@@ -920,10 +920,12 @@ public class Attributes {
    *
    * @param indent a String a spaces for the start of each line
    * @param includeTrailingComma if true, a comma is included after the closing } of the attributes
+   * @param includeWrapper if true, the attributes are wrapped in "attributes": { ... }
    * @return a string with all of the attributes for a variable (or *GLOBAL*) formatted for NCO
    *     JSON, with a comma after the closing }.
    */
-  public String toNcoJsonString(String indent, boolean includeTrailingComma) {
+  public String toNcoJsonString(
+      String indent, boolean includeTrailingComma, boolean includeWrapper) {
     StringBuilder sb = new StringBuilder();
 
     // "attributes": {
@@ -938,7 +940,10 @@ public class Attributes {
     //  "double_att": { "type": "double", "data": [73.0, 72.0, 71.0, 70.010, 69.0010, 68.010,
     // 67.0100010]}
     // },
-    sb.append(indent + "\"attributes\": {\n");
+    if (includeWrapper) {
+      sb.append(indent + "\"attributes\": ");
+    }
+    sb.append("{\n");
 
     // each of the attributes
     String names[] = getNames();
@@ -960,7 +965,7 @@ public class Attributes {
       }
       sb.append(
           (somethingWritten ? ",\n" : "")
-              + indent
+              + (includeWrapper ? indent : "")
               + "  "
               + String2.toJson(tName)
               + ": {\"type\": \""
@@ -986,7 +991,7 @@ public class Attributes {
     sb.append(
         (somethingWritten ? "\n" : "")
             + // end previous line
-            indent
+            (includeWrapper ? indent : "")
             + "}"
             + (includeTrailingComma ? "," : "")
             + "\n");

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/Erddap.java
@@ -102,6 +102,7 @@ import java.util.BitSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -118,6 +119,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.semver4j.Semver;
@@ -938,6 +940,8 @@ public class Erddap extends HttpServlet {
         doVersion(request, response);
       } else if (endOfRequest.equals("version_string")) {
         doVersionString(request, response);
+      } else if (endOfRequest.equals("suggestVariableAttributes")) {
+        doSuggestVariableAttributes(language, requestNumber, request, response);
       } else {
         sendResourceNotFoundError(
             requestNumber,
@@ -1061,6 +1065,187 @@ public class Erddap extends HttpServlet {
       } catch (Throwable t2) {
         String2.log("Caught: " + MustBe.throwableToString(t2));
       }
+    }
+  }
+
+  /**
+   * Make ERDDAP's variable attribute suggestions available as a web service for dataset
+   * configuration use cases. Accept an ncoJson style request payload of variables with attributes
+   * and return variable attribute suggestions provided by
+   * EDD.makeReadyToUseAddVariableAttributesForDatasetsXml
+   *
+   * @param language the language index
+   * @param requestNumber the request number
+   * @param request the HttpServletRequest
+   * @param response the HttpServletResponse
+   * @throws Throwable if an error is encountered during request processing
+   */
+  private void doSuggestVariableAttributes(
+      int language, int requestNumber, HttpServletRequest request, HttpServletResponse response)
+      throws Throwable {
+    String contentType = request.getHeader("Content-Type");
+    String applicationJson = "application/json";
+    if (contentType == null || !contentType.toLowerCase().startsWith(applicationJson)) {
+      contentType = contentType == null ? "(unset)" : contentType;
+      sendGeoServicesRestError(
+          requestNumber,
+          request,
+          response,
+          true,
+          HttpServletResponse.SC_UNSUPPORTED_MEDIA_TYPE,
+          "Unsupported Content-Type: " + contentType + ". Expected: " + applicationJson,
+          null);
+      return;
+    }
+
+    String jsonp = request.getParameter("jsonp");
+    if (jsonp != null && !String2.isJsonpNameSafe(jsonp)) {
+      sendGeoServicesRestError(
+          requestNumber,
+          request,
+          response,
+          true,
+          HttpServletResponse.SC_BAD_REQUEST,
+          "Unsafe jsonp parameter: " + jsonp,
+          "jsonp parameter must be a valid JavaScript callback function name.");
+      return;
+    }
+
+    String acceptHeader = request.getHeader("Accept");
+    if (acceptHeader != null && !acceptHeader.equals("*/*")) {
+      acceptHeader = acceptHeader.toLowerCase();
+      if (acceptHeader.equals("application/json")) {
+        jsonp = null; // if Accept header is application/json, ignore jsonp parameter
+      } else if (acceptHeader.equals("application/javascript")) {
+        if (jsonp == null)
+          jsonp =
+              "callback"; // default callback name if Accept header is application/javascript and no
+        // jsonp parameter is provided
+      } else {
+        sendGeoServicesRestError(
+            requestNumber,
+            request,
+            response,
+            true,
+            HttpServletResponse.SC_BAD_REQUEST,
+            "Unsupported Accept header: " + acceptHeader,
+            "Allowed values: application/json, application/javascript");
+        return;
+      }
+    }
+
+    String ncoJsonLevel = Objects.requireNonNullElse(request.getParameter("ncoJsonLevel"), "0");
+    if (!ncoJsonLevel.equals("0") && !ncoJsonLevel.equals("2")) {
+      sendGeoServicesRestError(
+          requestNumber,
+          request,
+          response,
+          true,
+          HttpServletResponse.SC_BAD_REQUEST,
+          "Unsupported ncoJsonLevel",
+          "Allowed values: 0, 2");
+      return;
+    }
+
+    // read request body as JSON
+    JSONObject requestJson;
+    try {
+      JSONTokener tokener = new JSONTokener(request.getReader());
+      if (!tokener.more()) {
+        sendGeoServicesRestError(
+            requestNumber,
+            request,
+            response,
+            true,
+            HttpServletResponse.SC_BAD_REQUEST,
+            "Request body must not be empty.",
+            """
+                Provide an ncoJson style request body containing a "variables" object with attributes. Example:
+                {"variables": {"air_temp": {"name": "Air Temperature", "units": "degrees_Celsius"}}}
+                """);
+        return;
+      }
+      requestJson = new JSONObject(tokener);
+    } catch (JSONException e) {
+      sendGeoServicesRestError(
+          requestNumber,
+          request,
+          response,
+          true,
+          HttpServletResponse.SC_BAD_REQUEST,
+          "Error parsing json",
+          e.getMessage());
+      return;
+    }
+
+    // load global attributes
+    // NOTE: global attributes are only used for some corner case podaac datasets in variable
+    // attribute suggestion,
+    // so we can accept them but don't need to suggest their inclusion in the request payload
+    Attributes globalAtts = new Attributes();
+    if (requestJson.has("attributes")) {
+      JSONObject globalAttsJson = requestJson.getJSONObject("attributes");
+      globalAttsJson.keySet().forEach(key -> globalAtts.add(key, globalAttsJson.get(key)));
+    }
+
+    JSONObject processedVariablesJson = new JSONObject();
+
+    if (requestJson.has("variables")) {
+      JSONObject variablesJson = requestJson.getJSONObject("variables");
+      for (String varName : variablesJson.keySet()) {
+        Attributes varAtts = new Attributes();
+        JSONObject varJson = variablesJson.getJSONObject(varName);
+
+        // unwrap attributes if they are wrapped in an "attributes" object (standard ncoJson)
+        JSONObject varAttsJson =
+            varJson.has("attributes") ? varJson.getJSONObject("attributes") : varJson;
+
+        // load provided var attributes into Attributes
+        for (String att : varAttsJson.keySet()) {
+          if (varAttsJson.get(att) instanceof JSONObject
+              && ((JSONObject) varAttsJson.get(att)).has("data")) {
+            // unwrap ncoJson level 1 or 2 "data" attribute
+            varAtts.add(att, ((JSONObject) varAttsJson.get(att)).get("data"));
+          } else {
+            varAtts.add(att, varAttsJson.get(att));
+          }
+        }
+
+        // get suggested attributes
+        Attributes suggestedVarAttrs =
+            EDD.makeReadyToUseAddVariableAttributesForDatasetsXml(
+                globalAtts, varAtts, null, varName, true, false, true);
+
+        JSONObject processedVariableJson = new JSONObject();
+        if (ncoJsonLevel.equals("2")) {
+          // ncoJson level 2: use Attributes.toNcoJsonString
+          processedVariableJson.put(
+              "attributes", new JSONObject(suggestedVarAttrs.toNcoJsonString("", false, false)));
+        } else {
+          // ncoJson level 0: use simple key value pairs
+          JSONObject suggestedVarAttrsJson = new JSONObject();
+          for (String attr : suggestedVarAttrs.getNames()) {
+            suggestedVarAttrsJson.put(attr, suggestedVarAttrs.get(attr));
+          }
+          processedVariableJson.put("attributes", suggestedVarAttrsJson);
+        }
+
+        processedVariablesJson.put(varName, processedVariableJson);
+      }
+    }
+
+    JSONObject resultJson = new JSONObject();
+    resultJson.put("variables", processedVariablesJson);
+
+    try (Writer writer = response.getWriter()) {
+      if (jsonp != null) {
+        writer.write(jsonp + "(");
+        response.setContentType("application/javascript");
+      } else {
+        response.setContentType(applicationJson);
+      }
+      writer.write(resultJson.toString(0));
+      if (jsonp != null) writer.write(");");
     }
   }
 
@@ -12084,8 +12269,8 @@ widgets.select("frequencyOption", "", 1, frequencyOptions, frequencyOption, "") 
 
     // json
     if (fParamIsJson) {
-
-      try (Writer writer = getJsonWriter(request, response, "error", ".jsonText")) {
+      response.setStatus(httpErrorNumber);
+      try (Writer writer = getJsonWriter(request, response, "error", ".json")) {
         writer.write(
             "{\n"
                 + "  \"error\" :\n"

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/filetypes/NcoJsonFiles.java
@@ -269,7 +269,7 @@ public class NcoJsonFiles extends TableWriterFileType {
       writer.write("{\n");
 
       // write the global attributes
-      writer.write(njtmp.globalAttributes().toNcoJsonString("  ", true));
+      writer.write(njtmp.globalAttributes().toNcoJsonString("  ", true, true));
 
       // write row dimension
       // {
@@ -330,7 +330,7 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + tType
                 + "\",\n");
         // if twawm is not null, we need to write data as well
-        writer.write(atts.toNcoJsonString("      ", twawm != null));
+        writer.write(atts.toNcoJsonString("      ", twawm != null, true));
         if (twawm != null) {
           writer.write("      \"data\": [");
           try (DataInputStream dis = twawm.dataInputStream(col)) {
@@ -444,7 +444,7 @@ public class NcoJsonFiles extends TableWriterFileType {
         writer.write("{\n");
 
         // write the global attributes
-        writer.write(ada.globalAttributes().toNcoJsonString("  ", true));
+        writer.write(ada.globalAttributes().toNcoJsonString("  ", true, true));
 
         // write dimensions
         // {
@@ -498,7 +498,7 @@ public class NcoJsonFiles extends TableWriterFileType {
                   + "      \"type\": \""
                   + tType
                   + "\",\n");
-          writer.write(ada.axisAttributes(avi).toNcoJsonString("      ", writeData));
+          writer.write(ada.axisAttributes(avi).toNcoJsonString("      ", writeData, true));
           if (writeData) {
             writer.write("      \"data\": [");
             writer.write(ada.axisValues(avi).toJsonCsvString());
@@ -533,7 +533,7 @@ public class NcoJsonFiles extends TableWriterFileType {
       writer.write("{\n");
 
       // write the global attributes
-      writer.write(gda.globalAttributes().toNcoJsonString("  ", true));
+      writer.write(gda.globalAttributes().toNcoJsonString("  ", true, true));
 
       // write dimensions
       // {
@@ -607,7 +607,7 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + tType
                 + "\",\n");
 
-        writer.write(gda.axisAttributes(avi).toNcoJsonString("      ", writeData));
+        writer.write(gda.axisAttributes(avi).toNcoJsonString("      ", writeData, true));
 
         if (writeData) {
           writer.write("      \"data\": [");
@@ -660,7 +660,7 @@ public class NcoJsonFiles extends TableWriterFileType {
                 + "      \"type\": \""
                 + tType
                 + "\",\n");
-        writer.write(atts.toNcoJsonString("      ", writeData));
+        writer.write(atts.toNcoJsonString("      ", writeData, true));
         if (writeData) {
           writer.write("      \"data\":\n");
           for (int avi = 0; avi < nAV; avi++) writer.write("[ ");

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
                 <configuration>
                     <attachClasses>true</attachClasses>
                     <warSourceDirectory>${project.basedir}</warSourceDirectory>
-                    <warSourceExcludes>**/*.java, **/*.javaINACTIVE, **/*.javaInactive, **/*.java_NOT_YET, **/*.javaNOT_FINISHED, **/*.javaOLD, content/**, data/**, development/**, test-data/**, /src/test/**, target/**, src/**, WEB-INF/classes/gov/noaa/pfel/coastwatch/log.*, WEB-INF/lib/**, WEB-INF/NetCheck.*, WEB-INF/*.web.xml, WEB-INF/FileVisitorDNLS.sh, WEB-INF/incompleteMainCatalog.xml, WEB-INF/iobis.m, WEB-INF/obis.m, WEB-INF/QN2005193*, WEB-INF/ValidateDataSetProperties*, WEB-INF/fonts/**, WEB-INF/temp/**, WEB-INF/ref/*.zip, *.*, translation/**, .mvn/**, .settings/**, .github/**, .vscode/**</warSourceExcludes>
+                    <warSourceExcludes>**/*.java, **/*.javaINACTIVE, **/*.javaInactive, **/*.java_NOT_YET, **/*.javaNOT_FINISHED, **/*.javaOLD, content/**, data/**, development/**, test-data/**, /src/test/**, target/**, src/**, WEB-INF/classes/gov/noaa/pfel/coastwatch/log.*, WEB-INF/lib/**, WEB-INF/NetCheck.*, WEB-INF/*.web.xml, WEB-INF/FileVisitorDNLS.sh, WEB-INF/incompleteMainCatalog.xml, WEB-INF/iobis.m, WEB-INF/obis.m, WEB-INF/QN2005193*, WEB-INF/ValidateDataSetProperties*, WEB-INF/fonts/**, WEB-INF/temp/**, WEB-INF/ref/*.zip, *.*, translation/**, .mvn/**, .settings/**, .github/**, .vscode/**, docker/**, dokka/**, Dockerfile</warSourceExcludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/jetty/JettyTests.java
+++ b/src/test/java/jetty/JettyTests.java
@@ -70,6 +70,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.time.Year;
@@ -84,6 +85,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.apache.http.HttpStatus;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Jetty;
@@ -4981,6 +4983,302 @@ class JettyTests extends WireMockLifecycle {
             + String2.differentLine(
                 testEDDGridFromNcFilesUnpackedNcoJsonResponse.toString(2),
                 dataResponse.toString(2)));
+  }
+
+  /** Test Erddap.doSuggestVariableAttributes */
+  @org.junit.jupiter.api.Test
+  @TagJetty
+  void testSuggestVariableAttributes() throws Exception {
+    HttpClient client = HttpClient.newHttpClient();
+    URI uri = server.getURI().resolve("/erddap/suggestVariableAttributes");
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        null,
+        """
+        {
+          "variables": {
+            "air_temperature": {
+              "attributes": {
+                "name": {"type": "char", "data": "Air Temperature at station"},
+                "units": {"type": "char", "data": "degrees_Celsius"}
+              }
+            },
+            "wind_speed": {
+              "long_name": "The speed of the wind",
+              "units": "m/s"
+            }
+          }
+        }
+        """,
+        null,
+        null,
+        HttpStatus.SC_OK,
+        "application/json",
+        """
+        {
+          "variables": {
+            "air_temperature": {
+              "attributes": {
+                "ioos_category": "Temperature",
+                "standard_name": "air_temperature",
+                "units": "degree_C",
+                "long_name": "Air Temperature"
+              }
+            },
+            "wind_speed": {
+              "attributes": {
+                "ioos_category": "Wind",
+                "standard_name": "wind_speed"
+              }
+            }
+          }
+        }
+        """);
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        null,
+        """
+        {
+          "variables": {
+            "air_temperature": {
+              "attributes": {
+                "name": {"type": "char", "data": "Air Temperature at station"},
+                "units": {"type": "char", "data": "degrees_Celsius"}
+              }
+            },
+            "wind_speed": {
+              "long_name": "The speed of the wind",
+              "units": "m/s"
+            }
+          }
+        }
+        """,
+        null,
+        "2",
+        HttpStatus.SC_OK,
+        "application/json",
+        """
+        {
+          "variables": {
+            "air_temperature": {
+              "attributes": {
+                "ioos_category": {
+                  "data": "Temperature",
+                  "type": "char"
+                },
+                "standard_name": {
+                  "data": "air_temperature",
+                  "type": "char"
+                },
+                "units": {
+                  "data": "degree_C",
+                  "type": "char"
+                },
+                "long_name": {
+                  "data": "Air Temperature",
+                  "type": "char"
+                }
+              }
+            },
+            "wind_speed": {
+              "attributes": {
+                "ioos_category": {
+                  "data": "Wind",
+                  "type": "char"
+                },
+                "standard_name": {
+                  "data": "wind_speed",
+                  "type": "char"
+                }
+              }
+            }
+          }
+        }
+        """);
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        null,
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        "jsonpcallback",
+        null,
+        HttpStatus.SC_OK,
+        "application/javascript;charset=iso-8859-1",
+        """
+        jsonpcallback({"variables":{"sea_water_temperature":{"attributes":{"ioos_category":"Temperature","standard_name":"sea_water_temperature","long_name":"Sea Water Temperature"}}}});""");
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        "application/javascript",
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        "jsonpcallback",
+        null,
+        HttpStatus.SC_OK,
+        "application/javascript;charset=iso-8859-1",
+        """
+        jsonpcallback({"variables":{"sea_water_temperature":{"attributes":{"ioos_category":"Temperature","standard_name":"sea_water_temperature","long_name":"Sea Water Temperature"}}}});""");
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        "application/javascript",
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        null,
+        null,
+        HttpStatus.SC_OK,
+        "application/javascript;charset=iso-8859-1",
+        """
+        callback({"variables":{"sea_water_temperature":{"attributes":{"ioos_category":"Temperature","standard_name":"sea_water_temperature","long_name":"Sea Water Temperature"}}}});""");
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "application/json",
+        "application/javascript",
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        "1-invalid-jsonp",
+        null,
+        HttpStatus.SC_BAD_REQUEST,
+        "application/json;charset=utf-8",
+        """
+        {
+          "error" :
+          {
+            "code" : 400,
+            "message" : "Unsafe jsonp parameter: 1-invalid-jsonp",
+            "details" : ["jsonp parameter must be a valid JavaScript callback function name."]
+          }
+        }
+        """);
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        null,
+        null,
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        null,
+        null,
+        HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE,
+        "application/json;charset=utf-8",
+        """
+        {
+          "error" :
+          {
+            "code" : 415,
+            "message" : "Unsupported Content-Type: (unset). Expected: application/json",
+            "details" : [null]
+          }
+        }
+        """);
+
+    verifySuggestVariableAttributes(
+        client,
+        uri,
+        "bad/content-type",
+        null,
+        """
+        {"variables": {"sea_water_temperature":{"name":"water_t"}}}
+        """,
+        null,
+        null,
+        HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE,
+        "application/json;charset=utf-8",
+        """
+        {
+          "error" :
+          {
+            "code" : 415,
+            "message" : "Unsupported Content-Type: bad/content-type. Expected: application/json",
+            "details" : [null]
+          }
+        }
+        """);
+  }
+
+  /**
+   * Verify the response of the /erddap/suggestVariableAttributes endpoint with the given
+   * parameters.
+   *
+   * @param client the HttpClient to use for sending the request
+   * @param uri the URI of the /erddap/suggestVariableAttributes endpoint
+   * @param contentTypeHeader the value of the Content-Type header to set in the request
+   * @param acceptHeader the value of the Accept header to set in the request
+   * @param requestJson the JSON string to send in the request body
+   * @param jsonp the value of the jsonp query parameter to include in the request
+   * @param ncoJsonLevel the value of the ncoJsonLevel query parameter to include in the request
+   * @param expectedStatusCode the expected HTTP status code of the response
+   * @param expectedResponseContentType the expected Content-Type of the response
+   * @param expectedResponseBody the expected body of the response (will be compacted for comparison
+   *     if the expected response is json)
+   * @throws Exception if an error occurs while sending the request or verifying the response
+   */
+  private void verifySuggestVariableAttributes(
+      HttpClient client,
+      URI uri,
+      String contentTypeHeader,
+      String acceptHeader,
+      String requestJson,
+      String jsonp,
+      String ncoJsonLevel,
+      int expectedStatusCode,
+      String expectedResponseContentType,
+      String expectedResponseBody)
+      throws Exception {
+
+    List<String> params = new ArrayList<>();
+    if (jsonp != null) {
+      params.add("jsonp=" + jsonp);
+    }
+    if (ncoJsonLevel != null) {
+      params.add("ncoJsonLevel=" + ncoJsonLevel);
+    }
+    if (!params.isEmpty()) {
+      uri = URI.create(uri.toString() + "?" + String.join("&", params));
+    }
+
+    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder(uri);
+    if (contentTypeHeader != null) {
+      requestBuilder.header("Content-Type", contentTypeHeader);
+    }
+    if (acceptHeader != null) {
+      requestBuilder.header("Accept", acceptHeader);
+    }
+    HttpResponse<String> response =
+        client.send(
+            requestBuilder.POST(BodyPublishers.ofString(requestJson)).build(),
+            HttpResponse.BodyHandlers.ofString());
+    assertEquals(expectedStatusCode, response.statusCode());
+    assertEquals(
+        expectedResponseContentType, response.headers().firstValue("Content-Type").orElse(null));
+    String responseBody = response.body();
+    // compact the response bodies for comparison if the expected content type is application/json
+    if (expectedResponseContentType.equals("application/json")) {
+      responseBody = new JSONObject(responseBody).toString(0);
+      expectedResponseBody = new JSONObject(expectedResponseBody).toString(0);
+    }
+    assertEquals(expectedResponseBody, responseBody, "Response does not match expected.");
   }
 
   /* FileVisitorDNLS */


### PR DESCRIPTION
# Description

Provide ERDDAP's variable attribute suggestions in EDD.makeReadyToUseAddVariableAttributesForDatasetsXml as a JSON webservice, accepting an ncoJson style variable attribute payload and returning suggested attributes (standard name, long name, etc).

This is useful for external tools building datasets.xml config or otherwise curating variable attributes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes