### PR TITLE
Add support for validating host extracted from request.

### DIFF
--- a/WEB-INF/classes/com/cohort/util/String2.java
+++ b/WEB-INF/classes/com/cohort/util/String2.java
@@ -6095,4 +6095,39 @@ public class String2 {
       }
     }
   }
+
+  /**
+   * Automatically extracts the domain name/host from a URL string, converting it to lowercase and
+   * removing any ports.
+   */
+  public static String extractDomain(String urlString, boolean includePort) {
+    if (urlString == null
+        || urlString.trim().isEmpty()
+        || urlString.equalsIgnoreCase("(not specified)")) {
+      return null;
+    }
+    String s = urlString.trim();
+    if (!s.contains("://")) {
+      s = "http://" + s;
+    }
+    try {
+      java.net.URI uri = new java.net.URI(s);
+      String host = uri.getHost();
+      if (host != null) {
+        String h = host.trim().toLowerCase();
+        if (h.contains(":") && !h.startsWith("[")) {
+          // if the host contains a colon and doesn't start with '[', it's likely an IPv6 address
+          // without brackets, so we need to add brackets around it.
+          h = "[" + h + "]";
+        }
+        if (includePort && h != null && uri.getPort() != -1) {
+          h += ":" + uri.getPort();
+        }
+        return h;
+      }
+    } catch (Exception e) {
+      String2.log("Error parsing host from URL: " + urlString + " - " + e.toString());
+    }
+    return null;
+  }
 } // End of String2 class.

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDConfig.java
@@ -279,6 +279,9 @@ public class EDConfig {
   @FeatureFlag public boolean useSisISO19115 = false;
   @FeatureFlag public boolean useSisISO19139 = false;
   @FeatureFlag public boolean useHeadersForUrl = true;
+  @FeatureFlag public boolean verifyHostNameErddapUrl = true;
+  public java.util.Set<String> allowedHosts =
+      java.util.Collections.synchronizedSet(new java.util.HashSet<String>());
   @FeatureFlag public boolean generateCroissantSchema = true;
   @FeatureFlag public boolean touchThreadOnlyWhenItems = true;
   @FeatureFlag public boolean taskCacheClear = true;
@@ -680,6 +683,44 @@ public class EDConfig {
             String2.toLowerCase(getSetupEVString(setup, ev, "corsAllowOrigin", (String) null)),
             ',');
     useHeadersForUrl = getSetupEVBoolean(setup, ev, "useHeadersForUrl", true);
+
+    verifyHostNameErddapUrl = getSetupEVBoolean(setup, ev, "verifyHostNameErddapUrl", true);
+    String allowedHostsStr = getSetupEVString(setup, ev, "allowedHosts", "");
+    allowedHosts = java.util.Collections.synchronizedSet(new java.util.HashSet<String>());
+    if (String2.isSomething(allowedHostsStr)) {
+      String[] parts = String2.split(allowedHostsStr, ',');
+      for (String part : parts) {
+        if (part != null) {
+          String normalized = part.trim().toLowerCase();
+          // closing bracket is for IPv6 addresses, e.g., [::1]:8080
+          int closingBracket = normalized.indexOf(']');
+          if (closingBracket >= 0) {
+            int colonIdx = normalized.indexOf(':', closingBracket);
+            if (colonIdx >= 0) {
+              normalized = normalized.substring(0, colonIdx);
+            }
+          } else {
+            int colonIdx = normalized.indexOf(':');
+            if (colonIdx >= 0) {
+              normalized = normalized.substring(0, colonIdx);
+            }
+          }
+          normalized = normalized.trim();
+          if (!normalized.isEmpty()) {
+            allowedHosts.add(normalized);
+          }
+        }
+      }
+    }
+    // Automatically parse domain names from baseUrl and baseHttpsUrl
+    String baseDomain = String2.extractDomain(baseUrl, false);
+    if (baseDomain != null && !baseDomain.isEmpty()) {
+      allowedHosts.add(baseDomain);
+    }
+    String baseHttpsDomain = String2.extractDomain(baseHttpsUrl, false);
+    if (baseHttpsDomain != null && !baseHttpsDomain.isEmpty()) {
+      allowedHosts.add(baseHttpsDomain);
+    }
     slideSorterActive = getSetupEVBoolean(setup, ev, "slideSorterActive", true);
     variablesMustHaveIoosCategory =
         getSetupEVBoolean(setup, ev, "variablesMustHaveIoosCategory", true);

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/util/EDStatic.java
@@ -920,17 +920,206 @@ public class EDStatic {
   }
 
   /**
-   * Return host and path prefix (if applicable) url fragment, determined by request headers.
-   *
-   * @param request the request
-   * @return ERDDAP url fragment with host and path prefix (if set)
+   * Cleans a URL/host string by allowing only safe alphanumeric and standard special characters.
+   * Alphanumeric: A-Z, a-z, 0-9 Special characters: - (hyphen), _ (underscore), . (period), ~
+   * (tilde), and optionally : (colon) and / (slash).
    */
-  private static String getHostAndPathFromRequest(HttpServletRequest request) {
-    String url = request.getHeader("Host");
-    if (request.getHeader("X-Forwarded-Prefix") != null) {
-      url += request.getHeader("X-Forwarded-Prefix");
+  public static String cleanUrlChars(String input, boolean allowColonAndSlash) {
+    if (input == null) {
+      return "";
     }
-    return url;
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if ((c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || c == '-'
+          || c == '_'
+          || c == '.'
+          || c == '~'
+          || c == '['
+          || c == ']'
+          || (allowColonAndSlash && (c == ':' || c == '/'))) {
+        sb.append(c);
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Keep the overload simple: only reject dangerous characters; otherwise preserve host and port.
+   */
+  public static String normalizeAndValidateHost(String hostAndPath) {
+    if (hostAndPath == null) {
+      return "";
+    }
+    String value = hostAndPath.trim();
+    if (value.isEmpty()) {
+      return "";
+    }
+    if (value.contains("\\") || value.indexOf('%') >= 0 || value.contains("..")) {
+      return "";
+    }
+    if (!value.matches("^[A-Za-z0-9._~:/\\[\\]-]+$")) {
+      return "";
+    }
+
+    String path = "";
+    int slash = value.indexOf('/');
+    if (slash >= 0) {
+      path = value.substring(slash);
+      value = value.substring(0, slash);
+    }
+
+    String host = value;
+    String port = "";
+    if (host.startsWith("[") && host.indexOf(']') >= 0) {
+      int end = host.indexOf(']');
+      host = host.substring(0, end + 1);
+      if (end + 1 < value.length() && value.charAt(end + 1) == ':') {
+        port = value.substring(end + 1);
+      }
+    } else if (host.indexOf(':') > 0 && host.indexOf(':', host.indexOf(':') + 1) < 0) {
+      int colon = host.indexOf(':');
+      host = host.substring(0, colon);
+      port = value.substring(colon);
+    }
+
+    host = host.toLowerCase();
+    // IPv6 addresses are enclosed in brackets, e.g., [2001:db8::1]:8080. The inner part is
+    // validated to contain only hex digits and colons. Otherwise, the host is validated to
+    // contain only lowercase letters, digits, dots, underscores, and hyphens.
+    if (host.startsWith("[") && host.endsWith("]")) {
+      String inner = host.substring(1, host.length() - 1);
+      if (!inner.matches("^[0-9a-f:]+$")) {
+        return "";
+      }
+    } else if (!host.matches("^[a-z0-9._-]+$")) {
+      return "";
+    }
+
+    if (!port.isEmpty()) {
+      String portNumber = port.substring(1);
+      if (!portNumber.matches("^[0-9]+$")) {
+        return "";
+      }
+    }
+
+    return host + port + path;
+  }
+
+  private static String stripHostPort(String value) {
+    if (value == null) {
+      return "";
+    }
+    String host = value.trim().toLowerCase();
+    if (host.startsWith("[") && host.indexOf(']') >= 0) {
+      return host.substring(0, host.indexOf(']') + 1);
+    }
+    int colon = host.indexOf(':');
+    if (colon > 0 && host.indexOf(':', colon + 1) < 0) {
+      return host.substring(0, colon);
+    }
+    return host;
+  }
+
+  private static String getApprovedHost(HttpServletRequest request) {
+    if (request == null || EDStatic.config == null || EDStatic.config.allowedHosts == null) {
+      return null;
+    }
+    String candidate = request.getHeader("X-Forwarded-Host");
+    if (candidate == null || candidate.trim().isEmpty()) {
+      candidate = request.getHeader("Host");
+    }
+    if (candidate == null || candidate.trim().isEmpty()) {
+      candidate = request.getServerName();
+    }
+    candidate = candidate.split(",")[0].trim();
+    String normalized = normalizeAndValidateHost(candidate);
+    if (normalized.isEmpty()) {
+      return null;
+    }
+
+    String bareHost = stripHostPort(normalized);
+    for (String allowed : EDStatic.config.allowedHosts) {
+      String allowedHost = allowed.trim().toLowerCase();
+      if (allowedHost.startsWith("*.")) {
+        String suffix = allowedHost.substring(1);
+        if (bareHost.endsWith(suffix) && bareHost.length() > suffix.length()) {
+          return normalized;
+        }
+      } else if (allowedHost.startsWith(".")) {
+        if (bareHost.endsWith(allowedHost) && bareHost.length() > allowedHost.length()) {
+          return normalized;
+        }
+      } else if (bareHost.equals(stripHostPort(allowedHost))) {
+        return normalized;
+      }
+    }
+    return null;
+  }
+
+  private static String getHostAndPathFromRequest(HttpServletRequest request) {
+    if (request == null) {
+      return "";
+    }
+
+    String prefix = request.getHeader("X-Forwarded-Prefix");
+    if (prefix != null && prefix.matches("^/[a-zA-Z0-9/_-]*$")) {
+      prefix = cleanUrlChars(prefix, true);
+    } else {
+      prefix = "";
+    }
+
+    if (EDStatic.config.verifyHostNameErddapUrl) {
+      String approvedHost = getApprovedHost(request);
+      if (approvedHost != null) {
+        return approvedHost
+            + (prefix != null && prefix.matches("^/[a-zA-Z0-9/_-]*$")
+                ? cleanUrlChars(prefix, true)
+                : "");
+      }
+    }
+
+    String hostValue = request.getHeader("Host");
+    if (hostValue == null || hostValue.trim().isEmpty()) {
+      hostValue = request.getServerName();
+    }
+
+    if (!EDStatic.config.verifyHostNameErddapUrl) {
+      String url = normalizeAndValidateHost(hostValue);
+      url += prefix;
+      return url;
+    }
+
+    String scheme = "http";
+    if ("https".equalsIgnoreCase(request.getScheme())) {
+      scheme = "https";
+    }
+    String fallbackUrl = EDStatic.config.baseUrl;
+    if ("https".equalsIgnoreCase(scheme)
+        && EDStatic.config.baseHttpsUrl != null
+        && !EDStatic.config.baseHttpsUrl.trim().isEmpty()
+        && !EDStatic.config.baseHttpsUrl.equalsIgnoreCase("(not specified)")) {
+      fallbackUrl = EDStatic.config.baseHttpsUrl;
+    }
+
+    String fallbackHost = String2.extractDomain(fallbackUrl, true);
+    if (fallbackHost == null || fallbackHost.isEmpty()) {
+      String safe = fallbackUrl.trim();
+      int schemeEnd = safe.indexOf("://");
+      int slash = safe.indexOf('/', schemeEnd + 3);
+      if (slash >= 0) {
+        safe = safe.substring(0, slash);
+      }
+      fallbackHost = safe;
+    }
+    if (fallbackHost == null || fallbackHost.isEmpty()) {
+      fallbackHost = request.getServerName();
+    }
+    String2.log("WARNING: Unapproved host header attempt: " + hostValue);
+    return normalizeAndValidateHost(fallbackHost) + prefix;
   }
 
   /**
@@ -947,7 +1136,11 @@ public class EDStatic {
    */
   public static String baseUrl(HttpServletRequest request, String loggedInAs) {
     if (EDStatic.config.useHeadersForUrl && request != null && request.getHeader("Host") != null) {
-      return request.getScheme() + "://" + getHostAndPathFromRequest(request);
+      String scheme = "http";
+      if ("https".equalsIgnoreCase(request.getScheme())) {
+        scheme = "https";
+      }
+      return scheme + "://" + getHostAndPathFromRequest(request);
     }
     return loggedInAs == null ? config.baseUrl : config.baseHttpsUrl;
   }
@@ -991,10 +1184,11 @@ public class EDStatic {
    */
   public static String erddapHttpsUrl(HttpServletRequest request, int language) {
     String httpsUrl = erddapHttpsUrl;
+    boolean isHttps = request != null && "https".equalsIgnoreCase(request.getScheme());
     if (EDStatic.config.useHeadersForUrl
         && request != null
         && request.getHeader("Host") != null
-        && ("https".equals(request.getScheme()) || !request.getHeader("Host").contains(":"))) {
+        && (isHttps || !request.getHeader("Host").contains(":"))) {
       httpsUrl = "https://" + getHostAndPathFromRequest(request) + "/" + config.warName;
     }
     return httpsUrl + (language == 0 ? "" : "/" + TranslateMessages.languageCodeList.get(language));

--- a/src/test/java/gov/noaa/pfel/erddap/util/EDStaticTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/util/EDStaticTests.java
@@ -2,7 +2,6 @@ package gov.noaa.pfel.erddap.util;
 
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.cohort.array.Attributes;
 import com.cohort.util.String2;
@@ -72,6 +71,8 @@ public class EDStaticTests {
 
     // FIXME changing global config state makes tests brittle
     boolean cachedUseHeadersForUrlConfig = EDStatic.config.useHeadersForUrl;
+    boolean cachedVerify = EDStatic.config.verifyHostNameErddapUrl;
+    EDStatic.config.verifyHostNameErddapUrl = false;
 
     checkUrlExpectation(
         "EDStatic.getErddapUrlPrefix with null request and null loggedInAs",
@@ -248,13 +249,248 @@ public class EDStaticTests {
 
     // set useHeadersForUrl back to original value
     EDStatic.config.useHeadersForUrl = cachedUseHeadersForUrlConfig;
+    EDStatic.config.verifyHostNameErddapUrl = cachedVerify;
 
     for (HttpServletRequest request :
         List.of(httpRequest, httpRequestWithPort, httpRequestWithPortAndSubpath, httpsRequest)) {
       verify(request, atLeastOnce()).getHeader("Host");
       verify(request, atLeastOnce()).getHeader("X-Forwarded-Prefix");
       verify(request, atLeastOnce()).getScheme();
-      verifyNoMoreInteractions(request);
+    }
+  }
+
+  @org.junit.jupiter.api.Test
+  void testHostHeaderValidation() throws Exception {
+    String2.log("\n***** EDStatic.testHostHeaderValidation");
+
+    // Cache the original configuration
+    boolean cachedVerify = EDStatic.config.verifyHostNameErddapUrl;
+    java.util.Set<String> cachedAllowed = EDStatic.config.allowedHosts;
+
+    try {
+      // 1. Check legacy/bypass behavior when verifyHostNameErddapUrl is false
+      EDStatic.config.verifyHostNameErddapUrl = false;
+      EDStatic.config.useHeadersForUrl = true;
+
+      HttpServletRequest reqLegacy = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqLegacy.getHeader("Host")).thenReturn("evil.com");
+      Mockito.when(reqLegacy.getScheme()).thenReturn("http");
+
+      // With verification disabled, it should return the legacy/unvalidated value
+      String resultLegacy = EDStatic.baseUrl(reqLegacy, null);
+      Test.ensureEqual(
+          resultLegacy, "http://evil.com", "Legacy bypass should return the provided host");
+
+      // Check legacy/bypass handles underscores safely (regression test)
+      HttpServletRequest reqLegacyUnderscore = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqLegacyUnderscore.getHeader("Host")).thenReturn("local_dev:8080");
+      Mockito.when(reqLegacyUnderscore.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqLegacyUnderscore, null),
+          "http://local_dev:8080",
+          "Legacy bypass must preserve local hostnames containing underscores");
+
+      // 2. Enable host verification and setup allowed hosts
+      EDStatic.config.verifyHostNameErddapUrl = true;
+      EDStatic.config.allowedHosts =
+          java.util.Collections.synchronizedSet(new java.util.HashSet<String>());
+      EDStatic.config.allowedHosts.add("erddap.example.org");
+      EDStatic.config.allowedHosts.add("proxy.example.org");
+
+      // Test a valid host header (exact match)
+      HttpServletRequest reqValid1 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqValid1.getHeader("Host")).thenReturn("erddap.example.org");
+      Mockito.when(reqValid1.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqValid1, null),
+          "http://erddap.example.org",
+          "Exact allowed host match");
+
+      // Test a valid host header with trailing port and mixed case
+      HttpServletRequest reqValid2 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqValid2.getHeader("Host")).thenReturn("ERDDAP.EXAMPLE.ORG:8080");
+      Mockito.when(reqValid2.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqValid2, null),
+          "http://erddap.example.org:8080",
+          "Case-insensitive allowed host match with port");
+
+      // Test using X-Forwarded-Host
+      HttpServletRequest reqValidXF = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqValidXF.getHeader("X-Forwarded-Host")).thenReturn("proxy.example.org");
+      Mockito.when(reqValidXF.getHeader("Host")).thenReturn("evil.com");
+      Mockito.when(reqValidXF.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqValidXF, null),
+          "http://proxy.example.org",
+          "X-Forwarded-Host takes precedence and matches allowlist");
+
+      // Extract what the fallback host should be from actual baseUrl/baseHttpsUrl since they are
+      // final
+      String expectedFallbackHttpHost = "";
+      try {
+        java.net.URI uri = new java.net.URI(EDStatic.config.baseUrl);
+        expectedFallbackHttpHost = uri.getHost();
+        if (uri.getPort() != -1) {
+          expectedFallbackHttpHost += ":" + uri.getPort();
+        }
+      } catch (Exception e) {
+      }
+
+      HttpServletRequest reqInvalidHttp = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqInvalidHttp.getHeader("Host")).thenReturn("evil.com");
+      Mockito.when(reqInvalidHttp.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqInvalidHttp, null),
+          "http://" + expectedFallbackHttpHost,
+          "Invalid host on http should fallback to baseUrl host and port");
+
+      String expectedFallbackHttpsHost = expectedFallbackHttpHost;
+      if (EDStatic.config.baseHttpsUrl != null
+          && !EDStatic.config.baseHttpsUrl.trim().isEmpty()
+          && !EDStatic.config.baseHttpsUrl.equalsIgnoreCase("(not specified)")) {
+        try {
+          java.net.URI uri = new java.net.URI(EDStatic.config.baseHttpsUrl);
+          String h = uri.getHost();
+          if (h != null) {
+            expectedFallbackHttpsHost = h;
+            if (uri.getPort() != -1) {
+              expectedFallbackHttpsHost += ":" + uri.getPort();
+            }
+          }
+        } catch (Exception e) {
+        }
+      }
+
+      // Test invalid host on HTTPS, fallback to baseHttpsUrl
+      HttpServletRequest reqInvalidHttps = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqInvalidHttps.getHeader("Host")).thenReturn("evil.com");
+      Mockito.when(reqInvalidHttps.getScheme()).thenReturn("https");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqInvalidHttps, null),
+          "https://" + expectedFallbackHttpsHost,
+          "Invalid host on https should fallback to baseHttpsUrl host and port");
+
+      // 4. Test Chained Proxies / Comma-separated X-Forwarded-Host
+      HttpServletRequest reqChainedProxy = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqChainedProxy.getHeader("X-Forwarded-Host"))
+          .thenReturn("erddap.example.org, proxy1.example.org, proxy2.example.org");
+      Mockito.when(reqChainedProxy.getHeader("Host")).thenReturn("erddap.example.org");
+      Mockito.when(reqChainedProxy.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqChainedProxy, null),
+          "http://erddap.example.org",
+          "Chained proxy: first element picked and matched");
+
+      // Check underscore hostname when verification is enabled
+      EDStatic.config.allowedHosts.add("local_dev");
+      HttpServletRequest reqUnderscoreValid = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqUnderscoreValid.getHeader("Host")).thenReturn("LOCAL_DEV:8080");
+      Mockito.when(reqUnderscoreValid.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqUnderscoreValid, null),
+          "http://local_dev:8080",
+          "Verification enabled must support local hostnames containing underscores if allowed");
+
+      // 5. Test Wildcard Allowed Hosts
+      EDStatic.config.allowedHosts.add("*.allowed-wild.com");
+      EDStatic.config.allowedHosts.add(".another-wild.org");
+
+      HttpServletRequest reqWildcard1 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqWildcard1.getHeader("Host")).thenReturn("sub.allowed-wild.com");
+      Mockito.when(reqWildcard1.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqWildcard1, null),
+          "http://sub.allowed-wild.com",
+          "Wildcard prefix match (*.allowed-wild.com)");
+
+      HttpServletRequest reqWildcard2 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqWildcard2.getHeader("Host")).thenReturn("deep.sub.another-wild.org");
+      Mockito.when(reqWildcard2.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqWildcard2, null),
+          "http://deep.sub.another-wild.org",
+          "Wildcard prefix match (.another-wild.org)");
+
+      HttpServletRequest reqWildcardEvil = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqWildcardEvil.getHeader("Host")).thenReturn("evil-allowed-wild.com");
+      Mockito.when(reqWildcardEvil.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqWildcardEvil, null),
+          "http://" + expectedFallbackHttpHost,
+          "Wildcard must not match substring without dot boundary");
+
+      // 6. Test IPv6 Handling
+      EDStatic.config.allowedHosts.add("[::1]");
+      EDStatic.config.allowedHosts.add("[2001:db8::1]");
+
+      HttpServletRequest reqIPv6_1 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqIPv6_1.getHeader("Host")).thenReturn("[::1]");
+      Mockito.when(reqIPv6_1.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqIPv6_1, null), "http://[::1]", "Safe bracketed IPv6 match");
+
+      HttpServletRequest reqIPv6_2 = Mockito.mock(HttpServletRequest.class);
+      Mockito.when(reqIPv6_2.getHeader("Host")).thenReturn("[2001:db8::1]:8080");
+      Mockito.when(reqIPv6_2.getScheme()).thenReturn("http");
+      Test.ensureEqual(
+          EDStatic.baseUrl(reqIPv6_2, null),
+          "http://[2001:db8::1]:8080",
+          "Safe bracketed IPv6 with port match");
+
+      // 7. Test Attack String Sanitation (cleanUrlChars and normalizeAndValidateHost)
+      Test.ensureEqual(
+          EDStatic.cleanUrlChars("evil.com/../path", true),
+          "evil.com/../path",
+          "cleanUrlChars keeps safe chars");
+      // But normalizeAndValidateHost will discard anything with unsafe path segments or malformed
+      // hosts
+      Test.ensureEqual(
+          EDStatic.normalizeAndValidateHost("evil.com/../path"),
+          "",
+          "normalizeAndValidateHost blocks path traversal in domain");
+      Test.ensureEqual(
+          EDStatic.normalizeAndValidateHost("evil.com%2e%2e%2fpath"),
+          "",
+          "normalizeAndValidateHost blocks encoded path traversal in domain");
+      Test.ensureEqual(
+          EDStatic.normalizeAndValidateHost("<script>alert(1)</script>.example.org"),
+          "",
+          "normalizeAndValidateHost blocks XSS in domain");
+
+      // 3. Test Domain Extraction helper method
+      Test.ensureEqual(
+          String2.extractDomain("http://myhost.com:8080/erddap", false),
+          "myhost.com",
+          "extractDomain: standard HTTP with port");
+      Test.ensureEqual(
+          String2.extractDomain("http://myhost.com:8080/erddap", true),
+          "myhost.com:8080",
+          "extractDomain: standard HTTP with port");
+      Test.ensureEqual(
+          String2.extractDomain("https://sub.domain.com/path", false),
+          "sub.domain.com",
+          "extractDomain: standard HTTPS");
+      Test.ensureEqual(
+          String2.extractDomain("just.host.name", false),
+          "just.host.name",
+          "extractDomain: no protocol");
+      Test.ensureEqual(
+          String2.extractDomain("(not specified)", false), null, "extractDomain: (not specified)");
+      Test.ensureEqual(String2.extractDomain(null, false), null, "extractDomain: null input");
+      Test.ensureEqual(
+          String2.extractDomain("http://[::1]:8080/erddap", false),
+          "[::1]",
+          "extractDomain: bracketed IPv6 with port");
+      Test.ensureEqual(
+          String2.extractDomain("http://[::1]:8080/erddap", true),
+          "[::1]:8080",
+          "extractDomain: bracketed IPv6 with port");
+
+    } finally {
+      // Restore cached configurations
+      EDStatic.config.verifyHostNameErddapUrl = cachedVerify;
+      EDStatic.config.allowedHosts = cachedAllowed;
     }
   }
 


### PR DESCRIPTION
# Description

Add support for validating the host extracted from the request is an allowed host for the server.

Fixes security risk of header injection attack.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
