### PR TITLE
Fix formatting of time lev lat lon string in results

### DIFF
--- a/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
+++ b/src/test/java/gov/noaa/pfel/erddap/filetypes/NcHeaderFilesTests.java
@@ -538,6 +538,9 @@ the current year using available altimetry).";
             + results.substring(results.indexOf("      :ioos_category = ", commentStart));
     results = results.replaceAll("\'", "'");
     expected = expected.replaceAll("\'", "'");
+    if (results.contains("\"time lev lat lon \"")) {
+      results = results.replaceAll("\"time lev lat lon \"", "\"time lev lat lon\"");
+    }
     com.cohort.util.Test.ensureEqual(expected, results, "results=\n" + results);
   }
 


### PR DESCRIPTION
# Description

Docker builds and windows builds are still having issues. The string in question is metadata from a file and surrounded in quotes, so a trim won't fix (without unwrapping the quotes).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
