### PR TITLE
Fix _CoordinateAxes trailing space inconsistency in NcHeaderFiles (#169)

### DIFF
--- a/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
+++ b/WEB-INF/classes/gov/noaa/pfel/coastwatch/griddata/NcHelper.java
@@ -222,8 +222,16 @@ public class NcHelper {
       return PrimitiveArray.factory(byteAr, nc2Array.isUnsigned());
     }
 
+    Object o = nc2Array.copyTo1DJavaArray();
+    if (o instanceof String[] sa) {
+      for (int i = 0; i < sa.length; i++) {
+        if (sa[i] != null) sa[i] = sa[i].trim();
+      }
+      return new StringArray(sa);
+    }
+
     // ArrayXxxnumeric
-    return PrimitiveArray.factory(nc2Array.copyTo1DJavaArray(), nc2Array.isUnsigned());
+    return PrimitiveArray.factory(o, nc2Array.isUnsigned());
   }
 
   /**

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDGridFromDap.java
@@ -305,12 +305,16 @@ public class EDDGridFromDap extends EDDGrid {
       // This will fail (good) if dataset has changed significantly and
       //  quickRestart file has outdated information.
       quickRestartAttributes = NcHelper.readAttributesFromNc3(quickRestartFullFileName());
+      String cachedSourceUrl = quickRestartAttributes.getString("localSourceUrl");
+      if (cachedSourceUrl != null && !cachedSourceUrl.equals(tLocalSourceUrl)) {
+        quickRestartAttributes = null;
+      } else {
+        if (verbose) String2.log("  using info from quickRestartFile");
 
-      if (verbose) String2.log("  using info from quickRestartFile");
-
-      // set creationTimeMillis to time of previous creation, so next time
-      // to be reloaded will be same as if ERDDAP hadn't been restarted.
-      creationTimeMillis = quickRestartAttributes.getLong("creationTimeMillis");
+        // set creationTimeMillis to time of previous creation, so next time
+        // to be reloaded will be same as if ERDDAP hadn't been restarted.
+        creationTimeMillis = quickRestartAttributes.getLong("creationTimeMillis");
+      }
     }
 
     if (quickRestartAttributes != null) {
@@ -615,6 +619,7 @@ public class EDDGridFromDap extends EDDGrid {
         try {
           quickRestartAttributes = new Attributes();
           quickRestartAttributes.set("creationTimeMillis", "" + creationTimeMillis);
+          quickRestartAttributes.set("localSourceUrl", tLocalSourceUrl);
 
           // 1. Save global attributes
           for (String key : sourceGlobalAttributes.getNames()) {

--- a/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
+++ b/WEB-INF/classes/gov/noaa/pfel/erddap/dataset/EDDTableFromDapSequence.java
@@ -354,12 +354,16 @@ public class EDDTableFromDapSequence extends EDDTable {
       // This will fail (good) if dataset has changed significantly and
       //  quickRestart file has outdated information.
       quickRestartAttributes = NcHelper.readAttributesFromNc3(quickRestartFullFileName());
+      String cachedSourceUrl = quickRestartAttributes.getString("localSourceUrl");
+      if (cachedSourceUrl != null && !cachedSourceUrl.equals(tLocalSourceUrl)) {
+        quickRestartAttributes = null;
+      } else {
+        if (verbose) String2.log("  using info from quickRestartFile");
 
-      if (verbose) String2.log("  using info from quickRestartFile");
-
-      // set creationTimeMillis to time of previous creation, so next time
-      // to be reloaded will be same as if ERDDAP hadn't been restarted.
-      creationTimeMillis = quickRestartAttributes.getLong("creationTimeMillis");
+        // set creationTimeMillis to time of previous creation, so next time
+        // to be reloaded will be same as if ERDDAP hadn't been restarted.
+        creationTimeMillis = quickRestartAttributes.getLong("creationTimeMillis");
+      }
     }
 
     // create structures to hold the sourceAttributes temporarily

--- a/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/dataset/EDDGridFromDapTests.java
@@ -6795,7 +6795,7 @@ class EDDGridFromDapTests extends WireMockLifecycle {
               + "    longitude = 8640;\n"
               + "  variables:\n"
               + "    float chlorophyll\\(time=\\d{3}, altitude=1, latitude=4320, longitude=8640\\);\n"
-              + "      :_CoordinateAxes = \"time altitude latitude longitude \";\n"
+              + "      :_CoordinateAxes = \"time altitude latitude longitude\";\n"
               + "      :_FillValue = -9999999.0f; // float\n"
               + "      :colorBarMaximum = 30.0; // double\n"
               + "      :colorBarMinimum = 0.03; // double\n"

--- a/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
@@ -389,7 +389,7 @@ netcdf EDDGridFromDap.nc {
       :units = "degrees_east";
 
     float temp(time=1, depth=19, latitude=1, longitude=1);
-      :_CoordinateAxes = "time lev lat lon ";
+      :_CoordinateAxes = "time lev lat lon";
       :_FillValue = -9.99E33f; // float
       :colorBarMaximum = 32.0; // double
       :colorBarMinimum = 0.0; // double
@@ -400,7 +400,7 @@ netcdf EDDGridFromDap.nc {
       :units = "degree_C";
 
     float salt(time=1, depth=19, latitude=1, longitude=1);
-      :_CoordinateAxes = "time lev lat lon ";
+      :_CoordinateAxes = "time lev lat lon";
       :_FillValue = -9.99E33f; // float
       :colorBarMaximum = 37.0; // double
       :colorBarMinimum = 32.0; // double
@@ -411,7 +411,7 @@ netcdf EDDGridFromDap.nc {
       :units = "PSU";
 
     float u(time=1, depth=19, latitude=1, longitude=1);
-      :_CoordinateAxes = "time lev lat lon ";
+      :_CoordinateAxes = "time lev lat lon";
       :_FillValue = -9.99E33f; // float
       :colorBarMaximum = 0.5; // double
       :colorBarMinimum = -0.5; // double
@@ -422,7 +422,7 @@ netcdf EDDGridFromDap.nc {
       :units = "m s-1";
 
     float v(time=1, depth=19, latitude=1, longitude=1);
-      :_CoordinateAxes = "time lev lat lon ";
+      :_CoordinateAxes = "time lev lat lon";
       :_FillValue = -9.99E33f; // float
       :colorBarMaximum = 0.5; // double
       :colorBarMinimum = -0.5; // double
@@ -433,7 +433,7 @@ netcdf EDDGridFromDap.nc {
       :units = "m s-1";
 
     float w(time=1, depth=19, latitude=1, longitude=1);
-      :_CoordinateAxes = "time lev lat lon ";
+      :_CoordinateAxes = "time lev lat lon";
       :_FillValue = -9.99E33f; // float
       :colorBarMaximum = 1.0E-5; // double
       :colorBarMinimum = -1.0E-5; // double


### PR DESCRIPTION
# Description

* Fix _CoordinateAxes trailing space inconsistency in NcHeaderFiles
* Invalidate quickRestart cache when localSourceUrl changes in EDDGridFromDap and EDDTableFromDapSequence

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
