### PR TITLE
Configure CI JVM options and fork settings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -35,10 +35,14 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build and test with Maven
+      env:
+        JAVA_TOOL_OPTIONS: "-Xmx4g -XX:+UseG1GC"
       run: >
         mvn --batch-mode
         -Dgcf.skipInstallHooks=true
         -Dmaven.test.redirectTestOutputToFile=true
         -Ddownload.unpack=true
         -Ddownload.unpackWhenChanged=false
+        -DforkCount=1
+        -DreuseForks=true
         clean verify

--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -44,5 +44,6 @@ jobs:
         -Ddownload.unpack=true
         -Ddownload.unpackWhenChanged=false
         -DforkCount=1
-        -DreuseForks=true
+        -DreuseForks=false
+        -DargLine.extra="-Xmx4g -XX:+UseG1GC"
         clean verify

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -36,12 +36,16 @@ jobs:
         java-version: '25'
         distribution: 'temurin'
     - name: Build and test with Maven
+      env:
+        JAVA_TOOL_OPTIONS: "-Xmx4g -XX:+UseG1GC"
       run: >
         mvn --batch-mode
         -Dgcf.skipInstallHooks=true
         -Dmaven.test.redirectTestOutputToFile=true
         -Ddownload.unpack=true
         -Ddownload.unpackWhenChanged=false
+        -DforkCount=1
+        -DreuseForks=true
         clean verify
 
   build-and-push-docker:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -45,7 +45,8 @@ jobs:
         -Ddownload.unpack=true
         -Ddownload.unpackWhenChanged=false
         -DforkCount=1
-        -DreuseForks=true
+        -DreuseForks=false
+        -DargLine.extra="-Xmx4g -XX:+UseG1GC"
         clean verify
 
   build-and-push-docker:

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <mavenTestPluginVersion>3.5.6</mavenTestPluginVersion>
         <jacocoMavenVersion>0.8.15</jacocoMavenVersion>
         <download.unpackWhenChanged>true</download.unpackWhenChanged>
+        <argLine.extra></argLine.extra>
     </properties>
 
     <repositories>
@@ -622,7 +623,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar} ${argLine.extra}</argLine>
                     <environmentVariables>
                         <temp>${project.basedir}/target/temp/</temp>
                         <tmp>${project.basedir}/target/temp/</tmp>
@@ -645,7 +646,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <argLine>${failsafe.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                            <argLine>${failsafe.jacoco.args} -javaagent:${org.mockito:mockito-core:jar} ${argLine.extra}</argLine>
                             <environmentVariables>
                                 <temp>${project.basedir}/target/temp/</temp>
                                 <tmp>${project.basedir}/target/temp/</tmp>
@@ -677,7 +678,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar} ${argLine.extra}</argLine>
                     <environmentVariables>
                         <temp>${project.basedir}/target/temp/</temp>
                         <tmp>${project.basedir}/target/temp/</tmp>
@@ -701,7 +702,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${mavenTestPluginVersion}</version>
                 <configuration>
-                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>${surefire.jacoco.args} -javaagent:${org.mockito:mockito-core:jar} ${argLine.extra}</argLine>
                     <environmentVariables>
                         <temp>${project.basedir}/target/temp/</temp>
                         <tmp>${project.basedir}/target/temp/</tmp>

--- a/src/test/java/gov/noaa/pfel/coastwatch/sgt/GSHHSTests.java
+++ b/src/test/java/gov/noaa/pfel/coastwatch/sgt/GSHHSTests.java
@@ -3,8 +3,15 @@ package gov.noaa.pfel.coastwatch.sgt;
 import com.cohort.util.String2;
 import com.cohort.util.Test;
 import java.awt.geom.GeneralPath;
+import org.junit.jupiter.api.BeforeAll;
+import testDataset.Initialization;
 
 class GSHHSTests {
+
+  @BeforeAll
+  static void init() {
+    Initialization.edStatic();
+  }
 
   /** This runs a unit test. */
   @org.junit.jupiter.api.Test


### PR DESCRIPTION
# Description

Add step-level JAVA_TOOL_OPTIONS="-Xmx4g -XX:+UseG1GC" and Maven options -DforkCount=1 -DreuseForks=true to the Maven build steps in .github/workflows/on-pull.yml and .github/workflows/on-push.yml. This should resolves memory underflow errors in ERDDAP's internal memory management checks during CI runs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
